### PR TITLE
fix(host): bare-ELF path panicked on exit (platform::get before probe)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,12 @@ jobs:
         run: |
           gcc -m32 -static -nostdlib -no-pie -fno-pic -O2 -e _start \
             -o /tmp/hello.elf apps/hosted-test/hello.c
-          # The bare-ELF dev path never runs platform::probe(), so it prints the
-          # message then parks; cap it with timeout and assert on the output.
+          # The program prints its greeting then exit(0)s; cap with timeout.
           out=$(timeout 20 bazel-bin/kernel/retroos-host /tmp/hello.elf 2>&1 || true)
           echo "$out"
           echo "$out" | grep -q "Hello from an interpreted 32-bit Linux ELF!"
+          # ...and it must exit cleanly — no kernel panic behind the greeting.
+          if echo "$out" | grep -q "panicked"; then echo "kernel panicked on the bare-ELF path"; exit 1; fi
 
       # End-to-end games: boot each headless, drive keyboard, assert no kernel
       # panic (and, for text-mode programs, an expected on-screen string).

--- a/kernel/src/kernel/dos/machine/vga.rs
+++ b/kernel/src/kernel/dos/machine/vga.rs
@@ -19,7 +19,10 @@ use super::*;
 /// display ownership (foreground DOS owns the card, background threads run
 /// emulated) hangs off the same Platform type later.
 pub fn vga_present() -> bool {
-    crate::kernel::platform::get().display.vga_passthrough()
+    // No probe (bare-ELF dev path) ⇒ no card. Guards the console-VGA snapshot
+    // that thread-exit takes, which would otherwise trip `get`'s panic there.
+    crate::kernel::platform::probed()
+        && crate::kernel::platform::get().display.vga_passthrough()
 }
 
 // ============================================================================

--- a/kernel/src/kernel/platform.rs
+++ b/kernel/src/kernel/platform.rs
@@ -257,6 +257,14 @@ pub fn get() -> &'static Platform {
     }
 }
 
+/// Whether `probe` has run. The full disk-boot / windowed paths always probe;
+/// the minimal bare-ELF dev path (`host_run_elf`) does not. Lets the few
+/// pieces reachable from that path (console-VGA snapshot on thread exit) pick a
+/// sane default instead of tripping `get`'s panic-if-unprobed invariant.
+pub fn probed() -> bool {
+    unsafe { (&raw const PLATFORM).as_ref().unwrap().is_some() }
+}
+
 /// The audio probe is uniform across backends: an absent ISA device reads
 /// 0xFF (so no-SB is the same answer on the interpreter's port bus and on
 /// card-less metal), PCI config reads are 0xFFFFFFFF where there is no PCI,


### PR DESCRIPTION
`retroos-host FILE.elf` panicked `platform::get before platform::probe` on guest
`exit(0)`: thread teardown → `save_console_vga` → `dos::vga_present()` →
`platform::get()`, but the bare-ELF dev path never runs `platform::probe()`.

Masked twice until now: before the `active space missing` fix (#20) the program
crashed during *load* (never reached exit); after it, the ELF smoke asserted
only the greeting string — which prints *before* the exit panic.

**Fix:** add `platform::probed()`; `vga_present()` returns false when unprobed
(no card ⇒ skip the console-VGA snapshot). `get`'s panic-if-unprobed invariant
is preserved for genuine init-ordering bugs; disk-boot/windowed paths always
probe, so nothing changes there.

**Harden CI:** the hosted ELF smoke now asserts the greeting AND that no
`panicked` appears — so a crash behind program output can't read green again.

Verified: `hello.elf` exits code 0, no panic; `//:image` builds + boots to DN;
clippy clean (both configs); games PASS ×3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)