### PR TITLE
feat(net): Linux socket syscalls via hosted std::net punch-through

### DIFF
--- a/apps/hosted-test/netcat.c
+++ b/apps/hosted-test/netcat.c
@@ -1,0 +1,55 @@
+// Minimal nostdlib TCP client for the hosted socket-syscall smoke test.
+// socket()+connect() to 127.0.0.1:PORT, send a line, print the reply.
+// Uses the i386 socketcall(2) multiplexer directly (no libc).
+//
+//   gcc -m32 -static -nostdlib -no-pie -fno-pic -O2 -e _start -DPORT=NNNN \
+//       -o netcat.elf apps/hosted-test/netcat.c
+
+static int socketcall(int call, unsigned long *args) {
+    int ret;
+    __asm__ volatile("int $0x80" : "=a"(ret) : "a"(102), "b"(call), "c"(args) : "memory");
+    return ret;
+}
+static int sys_write(int fd, const char *buf, int len) {
+    int ret;
+    __asm__ volatile("int $0x80" : "=a"(ret) : "a"(4), "b"(fd), "c"(buf), "d"(len) : "memory");
+    return ret;
+}
+static void sys_exit(int code) {
+    __asm__ volatile("int $0x80" :: "a"(1), "b"(code));
+    __builtin_unreachable();
+}
+
+#define SYS_SOCKET  1
+#define SYS_CONNECT 3
+#define SYS_SEND    9
+#define SYS_RECV    10
+
+void _start(void) {
+    unsigned long a[6];
+
+    // socket(AF_INET=2, SOCK_STREAM=1, 0)
+    a[0] = 2; a[1] = 1; a[2] = 0;
+    int fd = socketcall(SYS_SOCKET, a);
+    if (fd < 0) { sys_write(1, "socket-fail\n", 12); sys_exit(1); }
+
+    // sockaddr_in { AF_INET, htons(PORT), 127.0.0.1 }
+    unsigned char sa[16] = {0};
+    sa[0] = 2; sa[1] = 0;                  // sin_family = AF_INET (little-endian)
+    sa[2] = (PORT >> 8) & 0xff; sa[3] = PORT & 0xff; // sin_port (big-endian)
+    sa[4] = 127; sa[5] = 0; sa[6] = 0; sa[7] = 1;    // 127.0.0.1
+    a[0] = (unsigned long)fd; a[1] = (unsigned long)sa; a[2] = 16;
+    if (socketcall(SYS_CONNECT, a) < 0) { sys_write(1, "connect-fail\n", 13); sys_exit(1); }
+
+    // send a request line
+    static const char req[] = "PING";
+    a[0] = (unsigned long)fd; a[1] = (unsigned long)req; a[2] = sizeof(req) - 1; a[3] = 0;
+    socketcall(SYS_SEND, a);
+
+    // recv the reply and echo it to stdout
+    char buf[256];
+    a[0] = (unsigned long)fd; a[1] = (unsigned long)buf; a[2] = sizeof(buf); a[3] = 0;
+    int n = socketcall(SYS_RECV, a);
+    if (n > 0) sys_write(1, buf, n);
+    sys_exit(0);
+}

--- a/arch-interp/src/lib.rs
+++ b/arch-interp/src/lib.rs
@@ -57,6 +57,7 @@ mod desc;
 mod devices;
 mod engine;
 mod hostfs;
+mod net;
 #[cfg(feature = "kvm")]
 mod kvm;
 mod machine;
@@ -100,6 +101,15 @@ pub use devices::{
 pub use hostfs::{
     host_clunk, host_create, host_dir_exists, host_open, host_read, host_readdir,
     host_remove, host_write, install_native_hostfs,
+};
+// Native socket backend (hosted "punch-through"): `install_native_sockets`
+// enables it; the `host_sock_*` fns are the primitive hooks the kernel's
+// `install_socket_backend` points at (direct std::net).
+pub use net::{
+    host_sock_accept, host_sock_bind, host_sock_close, host_sock_connect,
+    host_sock_getpeername, host_sock_getsockname, host_sock_listen, host_sock_recvfrom,
+    host_sock_sendto, host_sock_setsockopt, host_sock_shutdown, host_sock_socket,
+    install_native_sockets,
 };
 // Host-side VGA text-screen snapshotting (headless inspection of the guest's
 // 0xB8000 text buffer): `set_dump_path` arms it, `request_vga_dump` flips the

--- a/arch-interp/src/net.rs
+++ b/arch-interp/src/net.rs
@@ -1,0 +1,251 @@
+//! Native socket server for the hosted backend — the "punch-through" that
+//! proxies the kernel's Linux socket syscalls to the host's `std::net`.
+//!
+//! The kernel runs native in this process, so a guest `socket`/`connect`/
+//! `send`/`recv` becomes a real host TCP connection with no in-guest TCP/IP
+//! stack. State is thread-local (set on the CPU/kernel thread before startup),
+//! matching the native host-fs server. Raw `sockaddr_in` bytes cross the seam
+//! and are parsed here, so no kernel type appears in this crate.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::{Ipv4Addr, Shutdown, SocketAddrV4, TcpListener, TcpStream};
+
+// Linux errnos we hand back (negated by the caller side already expects <0).
+const EBADF: i32 = -9;
+const EINVAL: i32 = -22;
+const EAFNOSUPPORT: i32 = -97;
+const ECONNREFUSED: i32 = -111;
+const ENOTCONN: i32 = -107;
+const EIO: i32 = -5;
+
+enum HostSocket {
+    /// Created but not yet connected/bound.
+    Fresh { bind_addr: Option<SocketAddrV4> },
+    Stream(TcpStream),
+    Listener(TcpListener),
+}
+
+struct Sockets {
+    map: HashMap<i32, HostSocket>,
+    next: i32,
+}
+
+impl Sockets {
+    fn insert(&mut self, s: HostSocket) -> i32 {
+        let h = self.next;
+        self.next += 1;
+        self.map.insert(h, s);
+        h
+    }
+}
+
+thread_local! {
+    /// The native socket table for the injected backend. Set by
+    /// `install_native_sockets` on the CPU/kernel thread before startup.
+    static NATIVE_SOCKETS: RefCell<Option<Sockets>> = const { RefCell::new(None) };
+}
+
+/// Enable the native socket backend on this (CPU/kernel) thread.
+pub fn install_native_sockets() {
+    NATIVE_SOCKETS.with(|s| *s.borrow_mut() = Some(Sockets { map: HashMap::new(), next: 1 }));
+}
+
+fn with<R>(f: impl FnOnce(&mut Sockets) -> R, miss: R) -> R {
+    NATIVE_SOCKETS.with(|s| match s.borrow_mut().as_mut() {
+        Some(sk) => f(sk),
+        None => miss,
+    })
+}
+
+/// Decode a guest `sockaddr_in` (native-endian family, big-endian port).
+fn decode_sockaddr(a: &[u8]) -> Option<SocketAddrV4> {
+    if a.len() < 8 {
+        return None;
+    }
+    if u16::from_ne_bytes([a[0], a[1]]) != 2 {
+        return None; // not AF_INET
+    }
+    let port = u16::from_be_bytes([a[2], a[3]]);
+    Some(SocketAddrV4::new(Ipv4Addr::new(a[4], a[5], a[6], a[7]), port))
+}
+
+/// Encode a `sockaddr_in` (16 bytes) into `out` (capped); returns the full
+/// structure length (16), the value `getsockname`/`accept` report.
+fn encode_sockaddr(sa: SocketAddrV4, out: &mut [u8]) -> i32 {
+    let mut buf = [0u8; 16];
+    buf[0..2].copy_from_slice(&2u16.to_ne_bytes());
+    buf[2..4].copy_from_slice(&sa.port().to_be_bytes());
+    buf[4..8].copy_from_slice(&sa.ip().octets());
+    let n = out.len().min(16);
+    out[..n].copy_from_slice(&buf[..n]);
+    16
+}
+
+// ── The primitive free functions the kernel's `SocketHooks` point at ──────
+
+pub fn host_sock_socket(domain: i32, _ty: i32, _proto: i32) -> i32 {
+    if domain != 2 {
+        return EAFNOSUPPORT; // AF_INET only for now
+    }
+    with(|s| s.insert(HostSocket::Fresh { bind_addr: None }), EBADF)
+}
+
+pub fn host_sock_connect(h: i32, addr: &[u8]) -> i32 {
+    let Some(sa) = decode_sockaddr(addr) else { return EINVAL };
+    with(
+        |s| {
+            if !matches!(s.map.get(&h), Some(HostSocket::Fresh { .. })) {
+                return EBADF;
+            }
+            match TcpStream::connect(sa) {
+                Ok(stream) => {
+                    s.map.insert(h, HostSocket::Stream(stream));
+                    0
+                }
+                Err(_) => ECONNREFUSED,
+            }
+        },
+        EBADF,
+    )
+}
+
+pub fn host_sock_bind(h: i32, addr: &[u8]) -> i32 {
+    let Some(sa) = decode_sockaddr(addr) else { return EINVAL };
+    with(
+        |s| match s.map.get_mut(&h) {
+            Some(HostSocket::Fresh { bind_addr }) => {
+                *bind_addr = Some(sa);
+                0
+            }
+            _ => EBADF,
+        },
+        EBADF,
+    )
+}
+
+pub fn host_sock_listen(h: i32, _backlog: i32) -> i32 {
+    with(
+        |s| {
+            let addr = match s.map.get(&h) {
+                Some(HostSocket::Fresh { bind_addr: Some(a) }) => *a,
+                Some(HostSocket::Fresh { bind_addr: None }) => {
+                    SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)
+                }
+                _ => return EBADF,
+            };
+            match TcpListener::bind(addr) {
+                Ok(l) => {
+                    s.map.insert(h, HostSocket::Listener(l));
+                    0
+                }
+                Err(_) => EIO,
+            }
+        },
+        EBADF,
+    )
+}
+
+pub fn host_sock_accept(h: i32, addr_out: &mut [u8]) -> i32 {
+    // NB: blocking accept holds the table borrow — acceptable for the slice.
+    with(
+        |s| match s.map.get(&h) {
+            Some(HostSocket::Listener(l)) => match l.accept() {
+                Ok((stream, peer)) => {
+                    if let std::net::SocketAddr::V4(p) = peer {
+                        encode_sockaddr(p, addr_out);
+                    }
+                    s.insert(HostSocket::Stream(stream))
+                }
+                Err(_) => EIO,
+            },
+            _ => EBADF,
+        },
+        EBADF,
+    )
+}
+
+pub fn host_sock_sendto(h: i32, buf: &[u8], _flags: i32, _addr: &[u8]) -> i32 {
+    with(
+        |s| match s.map.get_mut(&h) {
+            Some(HostSocket::Stream(stream)) => match stream.write(buf) {
+                Ok(n) => n as i32,
+                Err(_) => EIO,
+            },
+            Some(_) => ENOTCONN,
+            None => EBADF,
+        },
+        EBADF,
+    )
+}
+
+pub fn host_sock_recvfrom(h: i32, buf: &mut [u8], _flags: i32, _addr_out: &mut [u8]) -> i32 {
+    with(
+        |s| match s.map.get_mut(&h) {
+            Some(HostSocket::Stream(stream)) => match stream.read(buf) {
+                Ok(n) => n as i32,
+                Err(_) => EIO,
+            },
+            Some(_) => ENOTCONN,
+            None => EBADF,
+        },
+        EBADF,
+    )
+}
+
+pub fn host_sock_setsockopt(_h: i32, _level: i32, _optname: i32, _opt: &[u8]) -> i32 {
+    0 // best-effort no-op (SO_REUSEADDR, TCP_NODELAY, …)
+}
+
+pub fn host_sock_getsockname(h: i32, addr_out: &mut [u8]) -> i32 {
+    with(
+        |s| match s.map.get(&h) {
+            Some(HostSocket::Stream(stream)) => match stream.local_addr() {
+                Ok(std::net::SocketAddr::V4(a)) => { encode_sockaddr(a, addr_out); 0 }
+                _ => EIO,
+            },
+            Some(HostSocket::Listener(l)) => match l.local_addr() {
+                Ok(std::net::SocketAddr::V4(a)) => { encode_sockaddr(a, addr_out); 0 }
+                _ => EIO,
+            },
+            _ => EBADF,
+        },
+        EBADF,
+    )
+}
+
+pub fn host_sock_getpeername(h: i32, addr_out: &mut [u8]) -> i32 {
+    with(
+        |s| match s.map.get(&h) {
+            Some(HostSocket::Stream(stream)) => match stream.peer_addr() {
+                Ok(std::net::SocketAddr::V4(a)) => { encode_sockaddr(a, addr_out); 0 }
+                _ => EIO,
+            },
+            _ => ENOTCONN,
+        },
+        EBADF,
+    )
+}
+
+pub fn host_sock_shutdown(h: i32, how: i32) -> i32 {
+    let how = match how {
+        0 => Shutdown::Read,
+        1 => Shutdown::Write,
+        _ => Shutdown::Both,
+    };
+    with(
+        |s| match s.map.get(&h) {
+            Some(HostSocket::Stream(stream)) => {
+                let _ = stream.shutdown(how);
+                0
+            }
+            _ => EBADF,
+        },
+        EBADF,
+    )
+}
+
+pub fn host_sock_close(h: i32) {
+    with(|s| { s.map.remove(&h); }, ());
+}

--- a/kernel/src/kernel/linux/mod.rs
+++ b/kernel/src/kernel/linux/mod.rs
@@ -37,6 +37,8 @@ const ENOENT: i32 = 2;
 const ESRCH: i32 = 3;
 const ENOEXEC: i32 = 8;
 const EBADF: i32 = 9;
+const ENOTSOCK: i32 = 88;
+const EMFILE: i32 = 24;
 const ECHILD: i32 = 10;
 const ENOMEM: i32 = 12;
 const EFAULT: i32 = 14;
@@ -405,6 +407,7 @@ fn dispatch_nr<A: crate::Arch>(machine: &mut A, kt: &mut thread::KernelThread<A>
         331 => sys_pipe(machine, kt, a, true),
         340 => SyscallResult::val(0),
         355 => sys_getrandom(machine, &mut kt.vcpu, a),
+        102 => sys_socketcall(machine, kt, a),
         _ => {
             println!("unimplemented syscall {}", nr);
             SyscallResult::val(-ENOSYS)
@@ -477,6 +480,20 @@ fn dispatch_nr_64<A: crate::Arch>(machine: &mut A, kt: &mut thread::KernelThread
         293 => sys_pipe(machine, kt, a, true),
         302 => SyscallResult::val(0),
         318 => sys_getrandom(machine, &mut kt.vcpu, a),
+        // Sockets (x86-64 direct numbering).
+        41  => sys_socket(kt, a.a0, a.a1, a.a2),
+        42  => sys_connect(machine, kt, a.a0, a.a1 as usize, a.a2 as usize),
+        43  => sys_accept(machine, kt, a.a0, a.a1 as usize, a.a2 as usize),
+        44  => sys_sendto(machine, kt, a.a0, a.a1 as usize, a.a2 as usize, a.a3, a.a4 as usize, a.a5 as usize),
+        45  => sys_recvfrom(machine, kt, a.a0, a.a1 as usize, a.a2 as usize, a.a3, a.a4 as usize, a.a5 as usize),
+        48  => sys_shutdown(kt, a.a0, a.a1),
+        49  => sys_bind(machine, kt, a.a0, a.a1 as usize, a.a2 as usize),
+        50  => sys_listen(kt, a.a0, a.a1),
+        51  => sys_getsockname(machine, kt, a.a0, a.a1 as usize, a.a2 as usize, false),
+        52  => sys_getsockname(machine, kt, a.a0, a.a1 as usize, a.a2 as usize, true),
+        54  => sys_setsockopt(machine, kt, a.a0, a.a1, a.a2, a.a3 as usize, a.a4 as usize),
+        55  => SyscallResult::val(0), // getsockopt — report success (SO_ERROR = 0)
+        288 => sys_accept(machine, kt, a.a0, a.a1 as usize, a.a2 as usize), // accept4
         _ => {
             println!("unimplemented x86_64 syscall {}", nr);
             SyscallResult::val(-ENOSYS)
@@ -852,6 +869,14 @@ fn sys_read<A: crate::Arch>(machine: &mut A, kt: &mut thread::KernelThread<A>, l
             if n > 0 { machine.copy_to(buf, &tmp[..n as usize]); }
             SyscallResult::val(n)
         }
+        thread::FdKind::Socket(h) => {
+            // read() on a socket == recv() with no flags. Blocking (host
+            // socket blocks the kernel thread) — fine for a single client.
+            let mut tmp = alloc::vec![0u8; len];
+            let n = crate::kernel::net::recvfrom(h, &mut tmp, 0, &mut []);
+            if n > 0 { machine.copy_to(buf, &tmp[..n as usize]); }
+            SyscallResult::val(n)
+        }
         thread::FdKind::ConsoleOut | thread::FdKind::PipeWrite(_) | thread::FdKind::Dir(_) => {
             SyscallResult::val(-EBADF)
         }
@@ -891,6 +916,12 @@ fn sys_write<A: crate::Arch>(machine: &mut A, kt: &mut thread::KernelThread<A>, 
             let mut tmp = alloc::vec![0u8; len];
             machine.copy_from(buf, &mut tmp);
             SyscallResult::val(vfs::write_by_handle(machine, handle, &tmp))
+        }
+        thread::FdKind::Socket(h) => {
+            // write() on a socket == send() with no flags.
+            let mut tmp = alloc::vec![0u8; len];
+            machine.copy_from(buf, &mut tmp);
+            SyscallResult::val(crate::kernel::net::sendto(h, &tmp, 0, &[]))
         }
         thread::FdKind::PipeRead(_) | thread::FdKind::None | thread::FdKind::Dir(_) => {
             SyscallResult::val(-EBADF)
@@ -942,6 +973,157 @@ fn sys_close<A: crate::Arch>(kt: &mut thread::KernelThread<A>, a: &Args) -> Sysc
     if kt.fds[fd].is_none() { return SyscallResult::val(-EBADF); }
     kt.close_fd(fd);
     SyscallResult::val(0)
+}
+
+// =============================================================================
+// Sockets — the injected socket layer (hosted std::net punch-through).
+//
+// Blocking is acceptable for this slice: a host socket call blocks the kernel
+// thread, which is fine for a single-threaded client (wget/curl). TODO:
+// non-blocking + integrate with the event loop's PendingPoll so concurrent
+// guests don't stall each other.
+// =============================================================================
+
+use crate::kernel::net;
+
+/// The i386 `socketcall(2)` multiplexer (nr 102): `a0` = subcall, `a1` = a
+/// pointer to a packed array of native-word (32-bit here) arguments. x86-64
+/// reaches the same shared handlers via direct syscalls.
+fn sys_socketcall<A: crate::Arch>(machine: &mut A, kt: &mut thread::KernelThread<A>, a: &Args) -> SyscallResult {
+    let call = a.a0 as u32;
+    let argp = a.a1 as usize;
+    let mut raw = [0u8; 24]; // up to 6 u32 args
+    machine.copy_from(argp, &mut raw);
+    let g = |i: usize| u32::from_le_bytes([raw[i*4], raw[i*4+1], raw[i*4+2], raw[i*4+3]]) as u64;
+    match call {
+        1  => sys_socket(kt, g(0), g(1), g(2)),
+        2  => sys_bind(machine, kt, g(0), g(1) as usize, g(2) as usize),
+        3  => sys_connect(machine, kt, g(0), g(1) as usize, g(2) as usize),
+        4  => sys_listen(kt, g(0), g(1)),
+        5  => sys_accept(machine, kt, g(0), g(1) as usize, g(2) as usize),
+        6  => sys_getsockname(machine, kt, g(0), g(1) as usize, g(2) as usize, false),
+        7  => sys_getsockname(machine, kt, g(0), g(1) as usize, g(2) as usize, true),
+        9  => sys_sendto(machine, kt, g(0), g(1) as usize, g(2) as usize, g(3), 0, 0),
+        10 => sys_recvfrom(machine, kt, g(0), g(1) as usize, g(2) as usize, g(3), 0, 0),
+        11 => sys_sendto(machine, kt, g(0), g(1) as usize, g(2) as usize, g(3), g(4) as usize, g(5) as usize),
+        12 => sys_recvfrom(machine, kt, g(0), g(1) as usize, g(2) as usize, g(3), g(4) as usize, g(5) as usize),
+        13 => sys_shutdown(kt, g(0), g(1)),
+        14 => sys_setsockopt(machine, kt, g(0), g(1), g(2), g(3) as usize, g(4) as usize),
+        15 => SyscallResult::val(0), // getsockopt — report success (SO_ERROR = 0)
+        18 => sys_accept(machine, kt, g(0), g(1) as usize, g(2) as usize), // accept4
+        _  => SyscallResult::val(-ENOSYS),
+    }
+}
+
+/// Resolve an fd to its backend socket handle.
+fn sock_handle<A: crate::Arch>(kt: &thread::KernelThread<A>, fd: u64) -> Result<i32, i32> {
+    let fd = fd as usize;
+    if fd >= thread::MAX_FDS { return Err(-EBADF); }
+    match kt.fds[fd] {
+        thread::FdKind::Socket(h) => Ok(h),
+        thread::FdKind::None => Err(-EBADF),
+        _ => Err(-ENOTSOCK),
+    }
+}
+
+/// Copy a `sockaddr` of `len` bytes from guest memory (capped).
+fn read_sockaddr<A: crate::Arch>(machine: &mut A, ptr: usize, len: usize) -> ([u8; 128], usize) {
+    let n = len.min(128);
+    let mut addr = [0u8; 128];
+    if ptr != 0 && n > 0 { machine.copy_from(ptr, &mut addr[..n]); }
+    (addr, n)
+}
+
+fn sys_socket<A: crate::Arch>(kt: &mut thread::KernelThread<A>, domain: u64, ty: u64, proto: u64) -> SyscallResult {
+    let h = net::socket(domain as i32, ty as i32, proto as i32);
+    if h < 0 { return SyscallResult::val(h); }
+    match kt.alloc_fd(3) {
+        Some(fd) => { kt.fds[fd] = thread::FdKind::Socket(h); SyscallResult::val(fd as i32) }
+        None => { net::close(h); SyscallResult::val(-EMFILE) }
+    }
+}
+
+fn sys_connect<A: crate::Arch>(machine: &mut A, kt: &mut thread::KernelThread<A>, fd: u64, addr_ptr: usize, addr_len: usize) -> SyscallResult {
+    let h = match sock_handle(kt, fd) { Ok(h) => h, Err(e) => return SyscallResult::val(e) };
+    let (addr, n) = read_sockaddr(machine, addr_ptr, addr_len);
+    SyscallResult::val(net::connect(h, &addr[..n]))
+}
+
+fn sys_bind<A: crate::Arch>(machine: &mut A, kt: &mut thread::KernelThread<A>, fd: u64, addr_ptr: usize, addr_len: usize) -> SyscallResult {
+    let h = match sock_handle(kt, fd) { Ok(h) => h, Err(e) => return SyscallResult::val(e) };
+    let (addr, n) = read_sockaddr(machine, addr_ptr, addr_len);
+    SyscallResult::val(net::bind(h, &addr[..n]))
+}
+
+fn sys_listen<A: crate::Arch>(kt: &mut thread::KernelThread<A>, fd: u64, backlog: u64) -> SyscallResult {
+    let h = match sock_handle(kt, fd) { Ok(h) => h, Err(e) => return SyscallResult::val(e) };
+    SyscallResult::val(net::listen(h, backlog as i32))
+}
+
+fn sys_accept<A: crate::Arch>(machine: &mut A, kt: &mut thread::KernelThread<A>, fd: u64, addr_ptr: usize, addrlen_ptr: usize) -> SyscallResult {
+    let h = match sock_handle(kt, fd) { Ok(h) => h, Err(e) => return SyscallResult::val(e) };
+    let mut addr = [0u8; 16];
+    let nh = net::accept(h, &mut addr);
+    if nh < 0 { return SyscallResult::val(nh); }
+    write_sockaddr_out(machine, addr_ptr, addrlen_ptr, &addr);
+    match kt.alloc_fd(3) {
+        Some(newfd) => { kt.fds[newfd] = thread::FdKind::Socket(nh); SyscallResult::val(newfd as i32) }
+        None => { net::close(nh); SyscallResult::val(-EMFILE) }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn sys_sendto<A: crate::Arch>(machine: &mut A, kt: &mut thread::KernelThread<A>, fd: u64, buf_ptr: usize, len: usize, flags: u64, addr_ptr: usize, addr_len: usize) -> SyscallResult {
+    let h = match sock_handle(kt, fd) { Ok(h) => h, Err(e) => return SyscallResult::val(e) };
+    let mut data = alloc::vec![0u8; len];
+    machine.copy_from(buf_ptr, &mut data);
+    let (addr, n) = read_sockaddr(machine, addr_ptr, addr_len);
+    SyscallResult::val(net::sendto(h, &data, flags as i32, &addr[..n]))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn sys_recvfrom<A: crate::Arch>(machine: &mut A, kt: &mut thread::KernelThread<A>, fd: u64, buf_ptr: usize, len: usize, flags: u64, addr_ptr: usize, addrlen_ptr: usize) -> SyscallResult {
+    let h = match sock_handle(kt, fd) { Ok(h) => h, Err(e) => return SyscallResult::val(e) };
+    let mut data = alloc::vec![0u8; len];
+    let mut addr = [0u8; 16];
+    let n = net::recvfrom(h, &mut data, flags as i32, &mut addr);
+    if n < 0 { return SyscallResult::val(n); }
+    machine.copy_to(buf_ptr, &data[..n as usize]);
+    write_sockaddr_out(machine, addr_ptr, addrlen_ptr, &addr);
+    SyscallResult::val(n)
+}
+
+fn sys_setsockopt<A: crate::Arch>(machine: &mut A, kt: &mut thread::KernelThread<A>, fd: u64, level: u64, optname: u64, opt_ptr: usize, opt_len: usize) -> SyscallResult {
+    let h = match sock_handle(kt, fd) { Ok(h) => h, Err(e) => return SyscallResult::val(e) };
+    let (opt, n) = read_sockaddr(machine, opt_ptr, opt_len);
+    SyscallResult::val(net::setsockopt(h, level as i32, optname as i32, &opt[..n]))
+}
+
+/// `getsockname` (peer=false) / `getpeername` (peer=true).
+fn sys_getsockname<A: crate::Arch>(machine: &mut A, kt: &mut thread::KernelThread<A>, fd: u64, addr_ptr: usize, addrlen_ptr: usize, peer: bool) -> SyscallResult {
+    let h = match sock_handle(kt, fd) { Ok(h) => h, Err(e) => return SyscallResult::val(e) };
+    let mut addr = [0u8; 16];
+    let r = if peer { net::getpeername(h, &mut addr) } else { net::getsockname(h, &mut addr) };
+    if r < 0 { return SyscallResult::val(r); }
+    write_sockaddr_out(machine, addr_ptr, addrlen_ptr, &addr);
+    SyscallResult::val(0)
+}
+
+fn sys_shutdown<A: crate::Arch>(kt: &mut thread::KernelThread<A>, fd: u64, how: u64) -> SyscallResult {
+    let h = match sock_handle(kt, fd) { Ok(h) => h, Err(e) => return SyscallResult::val(e) };
+    SyscallResult::val(net::shutdown(h, how as i32))
+}
+
+/// Write a 16-byte `sockaddr_in` back to the caller's `addr`/`addrlen`
+/// out-params (both may be null). `addrlen` is `socklen_t` (32-bit).
+fn write_sockaddr_out<A: crate::Arch>(machine: &mut A, addr_ptr: usize, addrlen_ptr: usize, addr: &[u8; 16]) {
+    if addr_ptr == 0 || addrlen_ptr == 0 { return; }
+    let mut cap = [0u8; 4];
+    machine.copy_from(addrlen_ptr, &mut cap);
+    let cap = u32::from_le_bytes(cap) as usize;
+    let n = cap.min(16);
+    machine.copy_to(addr_ptr, &addr[..n]);
+    machine.copy_to(addrlen_ptr, &16u32.to_le_bytes());
 }
 
 /// execve(11)
@@ -1200,6 +1382,7 @@ fn sys_fcntl<A: crate::Arch>(kt: &mut thread::KernelThread<A>, a: &Args) -> Sysc
                 thread::FdKind::Vfs(handle) => vfs::add_vfs_ref(handle),
                 thread::FdKind::PipeRead(idx) => crate::kernel::kpipe::add_reader(idx),
                 thread::FdKind::PipeWrite(idx) => crate::kernel::kpipe::add_writer(idx),
+                thread::FdKind::Socket(_) => {} // TODO: socket dup refcount
                 thread::FdKind::ConsoleOut | thread::FdKind::None | thread::FdKind::Dir(_) => {}
             }
             kt.fds[newfd] = kind;
@@ -1431,6 +1614,13 @@ pub(crate) fn run_poll<A: crate::Arch>(machine: &mut A, kt: &mut thread::KernelT
                     if (events & POLLIN) != 0 { revents |= POLLIN; }
                     if (events & POLLOUT) != 0 { revents |= POLLOUT; }
                 }
+                // Sockets: optimistically report ready for whatever was asked.
+                // Host sockets are blocking, so a following recv/send blocks
+                // until it actually completes. TODO: real readiness via a
+                // non-blocking poll on the host socket.
+                thread::FdKind::Socket(_) => {
+                    revents |= events & (POLLIN | POLLOUT);
+                }
                 thread::FdKind::None => {}
             }
         }
@@ -1613,6 +1803,10 @@ fn sys_fstat64<A: crate::Arch>(machine: &mut A, kt: &mut thread::KernelThread<A>
         }
         thread::FdKind::Dir(_) => {
             write_stat64(machine, stat_buf, 0o40755, 0, 0, want_64); // S_IFDIR
+            SyscallResult::val(0)
+        }
+        thread::FdKind::Socket(_) => {
+            write_stat64(machine, stat_buf, 0o140000 | 0o777, 0, 0, want_64); // S_IFSOCK
             SyscallResult::val(0)
         }
         thread::FdKind::None => SyscallResult::val(-EBADF),
@@ -1911,6 +2105,7 @@ fn sys_dup2<A: crate::Arch>(kt: &mut thread::KernelThread<A>, a: &Args) -> Sysca
         thread::FdKind::Vfs(handle) => vfs::add_vfs_ref(handle),
         thread::FdKind::PipeRead(idx) => crate::kernel::kpipe::add_reader(idx),
         thread::FdKind::PipeWrite(idx) => crate::kernel::kpipe::add_writer(idx),
+        thread::FdKind::Socket(_) => {} // TODO: socket dup refcount
         thread::FdKind::ConsoleOut | thread::FdKind::None | thread::FdKind::Dir(_) => {}
     }
     kt.fds[newfd] = kind;

--- a/kernel/src/kernel/mod.rs
+++ b/kernel/src/kernel/mod.rs
@@ -23,6 +23,7 @@ pub mod portio;
 pub mod sched;
 pub mod keyboard;
 pub mod kpipe;
+pub mod net;
 pub mod klog;
 pub mod linux;
 pub mod sound;

--- a/kernel/src/kernel/net.rs
+++ b/kernel/src/kernel/net.rs
@@ -1,0 +1,95 @@
+//! Socket layer — backend-injected, mirroring the host-fs "punch-through".
+//!
+//! The kernel is `no_std` and backend-agnostic. On HOSTED the kernel runs
+//! native in the host process, so instead of a TCP/IP stack we proxy the Linux
+//! socket syscalls straight to the host's `std::net`, injected as a fn-pointer
+//! table (`SocketHooks`) exactly like `hostfs::HostBackendHooks`. On METAL no
+//! backend is installed yet — the wrappers below return `-ENOSYS`; the real
+//! metal path (a NIC driver + smoltcp filling the same hooks) is a follow-up.
+//!
+//! Signatures are primitive-only so no kernel type crosses into `arch-interp`:
+//! raw `sockaddr` bytes travel as `&[u8]`, parsed on the host side.
+
+/// The installed native socket hook table. `socket`/`accept` return a handle
+/// (>= 0) or a negative errno; the byte-buffer calls return bytes moved or a
+/// negative errno. `addr_out` buffers are filled with a raw `sockaddr_in`.
+#[derive(Clone, Copy)]
+pub struct SocketHooks {
+    pub socket: fn(i32, i32, i32) -> i32,
+    pub connect: fn(i32, &[u8]) -> i32,
+    pub bind: fn(i32, &[u8]) -> i32,
+    pub listen: fn(i32, i32) -> i32,
+    /// Accept a connection: returns a new handle (>= 0) or -errno; writes the
+    /// peer's `sockaddr_in` into `addr_out` (needs >= 16 bytes).
+    pub accept: fn(i32, &mut [u8]) -> i32,
+    pub sendto: fn(i32, &[u8], i32, &[u8]) -> i32,
+    pub recvfrom: fn(i32, &mut [u8], i32, &mut [u8]) -> i32,
+    pub setsockopt: fn(i32, i32, i32, &[u8]) -> i32,
+    /// Fill `addr_out` with the local/peer `sockaddr_in`; returns its length.
+    pub getsockname: fn(i32, &mut [u8]) -> i32,
+    pub getpeername: fn(i32, &mut [u8]) -> i32,
+    pub shutdown: fn(i32, i32) -> i32,
+    pub close: fn(i32),
+}
+
+static mut SOCKET_BACKEND: Option<SocketHooks> = None;
+
+/// Install the native socket hooks. Single-threaded boot context (the entry
+/// calls this before `startup`), safe by the same argument as `install_portio`.
+pub fn install_socket_backend(hooks: SocketHooks) {
+    unsafe { SOCKET_BACKEND = Some(hooks); }
+}
+
+/// Whether a socket backend is installed (false on metal for now).
+pub fn socket_backend_installed() -> bool {
+    // Copy the Option out (Copy) so we never reference the mutable static —
+    // an error under edition 2024.
+    unsafe { SOCKET_BACKEND }.is_some()
+}
+
+#[inline]
+fn backend() -> Option<SocketHooks> {
+    unsafe { SOCKET_BACKEND }
+}
+
+/// -ENOSYS: what every wrapper returns when no backend is installed, so the
+/// Linux personality degrades cleanly (a program's socket() fails) rather than
+/// panicking on metal.
+const ENOSYS: i32 = -38;
+
+pub fn socket(domain: i32, ty: i32, proto: i32) -> i32 {
+    backend().map_or(ENOSYS, |b| (b.socket)(domain, ty, proto))
+}
+pub fn connect(h: i32, addr: &[u8]) -> i32 {
+    backend().map_or(ENOSYS, |b| (b.connect)(h, addr))
+}
+pub fn bind(h: i32, addr: &[u8]) -> i32 {
+    backend().map_or(ENOSYS, |b| (b.bind)(h, addr))
+}
+pub fn listen(h: i32, backlog: i32) -> i32 {
+    backend().map_or(ENOSYS, |b| (b.listen)(h, backlog))
+}
+pub fn accept(h: i32, addr_out: &mut [u8]) -> i32 {
+    backend().map_or(ENOSYS, |b| (b.accept)(h, addr_out))
+}
+pub fn sendto(h: i32, buf: &[u8], flags: i32, addr: &[u8]) -> i32 {
+    backend().map_or(ENOSYS, |b| (b.sendto)(h, buf, flags, addr))
+}
+pub fn recvfrom(h: i32, buf: &mut [u8], flags: i32, addr_out: &mut [u8]) -> i32 {
+    backend().map_or(ENOSYS, |b| (b.recvfrom)(h, buf, flags, addr_out))
+}
+pub fn setsockopt(h: i32, level: i32, optname: i32, opt: &[u8]) -> i32 {
+    backend().map_or(ENOSYS, |b| (b.setsockopt)(h, level, optname, opt))
+}
+pub fn getsockname(h: i32, addr_out: &mut [u8]) -> i32 {
+    backend().map_or(ENOSYS, |b| (b.getsockname)(h, addr_out))
+}
+pub fn getpeername(h: i32, addr_out: &mut [u8]) -> i32 {
+    backend().map_or(ENOSYS, |b| (b.getpeername)(h, addr_out))
+}
+pub fn shutdown(h: i32, how: i32) -> i32 {
+    backend().map_or(ENOSYS, |b| (b.shutdown)(h, how))
+}
+pub fn close(h: i32) {
+    if let Some(b) = backend() { (b.close)(h); }
+}

--- a/kernel/src/kernel/thread.rs
+++ b/kernel/src/kernel/thread.rs
@@ -34,6 +34,9 @@ pub enum FdKind {
     /// index to return; getdents64 advances it on each call so a sequential
     /// reader sees each entry exactly once and EOF after the last.
     Dir(u32),
+    /// Network socket — the i32 is the backend socket handle (injected socket
+    /// layer; hosted std::net punch-through).
+    Socket(i32),
 }
 
 impl FdKind {
@@ -371,6 +374,9 @@ impl<A: crate::Arch> KernelThread<A> {
             FdKind::PipeWrite(idx) => {
                 crate::kernel::kpipe::close_writer(idx);
             }
+            FdKind::Socket(h) => {
+                crate::kernel::net::close(h);
+            }
             FdKind::ConsoleOut | FdKind::None | FdKind::Dir(_) => {}
         }
         self.fds[fd] = FdKind::None;
@@ -409,6 +415,9 @@ impl<A: crate::Arch> KernelThread<A> {
                 FdKind::PipeWrite(idx) => {
                     crate::kernel::kpipe::add_writer(idx);
                 }
+                // TODO: refcount for fork/dup socket sharing — for now the child
+                // inherits the same backend handle; the first close frees it.
+                FdKind::Socket(_) => {}
                 FdKind::ConsoleOut | FdKind::None | FdKind::Dir(_) => {}
             }
         }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -62,6 +62,7 @@ pub use kernel::startup::startup;
 pub use kernel::platform::{set_host_env, DebugSink, HostEnv};
 pub use kernel::portio::{install_portio, PortIo};
 pub use kernel::hostfs::{install_host_backend, host_backend_installed, HostBackendHooks};
+pub use kernel::net::{install_socket_backend, socket_backend_installed, SocketHooks};
 
 /// Hosted: point the VGA console framebuffer at a scratch buffer so its writes
 /// (clear/scroll/putchar) don't dereference the unmapped `0xB8000` host

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -104,6 +104,7 @@ fn main() {
     // the deep driver call sites (portio), and the host environment facts the
     // platform probe reads (HostStdout debug, no fbcon, not metal).
     install_hosted_backend();
+    install_socket_backend_hosted();
     kernel::host_console_init();
     // Display: the kernel emulates the VGA (single-VGA design) and renders
     // frames through its present sink; we just park them in the backend's
@@ -207,6 +208,28 @@ fn install_hosted_backend() {
         fbcon_active: || false,
         debug: kernel::DebugSink::HostStdout,
         is_metal: false,
+    });
+}
+
+/// Install the native socket backend (hosted "punch-through" → host std::net).
+/// Networking is always available on hosted; metal installs nothing here (its
+/// NIC + smoltcp path is a future follow-up). Must run on the CPU/kernel thread
+/// (the native socket table is thread-local), before `startup`.
+fn install_socket_backend_hosted() {
+    arch::install_native_sockets();
+    kernel::install_socket_backend(kernel::SocketHooks {
+        socket: arch::host_sock_socket,
+        connect: arch::host_sock_connect,
+        bind: arch::host_sock_bind,
+        listen: arch::host_sock_listen,
+        accept: arch::host_sock_accept,
+        sendto: arch::host_sock_sendto,
+        recvfrom: arch::host_sock_recvfrom,
+        setsockopt: arch::host_sock_setsockopt,
+        getsockname: arch::host_sock_getsockname,
+        getpeername: arch::host_sock_getpeername,
+        shutdown: arch::host_sock_shutdown,
+        close: arch::host_sock_close,
     });
 }
 

--- a/play/src/main.rs
+++ b/play/src/main.rs
@@ -87,6 +87,23 @@ fn main() {
             debug: kernel::DebugSink::HostStdout,
             is_metal: false,
         });
+        // Native socket backend (hosted "punch-through" → host std::net); the
+        // socket table is thread-local, so install it on this CPU/kernel thread.
+        arch::install_native_sockets();
+        kernel::install_socket_backend(kernel::SocketHooks {
+            socket: arch::host_sock_socket,
+            connect: arch::host_sock_connect,
+            bind: arch::host_sock_bind,
+            listen: arch::host_sock_listen,
+            accept: arch::host_sock_accept,
+            sendto: arch::host_sock_sendto,
+            recvfrom: arch::host_sock_recvfrom,
+            setsockopt: arch::host_sock_setsockopt,
+            getsockname: arch::host_sock_getsockname,
+            getpeername: arch::host_sock_getpeername,
+            shutdown: arch::host_sock_shutdown,
+            close: arch::host_sock_close,
+        });
         // Display: the kernel emulates the VGA and renders (single-VGA
         // design); install its present sink to park frames in the backend
         // mailbox the window thread blits from.


### PR DESCRIPTION
First network consumer: Linux socket syscalls, with the HOSTED backend proxying
straight to the host's `std::net` — the same "punch-through" pattern as the host
filesystem. A 32-bit Linux ELF can now `socket`/`connect`/`send`/`recv` a TCP
connection through the hosted kernel to the real host network.

## Seam (mirrors `hostfs::HostBackendHooks` exactly)
- `kernel/src/kernel/net.rs`: `SocketHooks` (primitive-only fn-pointer table),
  `install_socket_backend`, `socket_backend_installed`. Raw `sockaddr` bytes
  cross the kernel↔arch-interp boundary as `&[u8]` (parsed host-side), so no
  kernel type leaks into the backend. Wrappers return `-ENOSYS` when no backend
  is installed → **metal degrades cleanly** (NIC + smoltcp is the follow-up).
- `FdKind::Socket(i32)` holds the backend handle.
- `linux/mod.rs`: i386 `socketcall(102)` demux + x86-64 direct socket syscalls,
  both funneling to shared handlers; `read`/`write`/`poll`/`fstat` learn sockets.
- `arch-interp/src/net.rs`: thread-local `std::net` server + `host_sock_*` fns;
  installed by both hosted entries on the CPU/kernel thread.

## Proof (independently reproduced)
```
gcc -m32 -static -nostdlib -no-pie -e _start -DPORT=18099 -o /tmp/netcat.elf apps/hosted-test/netcat.c
python3 -c "…bind 127.0.0.1:18099; accept; sendall(b'ECHO:'+recv())…" &
bazel-bin/kernel/retroos-host /tmp/netcat.elf   # → guest prints: ECHO:PING
```

## Verified
Hosted + metal `//:image` build; both clippy configs clean; games PASS ×3;
hosted ELF smoke PASS.

## Known limitations (follow-ups, noted in code)
- Blocking sockets (a host call blocks the kernel thread — fine for one client;
  TODO: non-blocking + `PendingPoll` for concurrent guests).
- No fork/dup socket refcount yet.
- Metal has no backend yet (NIC + smoltcp).

> Unrelated pre-existing bug surfaced by the test: the bare-ELF dev path panics
> `platform::get before platform::probe` on program *exit* — reproduces
> identically with `hello.elf` on master, fires *after* all program output.
> Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)