### PR TITLE
fix(host): init guest RAM before the bare-ELF run (active space missing)

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -139,6 +139,12 @@ fn main() {
         // drivable. Output already flows to stdout via the kernel's 0xE9 mirror.
         arch::enter_raw_mode();
         spawn_keyboard();
+        // Initialize guest RAM + the active address space before loading the
+        // ELF into it — the disk-boot path below does this via `init_guest_ram`
+        // too, but this branch diverges before reaching it. Without it the ELF
+        // loader's first `copy_to` resolves against no active space and panics
+        // ("active space missing").
+        arch::init_guest_ram(0);
         let mut machine = arch::Interp;
         kernel::host_run_elf(&mut machine, path.as_bytes(), data, argv);
     }


### PR DESCRIPTION
`retroos-host FILE.elf` (the disk-less dev path, and CI's hosted-ELF smoke)
panicked `active space missing` (`arch-interp/src/paging.rs:422`).

**Cause:** the bare-ELF branch in `kernel/src/main.rs` calls `host_run_elf`
without first creating the guest address space. `init_guest_ram(0)` — which
runs `mmu::init` → `paging::space_init` and makes space 0 active — sits *after*
the ELF branch (for the disk-boot path), and the ELF branch diverges
(`host_run_elf` returns `!`) before reaching it. So the ELF loader's first
`copy_to` (`load_elf` → `space_resolve` → `active_pd`) resolves against a space
that was never created.

**Fix:** call `init_guest_ram(0)` in the bare-ELF branch, exactly as the disk
path does one block later.

This was masked in CI because the job stops at the earlier clippy step (see #19);
with clippy green, the smoke runs and this is what it catches.

Verified: `retroos-host /tmp/hello.elf` now prints the greeting and parks (the
smoke's assertion) instead of dumping core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)