### PR TITLE
VFS: 9P-shaped trait + namespace composer + native host backend + correct fid lifecycle

### DIFF
--- a/arch-interp/src/hostfs.rs
+++ b/arch-interp/src/hostfs.rs
@@ -8,6 +8,7 @@
 //! are little-endian. The client always sends a complete command, then reads the
 //! reply, so each command is executed synchronously when its last byte arrives.
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fs;
 use std::io::{Read, Seek, SeekFrom, Write};
@@ -192,6 +193,134 @@ impl HostFs {
         }
         r.0
     }
+}
+
+// ── Native backend: the same std::fs server called directly (no COM1) ─────
+//
+// The kernel runs native in this process on the hosted backend, so `/host`
+// need not be byte-serial. These methods return the same values as the COM1
+// commands above, but as primitives the kernel's `InjectedHostFs` consumes
+// directly (via installed fn-pointers) — no framing, no UART round-trip.
+impl HostFs {
+    /// open → (status, handle, size); status < 0 = miss.
+    pub fn n_open(&mut self, path: &[u8]) -> (i32, u64, u32) {
+        let p = self.resolve(path);
+        match fs::metadata(&p) {
+            Ok(m) if m.is_file() => {
+                let h = self.assign(p);
+                (0, h as u64, m.len().min(u32::MAX as u64) as u32)
+            }
+            _ => (-1, 0, 0),
+        }
+    }
+
+    /// read → bytes read, or negative errno. `size` (the kernel's cached vnode
+    /// size) is unused — the read is bounded by `buf`.
+    pub fn n_read(&mut self, handle: u64, offset: u32, buf: &mut [u8]) -> i32 {
+        let n = self.handles.get(&(handle as u32)).and_then(|p| {
+            let mut f = fs::File::open(p).ok()?;
+            f.seek(SeekFrom::Start(offset as u64)).ok()?;
+            f.read(buf).ok()
+        });
+        match n {
+            Some(n) => n as i32,
+            None => -5,
+        }
+    }
+
+    /// readdir → (status, name, name_len, size, is_dir); status < 0 = end.
+    pub fn n_readdir(&self, dir: &[u8], index: usize) -> (i32, [u8; 100], usize, u32, bool) {
+        let p = self.resolve(dir);
+        match nth_entry(&p, index) {
+            Some((name, size, is_dir)) => {
+                let n = name.len().min(100);
+                let mut nb = [0u8; 100];
+                nb[..n].copy_from_slice(&name[..n]);
+                (0, nb, n, size, is_dir)
+            }
+            None => (-1, [0; 100], 0, 0, false),
+        }
+    }
+
+    pub fn n_dir_exists(&self, path: &[u8]) -> bool {
+        fs::metadata(self.resolve(path)).map(|m| m.is_dir()).unwrap_or(false)
+    }
+
+    /// create → (status, handle); status < 0 = fail.
+    pub fn n_create(&mut self, path: &[u8]) -> (i32, u64) {
+        let p = self.resolve(path);
+        match fs::File::create(&p) {
+            Ok(_) => (0, self.assign(p) as u64),
+            Err(_) => (-1, 0),
+        }
+    }
+
+    /// write → bytes written, or negative errno.
+    pub fn n_write(&mut self, handle: u64, offset: u32, data: &[u8]) -> i32 {
+        let ok = self.handles.get(&(handle as u32)).and_then(|p| {
+            let mut f = fs::OpenOptions::new().write(true).open(p).ok()?;
+            f.seek(SeekFrom::Start(offset as u64)).ok()?;
+            f.write_all(data).ok()
+        });
+        match ok {
+            Some(()) => data.len() as i32,
+            None => -5,
+        }
+    }
+
+    /// clunk: free the server-side fid (a cheap HashMap removal here).
+    pub fn n_clunk(&mut self, handle: u64) {
+        self.handles.remove(&(handle as u32));
+    }
+
+    /// remove → 0, or negative errno.
+    pub fn n_remove(&self, path: &[u8]) -> i32 {
+        match fs::remove_file(self.resolve(path)) {
+            Ok(_) => 0,
+            Err(_) => -1,
+        }
+    }
+}
+
+thread_local! {
+    /// The native host-fs server for the injected backend. Set by
+    /// `install_native_hostfs` on the CPU/kernel thread (interpreter state is
+    /// thread-local), before `startup`; the kernel's `/host` calls land here.
+    static NATIVE_HOSTFS: RefCell<Option<HostFs>> = const { RefCell::new(None) };
+}
+
+/// Install the native host-fs server rooted at `dir` (the hosted alternative to
+/// `attach_hostfs`'s COM1 UART). Call on the CPU/kernel thread before startup.
+pub fn install_native_hostfs(dir: &str) {
+    NATIVE_HOSTFS.with(|n| *n.borrow_mut() = Some(HostFs::new(dir)));
+}
+
+// The primitive free functions the kernel's `HostBackendHooks` point at. Each
+// dispatches to the thread-local server; a miss (server not installed) mirrors
+// the COM1 "no peer" errno so behaviour degrades the same way.
+pub fn host_open(path: &[u8]) -> (i32, u64, u32) {
+    NATIVE_HOSTFS.with(|n| n.borrow_mut().as_mut().map_or((-5, 0, 0), |fs| fs.n_open(path)))
+}
+pub fn host_read(handle: u64, offset: u32, buf: &mut [u8], _size: u32) -> i32 {
+    NATIVE_HOSTFS.with(|n| n.borrow_mut().as_mut().map_or(-5, |fs| fs.n_read(handle, offset, buf)))
+}
+pub fn host_readdir(dir: &[u8], index: usize) -> (i32, [u8; 100], usize, u32, bool) {
+    NATIVE_HOSTFS.with(|n| n.borrow().as_ref().map_or((-1, [0; 100], 0, 0, false), |fs| fs.n_readdir(dir, index)))
+}
+pub fn host_dir_exists(path: &[u8]) -> bool {
+    NATIVE_HOSTFS.with(|n| n.borrow().as_ref().map_or(false, |fs| fs.n_dir_exists(path)))
+}
+pub fn host_create(path: &[u8]) -> (i32, u64) {
+    NATIVE_HOSTFS.with(|n| n.borrow_mut().as_mut().map_or((-5, 0), |fs| fs.n_create(path)))
+}
+pub fn host_write(handle: u64, offset: u32, data: &[u8]) -> i32 {
+    NATIVE_HOSTFS.with(|n| n.borrow_mut().as_mut().map_or(-5, |fs| fs.n_write(handle, offset, data)))
+}
+pub fn host_clunk(handle: u64) {
+    NATIVE_HOSTFS.with(|n| { if let Some(fs) = n.borrow_mut().as_mut() { fs.n_clunk(handle) } });
+}
+pub fn host_remove(path: &[u8]) -> i32 {
+    NATIVE_HOSTFS.with(|n| n.borrow().as_ref().map_or(-1, |fs| fs.n_remove(path)))
 }
 
 /// Return the `index`-th directory entry as `(name_bytes, size, is_dir)`.

--- a/arch-interp/src/hostfs.rs
+++ b/arch-interp/src/hostfs.rs
@@ -308,7 +308,7 @@ pub fn host_readdir(dir: &[u8], index: usize) -> (i32, [u8; 100], usize, u32, bo
     NATIVE_HOSTFS.with(|n| n.borrow().as_ref().map_or((-1, [0; 100], 0, 0, false), |fs| fs.n_readdir(dir, index)))
 }
 pub fn host_dir_exists(path: &[u8]) -> bool {
-    NATIVE_HOSTFS.with(|n| n.borrow().as_ref().map_or(false, |fs| fs.n_dir_exists(path)))
+    NATIVE_HOSTFS.with(|n| n.borrow().as_ref().is_some_and(|fs| fs.n_dir_exists(path)))
 }
 pub fn host_create(path: &[u8]) -> (i32, u64) {
     NATIVE_HOSTFS.with(|n| n.borrow_mut().as_mut().map_or((-5, 0), |fs| fs.n_create(path)))

--- a/arch-interp/src/hostfs.rs
+++ b/arch-interp/src/hostfs.rs
@@ -101,8 +101,15 @@ impl HostFs {
                 }
                 Some((13 + dlen, self.write(le32(&buf[1..5]), le32(&buf[5..9]), &buf[13..13 + dlen])))
             }
-            CMD_CLOSE => Some((5.min(buf.len()).max(1), Vec::new())), // client never sends; no reply
-            _ => Some((1, Vec::new())),                              // unknown: skip one byte
+            CMD_CLOSE => {
+                // Tclunk: [cmd][u32 handle]. Fire-and-forget — free the fid, no reply.
+                if buf.len() < 5 {
+                    return None;
+                }
+                self.handles.remove(&le32(&buf[1..5]));
+                Some((5, Vec::new()))
+            }
+            _ => Some((1, Vec::new())), // unknown: skip one byte
         }
     }
 

--- a/arch-interp/src/lib.rs
+++ b/arch-interp/src/lib.rs
@@ -94,6 +94,13 @@ pub use devices::{
     attach_audio, attach_disk, attach_fw_cfg, attach_hostfs, register, register_debugcon,
     register_debugcon_file, PortIo,
 };
+// Native host-fs backend (hosted "punch-through"): `install_native_hostfs` sets
+// the root; the `host_*` fns are the primitive hooks the kernel's
+// `install_host_backend` points at (direct std::fs, no COM1).
+pub use hostfs::{
+    host_clunk, host_create, host_dir_exists, host_open, host_read, host_readdir,
+    host_remove, host_write, install_native_hostfs,
+};
 // Host-side VGA text-screen snapshotting (headless inspection of the guest's
 // 0xB8000 text buffer): `set_dump_path` arms it, `request_vga_dump` flips the
 // flag from a watcher thread, the CPU thread renders at the next slice boundary.

--- a/kernel/src/kernel/ext4fs.rs
+++ b/kernel/src/kernel/ext4fs.rs
@@ -47,9 +47,8 @@ pub struct Ext4Fs {
     /// Per-handle seekable file cursors (handle = monotonic counter). A `File`
     /// is just an inode + extent iterator + offset (a few hundred bytes), NOT
     /// the file's contents — so this stays small no matter how large the files
-    /// are. Lifetime matches the VFS path-cache: handles are not dropped on
-    /// close (the path-cache shares a handle across opens and is never
-    /// evicted), exactly as the old cached byte buffers lived.
+    /// are. `clunk` drops a cursor when its open file closes (each VFS open owns
+    /// its own handle), so the map tracks only currently-open files.
     open_files: RefCell<BTreeMap<u64, File>>,
     /// Next handle to assign.
     next_handle: RefCell<u64>,
@@ -210,5 +209,12 @@ impl Filesystem for Ext4Fs {
         // busybox reject it). read_dir follows symlinks (FollowSymlinks::All),
         // so a symlink TO a directory correctly counts as one.
         self.fs.read_dir(abs).is_ok()
+    }
+
+    /// Drop the seekable cursor for a closed handle (Tclunk). Without this the
+    /// `open_files` map — and, on hosted, the underlying host fd each `File`
+    /// holds — would grow for the life of the mount.
+    fn clunk(&self, handle: u64) {
+        self.open_files.borrow_mut().remove(&handle);
     }
 }

--- a/kernel/src/kernel/hostfs.rs
+++ b/kernel/src/kernel/hostfs.rs
@@ -261,6 +261,7 @@ impl Filesystem for HostFs {
 ///   `create`→ (status, handle); status < 0 = fail.
 ///   `write` → bytes written, or negative errno.
 #[derive(Clone, Copy)]
+#[allow(clippy::type_complexity)] // the readdir hook's tuple reply is documented above
 pub struct HostBackendHooks {
     pub open: fn(&[u8]) -> (i32, u64, u32),
     pub read: fn(u64, u32, &mut [u8], u32) -> i32,

--- a/kernel/src/kernel/hostfs.rs
+++ b/kernel/src/kernel/hostfs.rs
@@ -107,7 +107,6 @@ fn recv_u8() -> u8 {
 
 const CMD_OPEN: u8 = 0x01;
 const CMD_READ: u8 = 0x02;
-#[allow(dead_code)]
 const CMD_CLOSE: u8 = 0x03;
 const CMD_STAT: u8 = 0x04;
 const CMD_READDIR: u8 = 0x05;
@@ -230,15 +229,16 @@ impl Filesystem for HostFs {
         if status < 0 { return status; }
         written as i32
     }
-}
 
-/// Close a hostfs handle (called when VFS file entry is freed).
-/// Note: the VFS doesn't currently call close on the Filesystem trait,
-/// so hostfs handles leak. This is acceptable for now.
-#[allow(dead_code)]
-pub fn close_handle(handle: u32) {
-    if !is_ready() { return; }
-    send_byte(CMD_CLOSE);
-    send_u32(handle);
-    let _status = recv_i32();
+    /// Tclunk: tell the host to free the server-side fid. Fire-and-forget (the
+    /// server sends no reply). Implemented and ready, but the VFS does not call
+    /// it on file close yet — the `path_cache` shares a fid across opens, so
+    /// there is no safe per-close clunk point (see `vfs::Vfs::close_handle`).
+    /// Until fid lifecycle moves to cache eviction, hostfs leaks one handle per
+    /// distinct path opened.
+    fn clunk(&self, handle: u64) {
+        if !is_ready() { return; }
+        send_byte(CMD_CLOSE);
+        send_u32(handle as u32);
+    }
 }

--- a/kernel/src/kernel/hostfs.rs
+++ b/kernel/src/kernel/hostfs.rs
@@ -1,8 +1,15 @@
-//! Host filesystem — talks to hostfs.py via COM1 serial port.
+//! Host filesystem — two backends behind the one VFS `Filesystem` trait:
 //!
-//! Implements the VFS Filesystem trait by sending commands over the serial
-//! port, which QEMU bridges to a Unix socket where the host-side Python
-//! script serves real file operations.
+//! - `HostFs` (this file's original): the byte-serial COM1 client. On metal,
+//!   QEMU bridges COM1 to a host-side server; a real transport, kept for metal.
+//! - `InjectedHostFs`: the hosted "punch-through". The kernel runs native in
+//!   the host process there, so `/host` need not go over COM1 at all — the
+//!   entry crate installs `std::fs`-backed hooks (`install_host_backend`, the
+//!   same injection shape as `install_portio`) and this dispatches straight to
+//!   them: direct calls, no framing, no VM exit.
+//!
+//! Hook signatures are primitive-only so no non-primitive type crosses the
+//! arch-interp↔kernel boundary (arch-interp has no `kernel` dependency).
 
 use crate::kernel::portio::{inb, outb};
 use crate::kernel::vfs::{Filesystem, Vnode, DirEntry};
@@ -240,5 +247,94 @@ impl Filesystem for HostFs {
         if !is_ready() { return; }
         send_byte(CMD_CLOSE);
         send_u32(handle as u32);
+    }
+}
+
+// ── Injected native host backend (hosted "punch-through") ─────────────────
+
+/// The installed native host-fs hook table. Primitive signatures only: the
+/// entry crate wires these to `arch-interp`'s `std::fs` server (which has no
+/// `kernel` dependency, so no `Vnode`/`DirEntry` may appear here).
+///   `open`  → (status, handle, size); status < 0 = miss.
+///   `read`  → bytes read, or negative errno.
+///   `readdir` → (status, name, name_len, size, is_dir); status < 0 = end.
+///   `create`→ (status, handle); status < 0 = fail.
+///   `write` → bytes written, or negative errno.
+#[derive(Clone, Copy)]
+pub struct HostBackendHooks {
+    pub open: fn(&[u8]) -> (i32, u64, u32),
+    pub read: fn(u64, u32, &mut [u8], u32) -> i32,
+    pub readdir: fn(&[u8], usize) -> (i32, [u8; 100], usize, u32, bool),
+    pub dir_exists: fn(&[u8]) -> bool,
+    pub create: fn(&[u8]) -> (i32, u64),
+    pub write: fn(u64, u32, &[u8]) -> i32,
+    pub clunk: fn(u64),
+    pub remove: fn(&[u8]) -> i32,
+}
+
+static mut HOST_BACKEND: Option<HostBackendHooks> = None;
+
+/// Install the native host-fs hooks. Single-threaded boot context (the entry
+/// calls this before `startup`), safe by the same argument as `install_portio`.
+pub fn install_host_backend(hooks: HostBackendHooks) {
+    unsafe { HOST_BACKEND = Some(hooks); }
+}
+
+/// Whether a native host backend is installed — the hosted signal that `/host`
+/// is available without probing COM1 (see `platform::probe_media`).
+pub fn host_backend_installed() -> bool {
+    // Copy the Option out (both it and the hooks are `Copy`) so we never take a
+    // reference to the mutable static — an error under edition 2024.
+    unsafe { HOST_BACKEND }.is_some()
+}
+
+#[inline]
+fn backend() -> HostBackendHooks {
+    unsafe { HOST_BACKEND }.expect("host backend not installed")
+}
+
+/// The `Filesystem` mounted at `/host` (or root, under `Media::HostRoot`) on
+/// hosted: every call dispatches to the injected native `std::fs` hooks.
+pub struct InjectedHostFs;
+pub static INJECTED_HOSTFS: InjectedHostFs = InjectedHostFs;
+
+impl Filesystem for InjectedHostFs {
+    fn open(&self, path: &[u8]) -> Option<Vnode> {
+        let (status, handle, size) = (backend().open)(path);
+        if status < 0 { return None; }
+        Some(Vnode { handle, size, mode: 0o644 })
+    }
+
+    fn read(&self, handle: u64, offset: u32, buf: &mut [u8], size: u32) -> i32 {
+        (backend().read)(handle, offset, buf, size)
+    }
+
+    fn readdir(&self, dir: &[u8], index: usize) -> Option<DirEntry> {
+        let (status, name, name_len, size, is_dir) = (backend().readdir)(dir, index);
+        if status < 0 { return None; }
+        Some(DirEntry { name, name_len, size, is_dir,
+            mode: if is_dir { 0o755 } else { 0o644 } })
+    }
+
+    fn dir_exists(&self, path: &[u8]) -> bool {
+        (backend().dir_exists)(path)
+    }
+
+    fn create(&self, path: &[u8]) -> Option<Vnode> {
+        let (status, handle) = (backend().create)(path);
+        if status < 0 { return None; }
+        Some(Vnode { handle, size: 0, mode: 0o644 })
+    }
+
+    fn write(&self, handle: u64, offset: u32, data: &[u8]) -> i32 {
+        (backend().write)(handle, offset, data)
+    }
+
+    fn clunk(&self, handle: u64) {
+        (backend().clunk)(handle)
+    }
+
+    fn remove(&self, path: &[u8]) -> i32 {
+        (backend().remove)(path)
     }
 }

--- a/kernel/src/kernel/platform.rs
+++ b/kernel/src/kernel/platform.rs
@@ -369,7 +369,11 @@ fn is_linux_root(lba: u32) -> bool {
 
 fn probe_media<A: crate::Arch>(machine: &mut A) -> Media {
     let _ = machine;
-    let hostfs = crate::kernel::hostfs::init();
+    // A native host backend (hosted "punch-through") means /host is available
+    // without COM1 — take it as hostfs-present and skip the serial probe.
+    // Otherwise fall back to the COM1 transport (metal, or the Python bridge).
+    let hostfs = crate::kernel::hostfs::host_backend_installed()
+        || crate::kernel::hostfs::init();
 
     let mut mbr = [0u8; 512];
     crate::kernel::block::read_sectors(0, &mut mbr);

--- a/kernel/src/kernel/startup.rs
+++ b/kernel/src/kernel/startup.rs
@@ -59,6 +59,17 @@ pub fn startup<A: crate::Arch>(machine: &mut A, boot: &crate::BootConfig) -> ! {
 /// root, or AS the root under `Media::HostRoot`.
 static HOSTFS: crate::kernel::hostfs::HostFs = crate::kernel::hostfs::HostFs::new();
 
+/// The host fs to mount: the injected native `std::fs` backend when the entry
+/// installed one (hosted "punch-through" — direct calls, no COM1), else the
+/// COM1 `HOSTFS` client (metal / the Python bridge).
+fn host_fs() -> &'static dyn vfs::Filesystem {
+    if crate::kernel::hostfs::host_backend_installed() {
+        &crate::kernel::hostfs::INJECTED_HOSTFS
+    } else {
+        &HOSTFS
+    }
+}
+
 /// Derive the mount set from the platform's Media verdict (the probe already
 /// scanned the MBR and the hostfs transport); then the symbol index.
 /// /boot is an INVARIANT: the embedded bootfs (DN + COMMAND.COM), mounted on
@@ -97,14 +108,14 @@ fn mount_filesystems(platform: &'static crate::kernel::platform::Platform) {
                 }
             }
             if hostfs {
-                vfs::mount(b"host/", &HOSTFS);
+                vfs::mount(b"host/", host_fs());
                 println!("hostfs mounted at /host");
             }
         }
         Media::HostRoot => {
             // The host filesystem IS the VFS root: Linux binaries see /usr,
             // /lib, /etc natively; DOS C: is the /home/retroos subtree.
-            vfs::mount(b"", &HOSTFS);
+            vfs::mount(b"", host_fs());
             println!("hostfs mounted as root");
         }
         Media::Diskless => {}

--- a/kernel/src/kernel/vfs.rs
+++ b/kernel/src/kernel/vfs.rs
@@ -42,11 +42,19 @@ const PATH_KEY_MAX: usize = 164;
 
 /// Filesystem trait — implemented by TarFs, Ext4Fs, etc. POSIX-strict; the
 /// DOS personality wraps this layer with its own case-folding cache (DFS).
+///
+/// This is 9P-shaped: `open(path)` is a fused Twalk+Topen returning a fid
+/// (`Vnode::handle`), `read`/`write` carry the offset per call (like `Tread`/
+/// `Twrite`, so a fid can be shared across independent offsets), `clunk`
+/// releases a fid (`Tclunk`), and `remove` deletes a path (`Tremove`).
+/// In-process servers implement it as direct calls; a future wire codec can
+/// marshal the same operations over virtio-9p / TCP behind this trait.
 pub trait Filesystem {
     /// Look up a file by normalized path, case-sensitively (POSIX).
+    /// Fused Twalk+Topen: returns a fid (`Vnode::handle`).
     fn open(&self, path: &[u8]) -> Option<Vnode>;
 
-    /// Read from a file identified by handle at given byte offset.
+    /// Read from a file identified by handle at given byte offset (Tread).
     fn read(&self, handle: u64, offset: u32, buf: &mut [u8], size: u32) -> i32;
 
     /// Enumerate directory entries at index. Returns None at end.
@@ -58,17 +66,29 @@ pub trait Filesystem {
     /// Create (or truncate) a file. Returns vnode on success. Default = R/O.
     fn create(&self, _path: &[u8]) -> Option<Vnode> { None }
 
-    /// Write to a file identified by handle at given byte offset. Returns
-    /// bytes written, or negative errno. Default = R/O (silently accept).
+    /// Write to a file identified by handle at given byte offset (Twrite).
+    /// Returns bytes written, or negative errno. Default = R/O (silently accept).
     fn write(&self, _handle: u64, _offset: u32, data: &[u8]) -> i32 {
         data.len() as i32
     }
+
+    /// Release a fid (Tclunk). Default = no-op, for backends whose handle owns
+    /// no server-side resource (TarFs offsets, ext4 inode refs). Backends that
+    /// allocate per-open server state (hostfs COM1 fids, a future 9P client)
+    /// override this to free it. NOTE: the VFS does not yet call this on file
+    /// close — see `close_handle` for why (shared handles via `path_cache`).
+    fn clunk(&self, _handle: u64) {}
+
+    /// Remove a file by path (Tremove). Default = -1 (read-only / unsupported).
+    fn remove(&self, _path: &[u8]) -> i32 { -1 }
 }
 
-/// Identifies a file on a filesystem
+/// Identifies an open file on a filesystem — effectively a 9P fid plus the
+/// cached stat fields (`size`, `mode`) the qid/Tstat would carry. An explicit
+/// `Tstat` message is deferred until the wire codec needs it.
 #[derive(Clone, Copy)]
 pub struct Vnode {
-    pub handle: u64,  // filesystem-specific opaque handle (RAM_SENTINEL for overlay)
+    pub handle: u64,  // 9P fid: filesystem-specific opaque handle (RAM_SENTINEL for overlay)
     pub size: u32,
     /// POSIX permission bits (lower 12 — perms + setuid/setgid/sticky).
     /// Carried through from the backing filesystem (TAR's USTAR mode field,
@@ -111,14 +131,53 @@ pub struct FileEntry {
     pub ram_key_len: u8,
 }
 
-/// Mount table entry
+/// How a mount composes with any bindings already at its prefix — Plan 9's
+/// mount modes, trimmed to the two we use:
+/// - `Replace` — the single-winner mount (Plan 9 MREPL). Mounting `Replace` at
+///   a prefix first drops any existing bindings there, so the group has exactly
+///   one member. This reproduces the old longest-prefix table bit-for-bit and
+///   is the default; every startup mount uses it.
+/// - `Union` — stack a layer on top without removing what's there (Plan 9
+///   MBEFORE). A union group resolves most-recently-mounted first; `readdir`
+///   merges the members (an upper layer shadows a lower one on a name clash).
+///
+/// (Plan 9's MAFTER — stack at the *bottom* — has no consumer yet.)
+#[derive(Clone, Copy, PartialEq)]
+enum MountMode { Replace, Union }
+
+/// What a binding points at.
 #[derive(Clone, Copy)]
-struct Mount {
-    prefix: &'static [u8],  // e.g. b"" for root, b"boot/" for sub-mount
-    fs: &'static dyn Filesystem,
+enum BindTarget {
+    /// A real filesystem served at this prefix (a mount).
+    Server(&'static dyn Filesystem),
+    /// A redirect to another namespace path (a bind): a lookup here is retried
+    /// as `src_prefix + subpath`, so an existing subtree appears at a second
+    /// place (e.g. `bind disk1/games/ → games/`) with no backing fs of its own.
+    Alias { src_prefix: &'static [u8] },
 }
 
-const MAX_MOUNTS: usize = 6;
+/// One entry in the namespace: a prefix, what it points at, how it composes,
+/// and a monotonic sequence number that gives union members a stable order.
+///
+/// Prefixes and alias targets are `&'static` — boot-time mounts leak their
+/// (one-time, boot-lifetime) prefix, the same discipline the old fixed table
+/// used. The table is built entirely at startup before any file is opened, so
+/// the `mount_idx` values cached in `path_cache`/`file_table` (Vec indices)
+/// stay stable — do not mutate the table after boot without revisiting that.
+#[derive(Clone, Copy)]
+struct Binding {
+    prefix: &'static [u8],  // e.g. b"" for root, b"boot/" for sub-mount
+    target: BindTarget,
+    mode: MountMode,
+    seq: u32,
+}
+
+/// Max members in one union group (fixed scratch, no alloc on resolve). A
+/// union stack is tiny in practice; overflow drops the oldest layers (logged).
+const MAX_UNION: usize = 8;
+
+/// Alias (bind) expansion depth cap — breaks any accidental bind cycle.
+const ALIAS_DEPTH: u8 = 8;
 
 /// Single-directory readdir cache (avoids O(n²) re-scanning for sequential
 /// readdir). One directory cached at a time, growable so a flat dir with
@@ -152,8 +211,10 @@ static EMPTY_FS: EmptyFs = EmptyFs;
 
 /// All VFS state, behind one lock. See the module docs for the locking model.
 struct Vfs {
-    mounts: [Option<Mount>; MAX_MOUNTS],
-    mount_count: usize,
+    /// The namespace: an ordered, stackable, bind-capable mount table (the
+    /// composer). Built at startup; a Replace group is a single member.
+    mounts: Vec<Binding>,
+    next_seq: u32,
     /// Writable file overlay — persists across open/close cycles.
     ram_files: BTreeMap<Vec<u8>, Vec<u8>>,
     /// Path-keyed vnode cache in front of `fs.open()` (skips the FS walk on
@@ -176,8 +237,8 @@ impl Vfs {
             ram_key_len: 0,
         };
         Vfs {
-            mounts: [None; MAX_MOUNTS],
-            mount_count: 0,
+            mounts: Vec::new(),
+            next_seq: 0,
             ram_files: BTreeMap::new(),
             path_cache: BTreeMap::new(),
             file_table: [EMPTY; MAX_OPEN_FILES],
@@ -185,76 +246,158 @@ impl Vfs {
         }
     }
 
-    // ── mount table ──────────────────────────────────────────────────────
+    // ── mount table (namespace composer) ─────────────────────────────────
 
-    /// Find the mount whose prefix matches `path`: (mount_index, fs, path-after-
-    /// prefix). Longest prefix wins; a path equal to a prefix sans trailing `/`
-    /// resolves to that mount's root.
-    fn resolve_mount<'a>(&self, path: &'a [u8]) -> (u8, &'static dyn Filesystem, &'a [u8]) {
-        let mut best_idx = 0u8;
-        let mut best_len = 0usize;
-        let mut found = false;
-        for i in 0..self.mount_count {
-            if let Some(ref m) = self.mounts[i] {
-                let plen = m.prefix.len();
-                let matches = m.prefix.is_empty()
-                    || (path.len() >= plen && eq_ignore_case(&path[..plen], m.prefix))
-                    || (plen > 0 && m.prefix.last() == Some(&b'/')
-                        && path.len() == plen - 1
-                        && eq_ignore_case(path, &m.prefix[..plen-1]));
-                if matches && (!found || plen > best_len) {
-                    best_idx = i as u8;
-                    best_len = plen.min(path.len());
-                    found = true;
+    /// Visit the members serving `path`, highest-priority first, each resolved
+    /// to `(mount_idx, fs, subpath)`, calling `f` per member; return the first
+    /// `Some` it yields (short-circuit). So `open` stops at the first hit and
+    /// `dir_exists` at the first existing dir, while a `readdir` closure that
+    /// always returns `None` visits every member in order (union merge). Alias
+    /// (bind) targets are expanded by retrying under `src_prefix`, depth-capped.
+    ///
+    /// For a `Replace` group (every startup mount) there is exactly one member,
+    /// so this reduces to the old single-winner longest-prefix lookup.
+    fn resolve_members<R>(
+        &self,
+        path: &[u8],
+        depth: u8,
+        f: &mut impl FnMut(u8, &'static dyn Filesystem, &[u8]) -> Option<R>,
+    ) -> Option<R> {
+        // Longest matching prefix length across all bindings.
+        let mut best: Option<usize> = None;
+        for b in &self.mounts {
+            if match_prefix(b.prefix, path).is_some() {
+                best = Some(best.map_or(b.prefix.len(), |x| x.max(b.prefix.len())));
+            }
+        }
+        let best = best?;
+
+        // Members at that prefix, ordered most-recently-mounted (highest seq)
+        // first. A Replace group is a single member; a union stacks here.
+        let mut members = [(0usize, 0u32); MAX_UNION];
+        let mut n = 0;
+        for (i, b) in self.mounts.iter().enumerate() {
+            if b.prefix.len() == best && match_prefix(b.prefix, path).is_some() {
+                if n < MAX_UNION {
+                    members[n] = (i, b.seq);
+                    n += 1;
+                } else {
+                    crate::dbg_println!(
+                        "vfs: union group exceeds {} layers; dropping oldest", MAX_UNION);
                 }
             }
         }
-        if !found {
-            // Nothing mounted (e.g. the hosted bare-ELF Linux path, before a root
-            // fs exists). Resolve to the empty filesystem so opens miss with
-            // -ENOENT instead of panicking.
-            return (0, &EMPTY_FS, path);
-        }
-        let m = self.mounts[best_idx as usize].as_ref().unwrap();
-        (best_idx, m.fs, &path[best_len..])
-    }
+        members[..n].sort_by(|a, b| b.1.cmp(&a.1)); // seq desc = most-recent first
 
-    /// If `parent/<name>` (case-insensitive) is itself a mount point, return the
-    /// mount's directory component (e.g. parent=`home/retroos`, name=`BOOT` →
-    /// `b"boot"`). DFS uses this so a VFS mount point is a traversable directory
-    /// even though the parent's *backing* fs has no such readdir entry.
-    fn mount_child(&self, parent: &[u8], name: &[u8]) -> Option<&'static [u8]> {
-        let mut par = parent;
-        while par.first() == Some(&b'/') { par = &par[1..]; }
-        while par.last() == Some(&b'/') { par = &par[..par.len() - 1]; }
-        for i in 0..self.mount_count {
-            if let Some(ref m) = self.mounts[i] {
-                let prefix: &'static [u8] = m.prefix;
-                // Drop the trailing slash mount prefixes carry.
-                let p: &'static [u8] = if prefix.last() == Some(&b'/') {
-                    &prefix[..prefix.len() - 1]
-                } else { prefix };
-                if p.is_empty() { continue; } // root mount: no child name
-                let (dir, last): (&[u8], &'static [u8]) = match p.iter().rposition(|&b| b == b'/') {
-                    Some(idx) => (&p[..idx], &p[idx + 1..]),
-                    None => (&b""[..], p),
-                };
-                if eq_ignore_case(dir, par) && eq_ignore_case(last, name) {
-                    return Some(last);
+        for &(i, _) in &members[..n] {
+            let b = self.mounts[i];
+            let start = match_prefix(b.prefix, path).unwrap();
+            let subpath = &path[start..];
+            match b.target {
+                BindTarget::Server(fs) => {
+                    if let Some(r) = f(i as u8, fs, subpath) { return Some(r); }
+                }
+                BindTarget::Alias { src_prefix } => {
+                    if depth == 0 { continue; }
+                    // Retry the lookup as `src_prefix + subpath`.
+                    let mut buf = [0u8; PATH_KEY_MAX];
+                    let (pl, sl) = (src_prefix.len(), subpath.len());
+                    if pl + sl > buf.len() { continue; }
+                    buf[..pl].copy_from_slice(src_prefix);
+                    buf[pl..pl + sl].copy_from_slice(subpath);
+                    if let Some(r) = self.resolve_members(&buf[..pl + sl], depth - 1, f) {
+                        return Some(r);
+                    }
                 }
             }
         }
         None
     }
 
+    /// The single highest-priority `Server` member at the longest matching
+    /// prefix (non-allocating). Used by `create`/`delete`, which write to the
+    /// top layer. Alias heads and an empty table fall back to `EmptyFs` (so a
+    /// create on a bound or unmounted path lands on the RAM overlay).
+    fn resolve_head<'a>(&self, path: &'a [u8]) -> (u8, &'static dyn Filesystem, &'a [u8]) {
+        let mut best: Option<(usize, u32, usize, usize)> = None; // (plen, seq, idx, start)
+        for (i, b) in self.mounts.iter().enumerate() {
+            if let BindTarget::Server(_) = b.target
+                && let Some(start) = match_prefix(b.prefix, path) {
+                let better = match best {
+                    None => true,
+                    Some((bl, bseq, _, _)) =>
+                        b.prefix.len() > bl || (b.prefix.len() == bl && b.seq > bseq),
+                };
+                if better { best = Some((b.prefix.len(), b.seq, i, start)); }
+            }
+        }
+        match best {
+            Some((_, _, i, start)) => match self.mounts[i].target {
+                BindTarget::Server(fs) => (i as u8, fs, &path[start..]),
+                BindTarget::Alias { .. } => unreachable!(),
+            },
+            None => (0, &EMPTY_FS, path),
+        }
+    }
+
+    /// If `parent/<name>` (case-insensitive) is itself a mount/bind point,
+    /// return its directory component (e.g. parent=`home/retroos`, name=`BOOT`
+    /// → `b"boot"`). DFS uses this so a VFS mount point is a traversable
+    /// directory even though the parent's *backing* fs has no such readdir
+    /// entry. Both Server and Alias bindings expose their prefix here.
+    fn mount_child(&self, parent: &[u8], name: &[u8]) -> Option<&'static [u8]> {
+        let mut par = parent;
+        while par.first() == Some(&b'/') { par = &par[1..]; }
+        while par.last() == Some(&b'/') { par = &par[..par.len() - 1]; }
+        for b in &self.mounts {
+            let prefix: &'static [u8] = b.prefix;
+            // Drop the trailing slash mount prefixes carry.
+            let p: &'static [u8] = if prefix.last() == Some(&b'/') {
+                &prefix[..prefix.len() - 1]
+            } else { prefix };
+            if p.is_empty() { continue; } // root mount: no child name
+            let (dir, last): (&[u8], &'static [u8]) = match p.iter().rposition(|&b| b == b'/') {
+                Some(idx) => (&p[..idx], &p[idx + 1..]),
+                None => (&b""[..], p),
+            };
+            if eq_ignore_case(dir, par) && eq_ignore_case(last, name) {
+                return Some(last);
+            }
+        }
+        None
+    }
+
     fn mount_fs(&self, idx: u8) -> &'static dyn Filesystem {
-        self.mounts[idx as usize].as_ref().expect("VFS: invalid mount index").fs
+        match self.mounts[idx as usize].target {
+            BindTarget::Server(fs) => fs,
+            // A file handle only ever records a Server member (open resolves
+            // through Alias to the fs that actually held the file).
+            BindTarget::Alias { .. } => panic!("VFS: file handle points at a bind alias"),
+        }
+    }
+
+    /// Add a binding. `Replace` first drops any existing bindings at the exact
+    /// same prefix (single-winner); `Union` stacks on top. The whole table is
+    /// built at startup before any open, so this never reindexes live handles.
+    fn add_binding(&mut self, prefix: &'static [u8], target: BindTarget, mode: MountMode) {
+        if mode == MountMode::Replace {
+            self.mounts.retain(|b| !eq_ignore_case(b.prefix, prefix));
+        }
+        let seq = self.next_seq;
+        self.next_seq = self.next_seq.wrapping_add(1);
+        self.mounts.push(Binding { prefix, target, mode, seq });
     }
 
     fn mount(&mut self, prefix: &'static [u8], fs: &'static dyn Filesystem) {
-        assert!(self.mount_count < MAX_MOUNTS, "VFS: mount table full");
-        self.mounts[self.mount_count] = Some(Mount { prefix, fs });
-        self.mount_count += 1;
+        self.add_binding(prefix, BindTarget::Server(fs), MountMode::Replace);
+    }
+
+    fn mount_union(&mut self, prefix: &'static [u8], fs: &'static dyn Filesystem) {
+        self.add_binding(prefix, BindTarget::Server(fs), MountMode::Union);
+    }
+
+    fn bind(&mut self, prefix: &'static [u8], src_prefix: &'static [u8], mode: MountMode) {
+        self.add_binding(prefix, BindTarget::Alias { src_prefix }, mode);
     }
 
     // ── file table ───────────────────────────────────────────────────────
@@ -263,6 +406,15 @@ impl Vfs {
         (0..MAX_OPEN_FILES).find(|&i| self.file_table[i].refcount == 0)
     }
 
+    /// Drop one reference to a file-table entry. Frees the slot at refcount 0.
+    ///
+    /// This intentionally does NOT `clunk` the backing fid at refcount 0. The
+    /// `path_cache` caches each path's `Vnode` (fid included) indefinitely and
+    /// hands the *same* fid to every open of that path, so a live fid can be
+    /// referenced by the cache and by other file-table entries after this one
+    /// closes — clunking here would corrupt their reads and the next re-open.
+    /// Fid lifecycle therefore belongs with `path_cache` eviction, not here;
+    /// until then hostfs leaks one server handle per distinct path opened.
     fn close_handle(&mut self, idx: i32) {
         if idx >= 0 && (idx as usize) < MAX_OPEN_FILES {
             let entry = &mut self.file_table[idx as usize];
@@ -284,46 +436,60 @@ impl Vfs {
         self.dir_cache.valid = false;
     }
 
-    /// Populate the directory cache for `dir` (single pass).
+    /// Populate the directory cache for `dir` (single pass). Layers, top to
+    /// bottom (a name from a higher layer shadows the same name lower down):
+    /// the RAM overlay (writable, shadows the backing fs — matching `open`'s
+    /// RAM-first check), then the union stack of mounted filesystems (most-
+    /// recent first), then synthesized mount/bind-point directories.
     fn populate_dir_cache(&mut self, dir: &[u8]) {
         let dlen = dir.len().min(self.dir_cache.dir.len());
         self.dir_cache.dir[..dlen].copy_from_slice(&dir[..dlen]);
         self.dir_cache.dir_len = dlen;
-        self.dir_cache.entries.clear();
 
-        let (_midx, fs, subpath) = self.resolve_mount(dir);
-        let mut idx = 0usize;
-        while let Some(e) = fs.readdir(subpath, idx) {
-            self.dir_cache.entries.push(e);
-            idx += 1;
-        }
+        let mut entries: Vec<DirEntry> = Vec::new();
 
-        // Synthesize mount-point directories.
-        for i in 0..self.mount_count {
-            if let Some(ref m) = self.mounts[i]
-                && let Some(name) = mount_child_in_dir(m.prefix, dir) {
-                    let name_len = name.len().min(100);
-                    let mut de = DirEntry {
-                        name: [0; 100], name_len, size: 0, is_dir: true, mode: 0o755,
-                    };
-                    de.name[..name_len].copy_from_slice(&name[..name_len]);
-                    self.dir_cache.entries.push(de);
-                }
-        }
-
-        // RAM overlay files.
+        // RAM overlay files (writable layer, highest priority).
         for (key, data) in self.ram_files.iter() {
-            if let Some(basename) = entry_in_ram_dir(key, dir) {
+            if let Some(basename) = entry_in_ram_dir(key, dir)
+                && !dir_entries_has(&entries, basename) {
                 let len = basename.len().min(100);
                 let mut de = DirEntry {
                     name: [0; 100], name_len: len, size: data.len() as u32,
                     is_dir: false, mode: 0o644,
                 };
                 de.name[..len].copy_from_slice(&basename[..len]);
-                self.dir_cache.entries.push(de);
+                entries.push(de);
             }
         }
 
+        // Union merge: visit every member of the group in priority order (most
+        // recent first); an upper layer shadows a lower one on a name clash.
+        // For a Replace group this is just the one backing fs (== old behavior).
+        self.resolve_members(dir, ALIAS_DEPTH, &mut |_idx, fs, subpath| {
+            let mut idx = 0usize;
+            while let Some(e) = fs.readdir(subpath, idx) {
+                if !dir_entries_has(&entries, &e.name[..e.name_len]) {
+                    entries.push(e);
+                }
+                idx += 1;
+            }
+            None::<()>
+        });
+
+        // Synthesize mount/bind-point directories that live directly under `dir`.
+        for b in &self.mounts {
+            if let Some(name) = mount_child_in_dir(b.prefix, dir)
+                && !dir_entries_has(&entries, name) {
+                let name_len = name.len().min(100);
+                let mut de = DirEntry {
+                    name: [0; 100], name_len, size: 0, is_dir: true, mode: 0o755,
+                };
+                de.name[..name_len].copy_from_slice(&name[..name_len]);
+                entries.push(de);
+            }
+        }
+
+        self.dir_cache.entries = entries;
         self.dir_cache.valid = true;
     }
 
@@ -338,13 +504,14 @@ impl Vfs {
     }
 
     fn dir_exists(&self, path: &[u8]) -> bool {
-        let (_midx, fs, subpath) = self.resolve_mount(path);
-        // A mount root (and the VFS root) is structurally a directory — answer
-        // without querying the backing fs. This avoids blocking on a mount
-        // whose transport is unresponsive: e.g. `ls /` stats the /host hostfs
-        // mount, and a hostfs read with no server attached hangs forever.
-        if subpath.is_empty() { return true; }
-        fs.dir_exists(subpath)
+        // True if any member of the group has this dir. A mount root (and the
+        // VFS root) is structurally a directory — a member with an empty
+        // subpath answers true without querying the backing fs, which avoids
+        // blocking on a mount whose transport is unresponsive (e.g. `ls /`
+        // stats the /host mount; a hostfs read with no server attached hangs).
+        self.resolve_members(path, ALIAS_DEPTH, &mut |_idx, fs, subpath| {
+            if subpath.is_empty() || fs.dir_exists(subpath) { Some(()) } else { None }
+        }).is_some()
     }
 
     // ── open / create / read / write / seek ──────────────────────────────
@@ -387,9 +554,12 @@ impl Vfs {
             return table_idx as i32;
         }
 
-        let (midx, fs, subpath) = self.resolve_mount(path);
-        let vnode = match fs.open(subpath) {
-            Some(v) => v,
+        // Try each member of the group in priority order; first hit wins and
+        // its mount_idx is recorded (a Replace group = the single backing fs).
+        let (midx, vnode) = match self.resolve_members(path, ALIAS_DEPTH, &mut |idx, fs, subpath| {
+            fs.open(subpath).map(|v| (idx, v))
+        }) {
+            Some(x) => x,
             None => return -2,
         };
 
@@ -412,7 +582,7 @@ impl Vfs {
     }
 
     fn create_to_handle(&mut self, path: &[u8]) -> i32 {
-        let (midx, fs, subpath) = self.resolve_mount(path);
+        let (midx, fs, subpath) = self.resolve_head(path);
         if let Some(vnode) = fs.create(subpath) {
             let table_idx = match self.alloc_file_entry() {
                 Some(i) => i,
@@ -456,8 +626,18 @@ impl Vfs {
     fn delete(&mut self, path: &[u8]) -> i32 {
         if self.ram_files.remove(path).is_some() {
             self.invalidate_dir_cache();
-            0
-        } else { -2 }
+            return 0;
+        }
+        // Not a RAM-overlay file: ask the backing filesystem (Tremove). Backends
+        // that can't (or are read-only) return the default -1.
+        let (_midx, fs, subpath) = self.resolve_head(path);
+        let r = fs.remove(subpath);
+        if r >= 0 {
+            // The cached vnode (and any shared backend handle) is now stale.
+            self.path_cache.remove(path);
+            self.invalidate_dir_cache();
+        }
+        r
     }
 
     fn read_by_handle(&mut self, handle: i32, buf: &mut [u8]) -> i32 {
@@ -595,6 +775,26 @@ pub fn eq_ignore_case(a: &[u8], b: &[u8]) -> bool {
     a.len() == b.len() && a.iter().zip(b).all(|(x, y)| x.eq_ignore_ascii_case(y))
 }
 
+/// Does mount `prefix` match `path`? Returns the index in `path` where the
+/// subpath (path-after-prefix) begins, or `None`. The empty prefix (root)
+/// matches everything at 0; a path equal to a prefix sans its trailing `/`
+/// (e.g. `path="boot"` vs `prefix="boot/"`) matches with an empty subpath.
+fn match_prefix(prefix: &[u8], path: &[u8]) -> Option<usize> {
+    let plen = prefix.len();
+    if prefix.is_empty() {
+        Some(0)
+    } else if path.len() >= plen && eq_ignore_case(&path[..plen], prefix) {
+        Some(plen)
+    } else if prefix.last() == Some(&b'/')
+        && path.len() == plen - 1
+        && eq_ignore_case(path, &prefix[..plen - 1])
+    {
+        Some(path.len())
+    } else {
+        None
+    }
+}
+
 fn alloc_fd(fds: &[FdKind; MAX_FDS]) -> Option<usize> {
     (FIRST_FD..MAX_FDS).find(|&fd| fds[fd].is_none())
 }
@@ -606,6 +806,12 @@ fn vfs_handle(fds: &[FdKind; MAX_FDS], fd: i32) -> Result<i32, i32> {
         FdKind::Vfs(idx) => Ok(idx),
         _ => Err(-9),
     }
+}
+
+/// Case-insensitive membership test over already-collected dir entries — the
+/// union-merge shadow rule (a name from a higher layer hides it below).
+fn dir_entries_has(entries: &[DirEntry], name: &[u8]) -> bool {
+    entries.iter().any(|e| eq_ignore_case(&e.name[..e.name_len], name))
 }
 
 fn clone_dir_entry(e: &DirEntry) -> DirEntry {
@@ -642,9 +848,29 @@ fn entry_in_ram_dir<'a>(entry_name: &'a [u8], dir: &[u8]) -> Option<&'a [u8]> {
 // Called by syscalls.rs and vm86.rs.
 // ============================================================================
 
-/// Mount a filesystem at a prefix. Empty prefix = root.
+/// Mount a filesystem at a prefix (single-winner). Empty prefix = root.
+/// Replaces any binding already at that exact prefix.
 pub fn mount(prefix: &'static [u8], fs: &'static dyn Filesystem) {
     VFS.lock().mount(prefix, fs);
+}
+
+/// Union-mount a filesystem at a prefix: stack it on top of whatever is there
+/// (Plan 9 MBEFORE). Lookups try it first; `readdir` merges the layers.
+pub fn mount_union(prefix: &'static [u8], fs: &'static dyn Filesystem) {
+    VFS.lock().mount_union(prefix, fs);
+}
+
+/// Bind: make the subtree at `src_prefix` also appear at `prefix` (a path
+/// redirect, no backing fs of its own). `Replace` = single-winner at `prefix`;
+/// pass a union bind to stack it over an existing mount there.
+pub fn bind(prefix: &'static [u8], src_prefix: &'static [u8]) {
+    VFS.lock().bind(prefix, src_prefix, MountMode::Replace);
+}
+
+/// Union-bind: like [`bind`] but stacked on top (Plan 9 MBEFORE) so both the
+/// bound subtree and whatever was already at `prefix` compose there.
+pub fn bind_union(prefix: &'static [u8], src_prefix: &'static [u8]) {
+    VFS.lock().bind(prefix, src_prefix, MountMode::Union);
 }
 
 /// Open a file by absolute VFS path. Returns fd (>= 3) or negative error.

--- a/kernel/src/kernel/vfs.rs
+++ b/kernel/src/kernel/vfs.rs
@@ -72,11 +72,11 @@ pub trait Filesystem {
         data.len() as i32
     }
 
-    /// Release a fid (Tclunk). Default = no-op, for backends whose handle owns
-    /// no server-side resource (TarFs offsets, ext4 inode refs). Backends that
-    /// allocate per-open server state (hostfs COM1 fids, a future 9P client)
-    /// override this to free it. NOTE: the VFS does not yet call this on file
-    /// close — see `close_handle` for why (shared handles via `path_cache`).
+    /// Release a fid (Tclunk). Called by the VFS when the last reference to an
+    /// open file closes (`close_handle`). Default = no-op, for backends whose
+    /// handle owns no per-open resource (TarFs's archive offset). Backends that
+    /// allocate per-open server state — ext4's `File` cursor, hostfs's COM1 /
+    /// native fid, a future 9P client — override this to free it.
     fn clunk(&self, _handle: u64) {}
 
     /// Remove a file by path (Tremove). Default = -1 (read-only / unsupported).
@@ -162,8 +162,8 @@ enum BindTarget {
 /// Prefixes and alias targets are `&'static` — boot-time mounts leak their
 /// (one-time, boot-lifetime) prefix, the same discipline the old fixed table
 /// used. The table is built entirely at startup before any file is opened, so
-/// the `mount_idx` values cached in `path_cache`/`file_table` (Vec indices)
-/// stay stable — do not mutate the table after boot without revisiting that.
+/// the `mount_idx` values stored in `file_table` (Vec indices) stay stable —
+/// do not mutate the table after boot without revisiting that.
 #[derive(Clone, Copy)]
 struct Binding {
     prefix: &'static [u8],  // e.g. b"" for root, b"boot/" for sub-mount
@@ -217,9 +217,6 @@ struct Vfs {
     next_seq: u32,
     /// Writable file overlay — persists across open/close cycles.
     ram_files: BTreeMap<Vec<u8>, Vec<u8>>,
-    /// Path-keyed vnode cache in front of `fs.open()` (skips the FS walk on
-    /// repeated opens — matters most for ext4). RAM overlay shadows it.
-    path_cache: BTreeMap<Vec<u8>, (u8, Vnode)>,
     /// Global file table — slot is free when refcount == 0.
     file_table: [FileEntry; MAX_OPEN_FILES],
     dir_cache: DirCache,
@@ -240,7 +237,6 @@ impl Vfs {
             mounts: Vec::new(),
             next_seq: 0,
             ram_files: BTreeMap::new(),
-            path_cache: BTreeMap::new(),
             file_table: [EMPTY; MAX_OPEN_FILES],
             dir_cache: DirCache::new(),
         }
@@ -406,20 +402,25 @@ impl Vfs {
         (0..MAX_OPEN_FILES).find(|&i| self.file_table[i].refcount == 0)
     }
 
-    /// Drop one reference to a file-table entry. Frees the slot at refcount 0.
+    /// Drop one reference to a file-table entry; at refcount 0 release the slot
+    /// and `clunk` the backing fid (Tclunk).
     ///
-    /// This intentionally does NOT `clunk` the backing fid at refcount 0. The
-    /// `path_cache` caches each path's `Vnode` (fid included) indefinitely and
-    /// hands the *same* fid to every open of that path, so a live fid can be
-    /// referenced by the cache and by other file-table entries after this one
-    /// closes — clunking here would corrupt their reads and the next re-open.
-    /// Fid lifecycle therefore belongs with `path_cache` eviction, not here;
-    /// until then hostfs leaks one server handle per distinct path opened.
+    /// This is correct because every `open()` gets its *own* fid — there is no
+    /// shared-fid cache — so refcount 0 means the last reference to *this* fid
+    /// is gone. `dup`/`fork` share one file-table entry (refcount > 1), so the
+    /// fid is clunked exactly once, when the last of them closes; two
+    /// independent opens of the same path hold distinct fids and clunk
+    /// independently. RAM-overlay entries own no backing fid (skip).
     fn close_handle(&mut self, idx: i32) {
-        if idx >= 0 && (idx as usize) < MAX_OPEN_FILES {
-            let entry = &mut self.file_table[idx as usize];
-            if entry.refcount > 0 {
-                entry.refcount -= 1;
+        if idx < 0 || (idx as usize) >= MAX_OPEN_FILES { return; }
+        let i = idx as usize;
+        if self.file_table[i].refcount == 0 { return; }
+        self.file_table[i].refcount -= 1;
+        if self.file_table[i].refcount == 0 {
+            let handle = self.file_table[i].vnode.handle;
+            if handle != RAM_SENTINEL {
+                let midx = self.file_table[i].mount_idx;
+                self.mount_fs(midx).clunk(handle);
             }
         }
     }
@@ -539,31 +540,17 @@ impl Vfs {
             return table_idx as i32;
         }
 
-        // Path cache: skip fs.open if we've already resolved this path. The
-        // cached vnode's FS-internal handle is shared across file-table entries;
-        // each entry still has its own offset.
-        if let Some(&(midx, vnode)) = self.path_cache.get(path) {
-            let table_idx = match self.alloc_file_entry() {
-                Some(i) => i,
-                None => return -24,
-            };
-            self.file_table[table_idx] = FileEntry {
-                vnode, ino: path_ino(path), offset: 0, refcount: 1, mount_idx: midx,
-                ram_key: [0; PATH_KEY_MAX], ram_key_len: 0,
-            };
-            return table_idx as i32;
-        }
-
         // Try each member of the group in priority order; first hit wins and
         // its mount_idx is recorded (a Replace group = the single backing fs).
+        // Every open gets its OWN fid from `fs.open` — fids are never cached or
+        // shared, so `close_handle` can `clunk` this fid at refcount 0 without
+        // affecting any other open (see `close_handle`).
         let (midx, vnode) = match self.resolve_members(path, ALIAS_DEPTH, &mut |idx, fs, subpath| {
             fs.open(subpath).map(|v| (idx, v))
         }) {
             Some(x) => x,
             None => return -2,
         };
-
-        self.path_cache.insert(path.to_vec(), (midx, vnode));
 
         let table_idx = match self.alloc_file_entry() {
             Some(i) => i,
@@ -633,8 +620,6 @@ impl Vfs {
         let (_midx, fs, subpath) = self.resolve_head(path);
         let r = fs.remove(subpath);
         if r >= 0 {
-            // The cached vnode (and any shared backend handle) is now stale.
-            self.path_cache.remove(path);
             self.invalidate_dir_cache();
         }
         r

--- a/kernel/src/kernel/vfs.rs
+++ b/kernel/src/kernel/vfs.rs
@@ -168,7 +168,9 @@ enum BindTarget {
 struct Binding {
     prefix: &'static [u8],  // e.g. b"" for root, b"boot/" for sub-mount
     target: BindTarget,
-    mode: MountMode,
+    // NB: the mount MODE (Replace vs Union) is applied when the binding is
+    // added (Replace drops peers at the prefix; see `add_binding`) — it does
+    // not need to persist per-binding, so it is not stored here.
     seq: u32,
 }
 
@@ -283,7 +285,7 @@ impl Vfs {
                 }
             }
         }
-        members[..n].sort_by(|a, b| b.1.cmp(&a.1)); // seq desc = most-recent first
+        members[..n].sort_by_key(|&(_, seq)| core::cmp::Reverse(seq)); // most-recent (highest seq) first
 
         for &(i, _) in &members[..n] {
             let b = self.mounts[i];
@@ -381,7 +383,7 @@ impl Vfs {
         }
         let seq = self.next_seq;
         self.next_seq = self.next_seq.wrapping_add(1);
-        self.mounts.push(Binding { prefix, target, mode, seq });
+        self.mounts.push(Binding { prefix, target, seq });
     }
 
     fn mount(&mut self, prefix: &'static [u8], fs: &'static dyn Filesystem) {

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -61,6 +61,7 @@ pub use arch_abi::{
 pub use kernel::startup::startup;
 pub use kernel::platform::{set_host_env, DebugSink, HostEnv};
 pub use kernel::portio::{install_portio, PortIo};
+pub use kernel::hostfs::{install_host_backend, host_backend_installed, HostBackendHooks};
 
 /// Hosted: point the VGA console framebuffer at a scratch buffer so its writes
 /// (clear/scroll/putchar) don't dereference the unmapped `0xB8000` host

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -113,7 +113,20 @@ fn main() {
         lib::vga_render::set_present_sink(arch::publish_frame);
     }
     if let Some(dir) = &host_dir {
-        arch::attach_hostfs(dir); // COM1 → /host (or the root, per Media)
+        // Native host-fs backend (the hosted "punch-through"): /host (or the
+        // root, per Media) is served by direct std::fs calls, not byte-serial
+        // COM1. Same injection shape as install_hosted_backend above.
+        arch::install_native_hostfs(dir);
+        kernel::install_host_backend(kernel::HostBackendHooks {
+            open: arch::host_open,
+            read: arch::host_read,
+            readdir: arch::host_readdir,
+            dir_exists: arch::host_dir_exists,
+            create: arch::host_create,
+            write: arch::host_write,
+            clunk: arch::host_clunk,
+            remove: arch::host_remove,
+        });
     }
     if let Some(path) = wav {
         arch::attach_audio(&path); // canonical audio device → WAV file

--- a/play/src/main.rs
+++ b/play/src/main.rs
@@ -92,7 +92,22 @@ fn main() {
         // mailbox the window thread blits from.
         lib::vga_render::set_present_sink(arch::publish_frame);
         if let Some(dir) = &host_dir {
-            arch::attach_hostfs(dir); // COM1 → /host
+            // Native host-fs backend (the hosted "punch-through"): /host is
+            // served by direct std::fs calls, not byte-serial COM1. Install the
+            // std::fs server root on this (CPU) thread and wire its primitive
+            // hooks into the one kernel library — same injection shape as
+            // install_portio above.
+            arch::install_native_hostfs(dir);
+            kernel::install_host_backend(kernel::HostBackendHooks {
+                open: arch::host_open,
+                read: arch::host_read,
+                readdir: arch::host_readdir,
+                dir_exists: arch::host_dir_exists,
+                create: arch::host_create,
+                write: arch::host_write,
+                clunk: arch::host_clunk,
+                remove: arch::host_remove,
+            });
         }
         if let Some(path) = &wav {
             arch::attach_audio(path); // canonical audio → WAV (offline check)


### PR DESCRIPTION
Reworks the VFS from a flat, single-winner mount table into a Plan 9-style
namespace composer, shapes the `Filesystem` trait toward 9P, adds an injectable
native `std::fs` host backend (retiring byte-serial COM1 for `/host` on hosted),
and fixes backend-handle (fid) lifecycle so open handles are actually released.

The kernel stays **one backend-agnostic `no_std` library** throughout — the host
backend is injected via a fn-pointer hook (same shape as `install_portio`), not a
new crate or an `arch-interp → kernel` dependency.

## Commits

**1. `refactor(vfs)` — 9P-shape the trait + namespace composer**
- Added defaulted `clunk` (Tclunk) / `remove` (Tremove) to `Filesystem`;
  annotated `Vnode`/`DirEntry` as the 9P fid/qid+stat they already are.
- Replaced `[Option<Mount>; 6]` with a `Vec<Binding>` composer:
  `MountMode {Replace, Union}`, `BindTarget {Server, Alias}`, monotonic seq.
  `resolve_members` is the one primitive — visits a prefix group most-recent-first,
  short-circuits for `open`/`dir_exists`, visits-all for the `readdir` union merge,
  and expands `Alias` (bind) by depth-capped recursive rewrite (no heap alloc on
  resolve). `Replace` reproduces the old longest-prefix behavior bit-for-bit;
  every startup mount stays `Replace`.
- `delete()` routes through `fs.remove`; readdir union-merges with dedup and layers
  the RAM overlay on top. New public `mount_union` / `bind` / `bind_union`.

**2. `feat(hostfs)` — injectable native `std::fs` backend (retire COM1 on hosted)**
- `HostBackendHooks` (primitive-only fn-pointers → no `Vnode`/`DirEntry` crosses
  the arch-interp↔kernel boundary), `install_host_backend` / `host_backend_installed`,
  and `InjectedHostFs` — the `Filesystem` mounted at `/host` (or root under
  `HostRoot`) that dispatches straight to the hooks.
- `arch-interp` exposes native `n_*` methods over its existing `std::fs` `HostFs`,
  a thread-local instance, and the `host_*` free fns + `install_native_hostfs`.
- Both hosted entries install it on `--host DIR`; metal is untouched (keeps COM1).

**3. `fix(vfs)` — per-open fids + clunk on last close**
- The old shared-fid `path_cache` leaked a hostfs server fid per distinct path
  **and an open ext4 `File` cursor (host fd) per distinct path**, unbounded.
- Dropped `path_cache`; every `open()` gets its own fid; `close_handle` clunks it
  at refcount 0 (`dup`/`fork` share one entry → clunk once at last close; process
  exit closes all fds). `Ext4Fs::clunk` drops the cursor; TarFs handle is a
  stateless offset (no-op).

## Verification
- Metal `//:image` + hosted (`retroos-play`, `retroos-host`) build clean.
- Games suite PASS (DN from `C:\BOOT`, DIGGER real-mode, DOOM DPMI — all load from ext4).
- Metal QEMU boots to `DiskRoot` (ext4 root + COM1 `/host` + bootfs), DN launches.
- Composer, native backend, and fid model each proven end-to-end on real
  filesystems via throwaway metal/hosted probes (reverted): union merge +
  bind/Alias listings; native `/host` readdir/open/read with no COM1; and
  re-open + concurrent-open fid isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)