### PR TITLE
fix(dos): suspend the locked-stack chain cursor across EXEC

### DIFF
--- a/kernel/src/kernel/dos/dos.rs
+++ b/kernel/src/kernel/dos/dos.rs
@@ -2725,6 +2725,9 @@ fn exec_program(machine: &mut crate::TheArch, kt: &mut thread::KernelThread, dos
         &mut dos.pm_rm_vector_shadow,
         [(0, 0, 0); 256],
     );
+    // The child begins a fresh continuation chain: its locked-stack cursor
+    // must not point into the parent's PM stack (see ExecParent docs).
+    let suspended_locked_stack = dos.pc.locked_stack.other_stack.take();
     let parent_pm_mode = regs.mode() != crate::UserMode::VM86;
     let mut parent_ivt = [(0u8, 0u16, 0u16); 12];
     for (slot, &int_num) in parent_ivt.iter_mut().zip(EXEC_SAVED_IVT_VECTORS.iter()) {
@@ -2757,6 +2760,7 @@ fn exec_program(machine: &mut crate::TheArch, kt: &mut thread::KernelThread, dos
         ldt_alloc: suspended_ldt_alloc,
         pm_rm_vector_shadow: suspended_pm_rm_vector_shadow,
         pm_dos: suspended_pm_dos,
+        locked_stack_other: suspended_locked_stack,
         pm_mode: parent_pm_mode,
         prev: prev.map(alloc::boxed::Box::new),
     });
@@ -2949,6 +2953,9 @@ fn exec_return(machine: &mut crate::TheArch, dos: &mut thread::DosState, regs: &
         dos.ldt_alloc = parent.ldt_alloc;
         dos.pm_rm_vector_shadow = parent.pm_rm_vector_shadow;
         dos.pm_dos = parent.pm_dos;
+        // Restore the parent's continuation-chain cursor alongside its LDT:
+        // the two are a matched pair (cursor indexes stack via LDT selectors).
+        dos.pc.locked_stack.other_stack = parent.locked_stack_other;
     }
     // LDTR currently points at the child's LDT — reload (same box if we
     // preserved it, parent's box if we restored).

--- a/kernel/src/kernel/dos/mod.rs
+++ b/kernel/src/kernel/dos/mod.rs
@@ -336,6 +336,15 @@ pub struct ExecParent {
     /// Parent's PMDOS routing flag, suspended alongside dpmi/pm_vectors so
     /// the child runs with the default reflect-to-RM INT 21 path.
     pub pm_dos: bool,
+    /// Parent's locked-stack chain cursor (`pc.locked_stack.other_stack`),
+    /// suspended so the child starts a fresh continuation chain. The cursor
+    /// is a LIFO position into the parent's host/PM stack tied to the
+    /// parent's LDT selectors; leaving it visible to the child makes the
+    /// child's first PM IRQ plant its resume continuation on the *parent's*
+    /// stack selector — which is null in the child's fresh LDT, so the exit
+    /// IRET to the resume park #GPs in ring 0 (the OMF-launcher relaunch
+    /// crash). Restored on `exec_return` alongside dpmi/ldt.
+    pub locked_stack_other: Option<(u16, u32)>,
     /// Parent was running in PM at EXEC time. The child is always VM86;
     /// `exec_return` uses this to flip `VM_FLAG` back so the dispatch tail
     /// runs the PM iret-frame pop instead of the VM86 one.


### PR DESCRIPTION
## Summary

Relaunching a DPMI game from a DPMI launcher (e.g. OMF 2097's menu → game → exit → game → exit) panicked the kernel on the **second** exit: a ring-0 `#GP` at the exit `IRET`, returning to the DPMI resume-continuation park (`CS=SPECIAL_STUB`, `SS=`client-SS idx 19) while the live LDT was the fresh child's — where index 19 is null.

## Root cause

`EXEC` already suspends the parent's `dpmi`/`ldt`/`pm_vectors`/`pm_dos` into `ExecParent` so the child runs with a clean protected-mode context, but it left `pc.locked_stack.other_stack` — the LIFO cursor into the parent's PM continuation chain — untouched. That cursor indexes a stack *through the parent's LDT selectors*.

A same-thread synth `EXEC` therefore handed the child the parent's cursor. The child's first PM IRQ, seeing `other_stack = Some` in PM mode, planted its resume continuation on `SS=0x9f` (client SS) instead of the host stack. In the child's fresh LDT that selector is null, so the `IRET` to the resume park `#GP`'d in ring 0. It only bit on the second exit because that's when the stale cursor happened to be live at the right moment.

## Fix

Suspend `other_stack` into `ExecParent` (reset to `None` for the child) and restore it in `exec_return` in the same branch that restores the parent's LDT — the cursor and the LDT are a matched pair. TSR exits that keep the child's DPMI session keep the child's chain, mirroring the existing `dpmi`/`ldt` handling. 16 lines.

## Notes

- **Pre-existing bug**, not a regression — confirmed it reproduces before the exception-stack fix (a79be28). Surfaced now that DPMI launchers relaunch cleanly.
- The ring-0 fault dumper added in a79be28, plus a one-off live-LDT descriptor dump, localized it.

## Verification

- OMF launch → game → exit, repeated 3× — no longer panics (previously deterministic on the 2nd exit).
- Duke3D demo loop and Extreme Pinball unaffected.
- Both clippy configs (metal + host crates) pass locally; branch CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSSiMx7EqsJZ11Gz6pWEKK