### PR TITLE
chore(clippy): clear pre-existing -D warnings debt

### DIFF
--- a/arch-abi/src/monitor.rs
+++ b/arch-abi/src/monitor.rs
@@ -152,7 +152,7 @@ fn push16<P: GuestBytes>(regs: &mut Regs, space: &mut P, ss_base: u32, ss_32: bo
 #[inline]
 fn pop16<P: GuestBytes>(regs: &mut Regs, space: &mut P, ss_base: u32, ss_32: bool) -> u16 {
     let cur = get_sp(regs, ss_32);
-    let val = space.read::<u16>((ss_base.wrapping_add(cur) as usize));
+    let val = space.read::<u16>(ss_base.wrapping_add(cur) as usize);
     set_sp(regs, ss_32, cur.wrapping_add(2));
     val
 }
@@ -167,7 +167,7 @@ fn push32<P: GuestBytes>(regs: &mut Regs, space: &mut P, ss_base: u32, ss_32: bo
 #[inline]
 fn pop32<P: GuestBytes>(regs: &mut Regs, space: &mut P, ss_base: u32, ss_32: bool) -> u32 {
     let cur = get_sp(regs, ss_32);
-    let val = space.read::<u32>((ss_base.wrapping_add(cur) as usize));
+    let val = space.read::<u32>(ss_base.wrapping_add(cur) as usize);
     set_sp(regs, ss_32, cur.wrapping_add(4));
     val
 }
@@ -496,14 +496,14 @@ pub fn step_virtual_if<A: Arch>(arch: &mut A, regs: &mut Regs) -> MonitorResult 
         let (cs_base, _) = code_view::<A>(regs);
         let mut p = regs.ip32();
         loop {
-            let b = arch.read::<u8>((cs_base.wrapping_add(p) as usize));
+            let b = arch.read::<u8>(cs_base.wrapping_add(p) as usize);
             if b == 0x66 || b == 0x67 || b == 0xF0 || b == 0xF2 || b == 0xF3 {
                 p = p.wrapping_add(1);
             } else {
                 break;
             }
         }
-        let op = arch.read::<u8>((cs_base.wrapping_add(p) as usize));
+        let op = arch.read::<u8>(cs_base.wrapping_add(p) as usize);
         // 0x9C PUSHF, 0x9D POPF, 0xCF IRET, 0xFA CLI, 0xFB STI.
         let must_emulate = matches!(op, 0x9C | 0x9D | 0xCF | 0xFA | 0xFB);
         if !must_emulate {

--- a/arch-interp/src/backend.rs
+++ b/arch-interp/src/backend.rs
@@ -33,6 +33,10 @@ impl Arch for Interp {
     // The interp still keeps an internal live frame (`vcpu::REGS`) that its CPU
     // core syncs against; bridge the loop-owned `Vcpu` to it around each call.
     // (The internal frame goes away when the globals migrate into `Interp`.)
+    // `&mut *(&raw mut REGS)` is the `&raw`-first form that avoids a
+    // `static_mut_refs` reference; clippy's `deref_addrof` rewrite would
+    // reintroduce it.
+    #[allow(clippy::deref_addrof)]
     fn execute(&mut self, regs: &mut Regs) -> KernelEvent {
         // Bridge the loop-owned registers to the backend's live frame for the
         // run (the active SPACE already lives in `REGS.space`), then read them
@@ -43,6 +47,10 @@ impl Arch for Interp {
         core::mem::swap(&mut live.regs, regs);
         ev
     }
+    // deref_addrof: same `&raw`-first REGS idiom as `execute`.
+    // not_unsafe_ptr_arg_deref: the `*mut Fx`/`*mut u64` args are the trait's
+    // fixed signature; the deref is guarded by the `is_null` check above.
+    #[allow(clippy::deref_addrof, clippy::not_unsafe_ptr_arg_deref)]
     fn activate(&mut self, incoming: RootPageTable, fx_ptr: *mut Self::Fx, _hash_ptr: *mut u64) -> RootPageTable {
         // Swap the live FPU with the thread's save area (null ⇒ transient
         // kernel-only swap, skip). KVM: state is the vcpu's XSAVE; TCG: no-op.

--- a/arch-interp/src/calls.rs
+++ b/arch-interp/src/calls.rs
@@ -9,7 +9,6 @@
 #![allow(unused_variables)]
 
 use crate::space::RootPageTable;
-use crate::vcpu::Vcpu;
 use arch_abi::KernelEvent;
 
 /// Arch call numbers — kept identical to the metal backend (`traps::arch_call`)

--- a/arch-interp/src/cpu.rs
+++ b/arch-interp/src/cpu.rs
@@ -333,6 +333,9 @@ fn io_with<R>(f: impl FnOnce(&mut Unicorn<'static, Ctx>) -> R) -> R {
 /// that the redirection bitmap does NOT intercept is reflected to the guest's
 /// real-mode IVT here and execution continues — only trapped vectors (and the
 /// DPL=3 gates 3/4) bubble to the kernel.
+// `&mut *(&raw mut REGS)` is the `&raw`-first form that avoids a
+// `static_mut_refs` reference; clippy's `deref_addrof` rewrite would reintroduce it.
+#[allow(clippy::deref_addrof)]
 pub fn execute() -> KernelEvent {
     io_with(|uc| loop {
         // Service an off-thread VGA-screen snapshot request, and paint the live

--- a/arch-metal/src/backend.rs
+++ b/arch-metal/src/backend.rs
@@ -40,6 +40,10 @@ impl Arch for Metal {
     // Bridge the loop-owned `Vcpu` to it around each call; the bridge copy is the
     // register file only (~200 B) — the address space / CR3 is touched only at
     // switch. (The internal frame goes away when the globals migrate into `Metal`.)
+    // `&mut *(&raw mut REGS)` is the deliberate `&raw`-first form that avoids a
+    // `static_mut_refs` reference; clippy's `deref_addrof` "simplification"
+    // would reintroduce exactly that, so allow it here.
+    #[allow(clippy::deref_addrof)]
     fn execute(&mut self, regs: &mut Regs) -> KernelEvent {
         // Bridge the loop-owned registers to the live trap frame for the run
         // (the active SPACE already lives in `REGS.space`), then read them back.
@@ -49,6 +53,7 @@ impl Arch for Metal {
         core::mem::swap(&mut live.regs, regs);
         ev
     }
+    #[allow(clippy::deref_addrof)] // `&raw const REGS`-first form; see `execute`
     fn activate(&mut self, incoming: RootPageTable, fx_ptr: *mut Self::Fx, hash_ptr: *mut u64) -> RootPageTable {
         // `activate` moves only the SPACE (registers are managed by `execute`).
         // The metal SWITCH_TO handler swaps both regs and space with the live

--- a/arch-metal/src/lib.rs
+++ b/arch-metal/src/lib.rs
@@ -109,7 +109,6 @@ pub use descriptors::{USER_CS, USER_CS64, USER_DS};
 // arch API; the HW backend implements them as INT 0x80 stubs in `calls.rs`).
 pub use traps::arch_call;
 pub use calls::*;
-pub(crate) use traps::REGS;
 
 // Power/halt entry points. The kernel layer must not toggle IF directly —
 // `cli`/`sti` stay arch-private; use `halt_forever` (panic) and

--- a/arch-metal/src/monitor.rs
+++ b/arch-metal/src/monitor.rs
@@ -11,8 +11,6 @@
 //! re-exported `KernelEvent`/`IoSize`) is unchanged — callers in `traps.rs` /
 //! `backend.rs` keep resolving `crate::monitor::*` as before.
 
-use crate::Vcpu;
-use crate::paging2::RootPageTable;
 use arch_abi::Regs;
 
 // Backend-agnostic arch↔kernel contract types, re-exported so

--- a/arch-metal/src/vcpu.rs
+++ b/arch-metal/src/vcpu.rs
@@ -12,7 +12,6 @@
 //! kernel-facing shape of this type does not change.
 
 use arch_abi::GuestBytes;
-use super::paging2::RootPageTable;
 
 /// Register state + address-space handle for one execution context. The shape is
 /// shared across backends, so it is `arch_abi::Vcpu<P>` over this backend's

--- a/kernel/src/kernel/dos/bios.rs
+++ b/kernel/src/kernel/dos/bios.rs
@@ -163,7 +163,7 @@ macro_rules! bda_field {
 /// identical values — the layering matches a real machine (BIOS first, DOS
 /// on top). Native-vs-substitute is decided by the boot-time probe
 /// (`platform::Firmware`), not sniffed here.
-pub(super) fn install<A: crate::Arch>(machine: &mut A, regs: &mut Regs) {
+pub(super) fn install<A: crate::Arch>(machine: &mut A, _regs: &mut Regs) {
     crate::dbg_println!("DOS: no BIOS ROM — installing the personality BIOS (display {:?})",
         crate::kernel::platform::get().display);
     // Vectors with a real service keep their own stub (slot index == vector);

--- a/kernel/src/kernel/dos/dos.rs
+++ b/kernel/src/kernel/dos/dos.rs
@@ -116,7 +116,7 @@ fn cmos_date<A: crate::Arch>(machine: &mut A) -> (u16, u8, u8, u8) {
     (year, month, day, day_of_week(year, month, day))
 }
 
-fn current_dos_timestamp<A: crate::Arch>(machine: &mut A, regs: &Regs) -> (u16, u16) {
+fn current_dos_timestamp<A: crate::Arch>(machine: &mut A, _regs: &Regs) -> (u16, u16) {
     let (hour, min, sec, _) = bios_time_of_day(machine);
     let (year, month, day, _) = cmos_date(machine);
     let dos_time = ((hour as u16) << 11) | ((min as u16) << 5) | ((sec as u16) / 2);
@@ -3594,7 +3594,7 @@ pub(super) fn setup_ivt<A: crate::Arch>(machine: &mut A, regs: &mut Regs) {
     write_u16(machine, 0x40, 0x17, kbd_flags);
 }
 
-fn setup_lol_sft<A: crate::Arch>(machine: &mut A, regs: &mut Regs) {
+fn setup_lol_sft<A: crate::Arch>(machine: &mut A, _regs: &mut Regs) {
     let sft_addr = LOW_MEM_BASE + core::mem::offset_of!(LowMem, sft) as u32;
     let cds_addr = LOW_MEM_BASE + core::mem::offset_of!(LowMem, cds) as u32;
     let boot_seg = ((LOW_MEM_BASE + core::mem::offset_of!(LowMem, boot_psp) as u32) >> 4) as u16;
@@ -3718,7 +3718,7 @@ fn fill_env(env: &mut [u8], parent_env: &[u8], prog_name: &[u8]) {
 
 /// Initialize a freshly-allocated PSP at `psp_seg` to point at its env
 /// block at `env_seg`, with parent_psp / JFT / cmdline default fields set.
-fn init_psp<A: crate::Arch>(machine: &mut A, regs: &mut Regs, psp_seg: u16, env_seg: u16, parent_psp: u16) {
+fn init_psp<A: crate::Arch>(machine: &mut A, _regs: &mut Regs, psp_seg: u16, env_seg: u16, parent_psp: u16) {
     let mut jft = [0xFFu8; 20];
     jft[0] = 0; jft[1] = 1; jft[2] = 2;   // stdin/stdout/stderr → SFT 0/1/2
     let mut cmdline = [0u8; 127];

--- a/kernel/src/kernel/dos/machine/mod.rs
+++ b/kernel/src/kernel/dos/machine/mod.rs
@@ -316,7 +316,7 @@ impl MouseState {
     /// already drawn at this cell. Real Microsoft Mouse drivers also do this
     /// in graphics modes via a sprite — we don't (yet); games that go to
     /// mode 13h hide the driver cursor and draw their own anyway.
-    pub fn render_if_visible<A: crate::Arch>(&mut self, machine: &mut A, regs: &mut Regs) {
+    pub fn render_if_visible<A: crate::Arch>(&mut self, machine: &mut A, _regs: &mut Regs) {
         if self.show_count > 0 { return; }
         let col = (self.x >> 3) as u32;
         let row = (self.y >> 3) as u32;
@@ -344,7 +344,7 @@ impl MouseState {
     }
 
     /// AX=02h — hide cursor: increment counter; if it was 0, erase.
-    pub fn hide<A: crate::Arch>(&mut self, machine: &mut A, regs: &mut Regs) {
+    pub fn hide<A: crate::Arch>(&mut self, machine: &mut A, _regs: &mut Regs) {
         if self.show_count <= 0 { self.erase_cursor(machine); }
         self.show_count += 1;
     }

--- a/kernel/src/kernel/dos/machine/vga.rs
+++ b/kernel/src/kernel/dos/machine/vga.rs
@@ -1036,6 +1036,7 @@ fn modrm_len(modrm: u8, addr32: bool, peek: impl Fn(u32) -> u8, after: u32) -> u
 /// `def32` (default operand & address size) are resolved by the caller, which
 /// has the LDT. Returns false (→ real SEGV) for an instruction we don't model,
 /// so a gap is loud rather than silent corruption.
+#[allow(clippy::too_many_arguments)] // planar #PF decode needs the full seg/mode context
 pub fn handle_planar_fault<A: crate::Arch>(machine: &mut A, regs: &mut Regs, vga: &mut VgaState, cs_base: u32, def32: bool, ds_base: u32, es_base: u32, off: u32) -> bool {
     let vm86 = regs.mode() == crate::UserMode::VM86;
     let ip0 = if def32 { regs.ip32() } else { regs.ip32() & 0xFFFF };
@@ -1460,7 +1461,7 @@ impl VgaState {
     /// line-compare that select the visible window. Planar modes render our own
     /// `planes` in place (no copy); linear modes copy their guest aperture into
     /// `scratch`. `None` for a mode the renderer doesn't draw.
-    fn scanout<'a, A: crate::Arch>(&'a self, machine: &mut A, regs: &Regs, scratch: &'a mut alloc::vec::Vec<u8>)
+    fn scanout<'a, A: crate::Arch>(&'a self, machine: &mut A, _regs: &Regs, scratch: &'a mut alloc::vec::Vec<u8>)
         -> Option<lib::vga_render::Frame<'a>>
     {
         use lib::vga_render::{Frame, VgaMode};

--- a/kernel/src/kernel/dos/machine/vkbd.rs
+++ b/kernel/src/kernel/dos/machine/vkbd.rs
@@ -255,7 +255,7 @@ pub(super) fn normalize_scancode(pc: &mut PcMachine, scancode: u8) -> Option<u8>
 }
 
 /// Clear the BIOS keyboard buffer at 40:1A..40:3E.
-pub fn clear_bios_keyboard_buffer<A: crate::Arch>(machine: &mut A, regs: &mut Regs) {
+pub fn clear_bios_keyboard_buffer<A: crate::Arch>(machine: &mut A, _regs: &mut Regs) {
     write_u16(machine, 0x40, 0x1A, 0x001E);
     write_u16(machine, 0x40, 0x1C, 0x001E);
     for off in (0x1E..0x3E).step_by(2) {
@@ -264,7 +264,7 @@ pub fn clear_bios_keyboard_buffer<A: crate::Arch>(machine: &mut A, regs: &mut Re
 }
 
 /// Pop the next word from the BIOS keyboard buffer.
-pub fn pop_bios_keyboard_word<A: crate::Arch>(machine: &mut A, regs: &mut Regs) -> Option<u16> {
+pub fn pop_bios_keyboard_word<A: crate::Arch>(machine: &mut A, _regs: &mut Regs) -> Option<u16> {
     let head = read_u16(machine, 0x40, 0x1A);
     let tail = read_u16(machine, 0x40, 0x1C);
     if head == tail {

--- a/kernel/src/kernel/dos/machine/vsb.rs
+++ b/kernel/src/kernel/dos/machine/vsb.rs
@@ -200,7 +200,7 @@ impl SoundBlaster {
     /// state and OMF2's sound-init probe falls into a "wait for the card
     /// to settle" timeout branch (526 `INT 21 AH=2C` calls in the hang
     /// trace). Idempotent.
-    pub fn release_dma_pool<A: crate::Arch>(&mut self, machine: &mut A, regs: &mut Regs) {
+    pub fn release_dma_pool<A: crate::Arch>(&mut self, machine: &mut A, _regs: &mut Regs) {
         if self.emulated() {
             // No real card / no buffer alias in emulation: just stop the
             // software DSP so the next program sees a clean, idle card.
@@ -396,7 +396,7 @@ impl SoundBlaster {
     /// `maybe_remap` (a guest port write) and `sb_resume` (replaying the
     /// virtual-8237 state after a task switch).
     #[allow(clippy::too_many_arguments)]
-    fn arm<A: crate::Arch>(&mut self, machine: &mut A, regs: &mut Regs, chan: usize, host: usize, is16: bool,
+    fn arm<A: crate::Arch>(&mut self, machine: &mut A, _regs: &mut Regs, chan: usize, host: usize, is16: bool,
            gpa: u32, len: u32, mode: u8) {
         let bufpage = machine.dma_channel_buf(host);
         if bufpage == 0 { return; }              // no reserved buffer
@@ -487,7 +487,7 @@ impl SoundBlaster {
     /// the real 8237 channel so the card stops pulling a buffer that's no
     /// longer ours. The virtual 8237 keeps the armed state; `sb_resume`
     /// replays it. Must run with this task's address space active.
-    pub fn sb_suspend<A: crate::Arch>(&mut self, machine: &mut A, regs: &mut Regs) {
+    pub fn sb_suspend<A: crate::Arch>(&mut self, machine: &mut A, _regs: &mut Regs) {
         if self.emulated() { return; } // no real chip / alias to detach
         if self.bound_gpa == 0 { return; }
         mask_real_8237(machine, self.bound_host);
@@ -733,7 +733,7 @@ impl SoundBlaster {
     pub fn audio_tick<A: crate::Arch>(
         &mut self,
         machine: &mut A,
-        regs: &mut Regs,
+        _regs: &mut Regs,
         vpic: &mut super::vpic::VirtualPic,
     ) {
         if !self.emulated() {

--- a/kernel/src/kernel/dos/mod.rs
+++ b/kernel/src/kernel/dos/mod.rs
@@ -887,7 +887,7 @@ pub fn run_init_program<A: crate::Arch>(machine: &mut A, threads: &mut [thread::
 
     let (col, row) = vga::vga().cursor_pos();
     {
-        let regs = &mut t.kernel.vcpu;
+        let _regs = &mut t.kernel.vcpu;
         dos::Psp::set_cmdline(machine, loaded.psp_seg, &cmdline_tail);
         machine.write::<u8>(0x450, col as u8);
         machine.write::<u8>(0x451, row as u8);
@@ -935,7 +935,7 @@ fn snapshot_env<A: crate::Arch>(machine: &mut A, env_seg: u16) -> alloc::vec::Ve
 /// `dos.current_psp` is always a segment; PSP[0x2C] may have been
 /// converted to a selector at DPMI entry, so use `saved_rm_env` when the
 /// active PSP matches the one whose env we patched.
-pub fn snapshot_parent_env<A: crate::Arch>(machine: &mut A, regs: &mut Regs, dos: &thread::DosState<A>) -> alloc::vec::Vec<u8> {
+pub fn snapshot_parent_env<A: crate::Arch>(machine: &mut A, _regs: &mut Regs, dos: &thread::DosState<A>) -> alloc::vec::Vec<u8> {
     let psp_seg = dos.current_psp;
     let env_seg = match dos.dpmi.as_ref() {
         Some(dpmi) if dpmi.env_ldt_idx != 0 && dpmi.saved_rm_psp == psp_seg => {
@@ -1110,7 +1110,7 @@ pub fn raise_pending<A: crate::Arch>(machine: &mut A, dos: &mut thread::DosState
 /// Mirror `dos.dos_blocks` out as a real DOS Memory Control Block chain
 /// in VM86 memory. Free MCBs are synthesized in the gaps so the chain
 /// walks contiguously from `heap_base_seg` up to 0xA000.
-fn sync_mcb_chain<A: crate::Arch>(machine: &mut A, dos: &DosState<A>, regs: &mut Regs) {
+fn sync_mcb_chain<A: crate::Arch>(machine: &mut A, dos: &DosState<A>, _regs: &mut Regs) {
     let mut blocks = dos.dos_blocks.clone();
     blocks.sort_by_key(|b| b.seg);
 

--- a/kernel/src/kernel/elf.rs
+++ b/kernel/src/kernel/elf.rs
@@ -5,7 +5,6 @@
 
 const PAGE_SIZE: usize = 4096;
 extern crate alloc;
-use crate::Regs;
 use alloc::vec::Vec;
 pub use lib::elf::{ElfError, ElfClass};
 

--- a/kernel/src/kernel/hostfs.rs
+++ b/kernel/src/kernel/hostfs.rs
@@ -122,6 +122,12 @@ impl HostFs {
     }
 }
 
+impl Default for HostFs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Filesystem for HostFs {
     fn open(&self, path: &[u8]) -> Option<Vnode> {
         if !is_ready() { return None; }

--- a/kernel/src/kernel/linux/mod.rs
+++ b/kernel/src/kernel/linux/mod.rs
@@ -565,7 +565,7 @@ fn read_c_argv<A: crate::Arch>(machine: &mut A, ptr: usize, wide: bool) -> alloc
 ///   [16 random bytes] [string pool]
 ///
 /// For 64-bit: same layout with 8-byte slots.
-pub(crate) fn setup_user_stack<A: crate::Arch>(machine: &mut A, vcpu: &mut Regs, args: &[alloc::vec::Vec<u8>], want_64: bool, extra_auxv: &[(usize, usize)]) -> usize {
+pub(crate) fn setup_user_stack<A: crate::Arch>(machine: &mut A, _vcpu: &mut Regs, args: &[alloc::vec::Vec<u8>], want_64: bool, extra_auxv: &[(usize, usize)]) -> usize {
     // Write one machine word (4 or 8 bytes, per client bitness) to the stack.
     fn write_word<A: crate::Arch>(machine: &mut A, addr: usize, val: usize, want_64: bool) {
         if want_64 { machine.write::<u64>(addr, val as u64); }
@@ -945,7 +945,7 @@ fn sys_close<A: crate::Arch>(kt: &mut thread::KernelThread<A>, a: &Args) -> Sysc
 }
 
 /// execve(11)
-fn sys_execve<A: crate::Arch>(machine: &mut A, kt: &mut thread::KernelThread<A>, linux: &mut LinuxState, a: &Args, regs: &mut Regs) -> SyscallResult {
+fn sys_execve<A: crate::Arch>(machine: &mut A, _kt: &mut thread::KernelThread<A>, linux: &mut LinuxState, a: &Args, regs: &mut Regs) -> SyscallResult {
     use crate::kernel::exec;
 
     let path_ptr = a.a0 as usize;
@@ -1566,7 +1566,7 @@ fn sys_mmap2<A: crate::Arch>(machine: &mut A, kt: &mut thread::KernelThread<A>, 
 }
 
 /// stat64(195) / lstat64(196)
-fn sys_stat64<A: crate::Arch>(machine: &mut A, vcpu: &mut Regs, linux: &LinuxState, a: &Args, want_64: bool) -> SyscallResult {
+fn sys_stat64<A: crate::Arch>(machine: &mut A, _vcpu: &mut Regs, linux: &LinuxState, a: &Args, want_64: bool) -> SyscallResult {
     let path_ptr = a.a0 as usize;
     let stat_buf = a.a1 as usize;
     let mut path_buf = [0u8; 256];
@@ -1668,7 +1668,7 @@ fn write_stat_old<A: crate::Arch>(machine: &mut A, buf: usize, mode: u32, size: 
 
 /// stat(106) / lstat(107) — old struct stat layout. We have no symlinks so
 /// lstat falls through to stat.
-fn sys_stat_old<A: crate::Arch>(machine: &mut A, vcpu: &mut Regs, linux: &LinuxState, a: &Args) -> SyscallResult {
+fn sys_stat_old<A: crate::Arch>(machine: &mut A, _vcpu: &mut Regs, linux: &LinuxState, a: &Args) -> SyscallResult {
     let mut path_buf = [0u8; 256];
     let path_len = machine.copy_cstr(a.a0 as usize, &mut path_buf);
     let path = &path_buf[..path_len];

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -5,10 +5,10 @@
 //! carries `Vcpu<A>` / `A::Fx`. No backend crate is linked here —
 //! composition happens in the ENTRY crates, which pick the backend and call
 //! `startup`:
-//!   * `entry-metal`  — arch-metal (real x86); linked with `entry.asm` into
-//!     kernel.elf.
-//!   * `entry-hosted` — arch-interp (tcg or kvm engine); consumed by the
-//!     retroos-host and retroos-play binaries.
+//!
+//!   * `entry-metal` — arch-metal (real x86), linked with `entry.asm` into kernel.elf.
+//!   * `entry-hosted` — arch-interp (tcg or kvm engine), consumed by the retroos-host and retroos-play binaries.
+//!
 //! Host-side glue (platform probe, log sinks, symbolizers) is injected by the
 //! entries through plain function hooks — no `cfg` anywhere in this crate.
 


### PR DESCRIPTION
CI's `bazel build --config=clippy` (deny-warnings) has been failing on master
for many pushes on lint debt unrelated to any single change — so clippy can't
gate PRs. This clears it.

- **arch-abi**: drop double parens in `space.read`/`arch.read` calls.
- **arch-metal / arch-interp**: remove dead imports; `#[allow(clippy::deref_addrof)]`
  on the deliberate `&raw mut/const REGS` idiom (clippy's rewrite would
  reintroduce a `static_mut_refs` reference); `#[allow(not_unsafe_ptr_arg_deref)]`
  on the trait-fixed `activate` signature.
- **kernel**: prefix ~20 unused `regs`/`vcpu`/`kt` params with `_`; drop a dead
  import; `impl Default for HostFs`; `#[allow(too_many_arguments)]` on the
  planar-fault decoder; fix a lib.rs doc-list lazy-continuation.

No behavior change. Verified locally: clippy clean on **both** CI configs
(metal + host), `//:image` + `//kernel:kernel_elf` build, games suite passes.

> **Heads-up:** a *separate* pre-existing failure remains on master — the hosted
> bare-ELF smoke panics `active space missing` (`arch-interp/src/paging.rs:422`),
> masked until now because the clippy step failed first. It needs its own fix
> before CI is fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)