### PR TITLE
perf(arch-interp): materialize descriptors on swap, not every guest entry

### DIFF
--- a/arch-abi/src/arch.rs
+++ b/arch-abi/src/arch.rs
@@ -267,6 +267,11 @@ pub trait Arch: Sized + GuestBytes {
     fn map_vga_text_aperture(&mut self);
     /// Load the LDT (write base+limit into the GDT slot and `LLDT`).
     fn load_ldt(&mut self, ldt: &[u64]);
+    /// Notify the backend that the active thread's LDT descriptors changed
+    /// (a DPMI descriptor edit). Metal reads the live hardware LDT, so the
+    /// default is a no-op; the interpreter uses it to re-materialize its
+    /// software copy of the descriptor tables before the next guest entry.
+    fn on_ldt_changed(&mut self) {}
     /// Map a range of physical pages into user virtual space.
     fn map_phys_range(&mut self, vpage_start: usize, num_pages: usize, ppage_start: u64, flags: u64);
     /// Allocate `num_pages` physically contiguous, ISA-DMA-safe pages

--- a/arch-interp/src/backend.rs
+++ b/arch-interp/src/backend.rs
@@ -64,7 +64,14 @@ impl Arch for Interp {
         let old = core::mem::replace(&mut live.space, incoming);
         crate::engine::flush();
         crate::mmu::switch_to(live.space.0);
+        // A swap changes the active thread ⇒ its descriptor tables must be
+        // re-materialized before the next entry (catch-all for DOS and Linux).
+        crate::desc::mark_ldt_dirty();
         old
+    }
+
+    fn on_ldt_changed(&mut self) {
+        crate::desc::mark_ldt_dirty();
     }
 
     // ── Timer ──

--- a/arch-interp/src/cpu.rs
+++ b/arch-interp/src/cpu.rs
@@ -17,7 +17,7 @@
 //!   (a deterministic timer tick → `Irq`).
 
 use crate::sysdesc::{
-    ensure_sys_window, if_to_vif, sys_phys, sys_ptr, vif_to_if, write_tables, GDT_ADDR, GDT_BYTES,
+    ensure_sys_window, if_to_vif, sys_phys, sys_ptr, vif_to_if, ensure_tables, GDT_ADDR, GDT_BYTES,
     IF_FLAG, IOPL_MASK, KERNEL_CS, KERNEL_DS, LDT_ADDR, LDT_SEL, NT_FLAG, RING0_SP_TOP, SYS_BASE,
     SYS_SIZE, TF_FLAG, TRAMP_ADDR, VIF_FLAG, VM_FLAG,
 };
@@ -649,7 +649,7 @@ fn run_trampoline(uc: &mut Unicorn<'static, Ctx>, frame: &[u32], pre_segs: Optio
     w(uc, RegisterX86::SS, 0);
 
     // 2. Tables into the SYS frames; GDTR/LDTR at the PHYSICAL base while PG=0.
-    let ldt_limit = write_tables();
+    let ldt_limit = ensure_tables();
     set_mmr(uc, RegisterX86::GDTR, 0, sys_phys(GDT_ADDR), (GDT_BYTES - 1) as u32, 0);
     set_mmr(uc, RegisterX86::LDTR, LDT_SEL, sys_phys(LDT_ADDR), ldt_limit, 0x8200);
 

--- a/arch-interp/src/desc.rs
+++ b/arch-interp/src/desc.rs
@@ -42,6 +42,13 @@ struct Desc {
     ldt_len: usize,
     tls: [Tls; TLS_SLOTS],
     int_redir: [u8; 32],
+    // The SYS-frame GDT/LDT are arch's materialized copy of the ACTIVE thread's
+    // descriptors (persistent guest memory). `dirty` means they need a rewrite
+    // before the next guest entry; it is set on swap / descriptor edit / TLS
+    // change and cleared by `ensure_tables`. `ldt_limit` caches the last
+    // materialized LDTR limit so a clean entry needs no recompute.
+    ldt_limit: u32,
+    dirty: bool,
 }
 
 thread_local! {
@@ -51,6 +58,8 @@ thread_local! {
             ldt_len: 0,
             tls: [Tls { base: 0, limit: 0, present: false }; TLS_SLOTS],
             int_redir: INT_REDIR_INIT,
+            ldt_limit: 0,
+            dirty: true,
         })
     };
 }
@@ -61,18 +70,46 @@ pub fn int_intercepted(n: u8) -> bool {
     DESC.with(|d| d.borrow().int_redir[(n / 8) as usize] & (1 << (n % 8)) != 0)
 }
 
-/// The loaded LDT descriptors, copied out for programming the software CPU's
-/// LDT (cpu.rs writes these into a scratch table Unicorn reads as `env->ldt`).
-pub fn ldt_raw() -> std::vec::Vec<u64> {
+/// Copy the loaded LDT straight into the SYS LDT frame at `dst` (no heap), for
+/// `sysdesc::materialize`. Returns the LDTR limit. Mirrors the old `write_tables`
+/// cap of `LDT_MAX_BYTES/8` descriptors.
+pub(crate) fn copy_ldt_into(dst: *mut u8) -> u32 {
     DESC.with(|d| {
         let d = d.borrow();
         if d.ldt.is_null() {
-            return std::vec::Vec::new();
+            return 0;
         }
-        (0..d.ldt_len)
-            .map(|i| unsafe { core::ptr::read_unaligned(d.ldt.add(i)) })
-            .collect()
+        let n = d.ldt_len.min(crate::sysdesc::LDT_MAX_BYTES / 8);
+        for i in 0..n {
+            let desc = unsafe { core::ptr::read_unaligned(d.ldt.add(i)) };
+            unsafe {
+                core::ptr::copy_nonoverlapping(desc.to_le_bytes().as_ptr(), dst.add(i * 8), 8);
+            }
+        }
+        if n == 0 { 0 } else { (n * 8 - 1) as u32 }
     })
+}
+
+/// Mark the materialized descriptor tables stale (rewrite before next entry).
+/// Called on descriptor edits (`on_ldt_changed`) and thread swap (`activate`).
+pub fn mark_ldt_dirty() {
+    DESC.with(|d| d.borrow_mut().dirty = true);
+}
+
+/// Consume the dirty flag: true (and clear) if the tables need materializing.
+pub(crate) fn take_dirty() -> bool {
+    DESC.with(|d| {
+        let mut d = d.borrow_mut();
+        core::mem::replace(&mut d.dirty, false)
+    })
+}
+
+pub(crate) fn ldt_limit() -> u32 {
+    DESC.with(|d| d.borrow().ldt_limit)
+}
+
+pub(crate) fn set_ldt_limit(l: u32) {
+    DESC.with(|d| d.borrow_mut().ldt_limit = l);
 }
 
 /// Visit each present TLS slot as `(gdt_index, base, limit)` so cpu.rs can place
@@ -93,6 +130,7 @@ pub fn load_ldt(ldt: &[u64]) {
         let mut d = d.borrow_mut();
         d.ldt = ldt.as_ptr();
         d.ldt_len = ldt.len();
+        d.dirty = true; // new active LDT ⇒ re-materialize before next entry
     });
 }
 
@@ -105,6 +143,7 @@ pub fn set_tls_entry(index: i32, base: u32, limit: u32) -> i32 {
             d.tls.iter().position(|t| !t.present).unwrap_or(0)
         };
         d.tls[slot] = Tls { base, limit, present: true };
+        d.dirty = true; // GDT TLS slot changed ⇒ re-materialize
         (TLS_MIN + slot) as i32
     })
 }

--- a/arch-interp/src/kvm/run.rs
+++ b/arch-interp/src/kvm/run.rs
@@ -12,7 +12,7 @@
 use super::setup::{with, KvmCpu};
 use super::shim::{read_frame, ShimFrame, SHIM_PORT};
 use crate::sysdesc::{
-    if_to_vif, sys_ptr, vif_to_if, write_tables, GDT_ADDR, GDT_BYTES, IDT_ADDR, IOPL_MASK,
+    if_to_vif, sys_ptr, vif_to_if, ensure_tables, GDT_ADDR, GDT_BYTES, IDT_ADDR, IOPL_MASK,
     LDT_ADDR, LDT_SEL, NT_FLAG, TF_FLAG, TSS_ADDR, TSS_SEL, VIF_FLAG, VM_FLAG,
 };
 use arch_abi::monitor::MonitorResult;
@@ -110,7 +110,7 @@ fn decode_sel(sel: u16) -> kvm_segment {
 /// context, which is exactly the TLB flush the kernel's host-side page-table
 /// edits require before re-entry.
 fn enter(k: &mut KvmCpu, r: &Regs, mode: UserMode) {
-    let ldt_limit = write_tables();
+    let ldt_limit = ensure_tables();
 
     let mut sregs = k.sregs0;
     sregs.cr0 = 0x8000_0033; // PG | NE | ET | MP | PE (NE: VMX fixed-1; WP off like a 486)

--- a/arch-interp/src/sysdesc.rs
+++ b/arch-interp/src/sysdesc.rs
@@ -137,7 +137,10 @@ pub(crate) fn ensure_sys_window() {
 /// LDT (the kernel's active table) in the SYS-window frames. Returns the LDT
 /// byte limit (the GDTR/LDTR bases are set by the engine, which knows its
 /// paging phase). Writes go to the shared phys frames, not through the CPU.
-pub(crate) fn write_tables() -> u32 {
+/// Rebuild the GDT + LDT in the SYS frames from the active thread's descriptor
+/// state, caching the LDTR limit. Called only when the tables are dirty (thread
+/// swap / descriptor edit / TLS change) — NOT on every entry.
+fn materialize() {
     use arch_abi::{USER_CS, USER_DS};
     let mut gdt = [0u64; 32];
     gdt[(KERNEL_CS >> 3) as usize] = gdt_desc(0, 0xF_FFFF, 0x9A, 0xC); // ring-0 code32
@@ -159,11 +162,17 @@ pub(crate) fn write_tables() -> u32 {
         unsafe { core::ptr::copy_nonoverlapping(d.to_le_bytes().as_ptr(), gp.add(i * 8), 8); }
     }
 
-    let ldt = crate::desc::ldt_raw();
-    let n = ldt.len().min(LDT_MAX_BYTES / 8);
-    let lp = sys_ptr(LDT_ADDR);
-    for (i, d) in ldt.iter().take(n).enumerate() {
-        unsafe { core::ptr::copy_nonoverlapping(d.to_le_bytes().as_ptr(), lp.add(i * 8), 8); }
+    // LDT copied straight from the kernel's slice into the SYS frame — no heap.
+    let limit = crate::desc::copy_ldt_into(sys_ptr(LDT_ADDR));
+    crate::desc::set_ldt_limit(limit);
+}
+
+/// Return the LDTR limit, rebuilding the SYS-frame tables first iff they are
+/// dirty. The per-entry hook: a clean entry (the common render-loop case) does
+/// no table work at all, just returns the cached limit for LDTR programming.
+pub(crate) fn ensure_tables() -> u32 {
+    if crate::desc::take_dirty() {
+        materialize();
     }
-    if n == 0 { 0 } else { (n * 8 - 1) as u32 }
+    crate::desc::ldt_limit()
 }

--- a/kernel/src/kernel/dos/dpmi/mod.rs
+++ b/kernel/src/kernel/dos/dpmi/mod.rs
@@ -165,6 +165,9 @@ pub(in crate::kernel::dos) fn dpmi_enter<A: crate::Arch>(machine: &mut A, dos: &
     dos_trace!("[DPMI] ENTER -> pm cs:eip={:04X}:{:08X} ss:esp={:04X}:{:08X} ds={:04X} es={:04X}",
         regs.code_seg(), regs.ip32(), regs.stack_seg(), regs.sp32(),
         regs.ds as u16, regs.es as u16);
+    // Client CS/DS/SS descriptors were written into the LDT above — the backend
+    // must re-materialize its descriptor tables before the next entry.
+    machine.on_ldt_changed();
 }
 
 // PM #GP monitor lives in `arch/monitor.rs`. The arch decoder handles
@@ -180,7 +183,18 @@ pub(in crate::kernel::dos) fn dpmi_enter<A: crate::Arch>(machine: &mut A, dos: &
 /// PM client-initiated INT 31h — the DPMI service API, dispatched by AX.
 /// Caller (`dos::syscall`) has already classified the trap as client-side
 /// (CS not in the kernel's stub LDT slots).
+///
+/// Wrapper: any INT 31h handler may edit the LDT (descriptor alloc / set base /
+/// set limit), so unconditionally tell the backend to re-materialize its
+/// descriptor tables after dispatch — cheap (INT 31h is rare vs guest
+/// instructions) and catches every early-return path in the inner dispatch.
 pub(super) fn dpmi_api<A: crate::Arch>(machine: &mut A, dos: &mut thread::DosState<A>, regs: &mut Regs) -> thread::KernelAction {
+    let action = dpmi_api_inner(machine, dos, regs);
+    machine.on_ldt_changed();
+    action
+}
+
+fn dpmi_api_inner<A: crate::Arch>(machine: &mut A, dos: &mut thread::DosState<A>, regs: &mut Regs) -> thread::KernelAction {
     let dpmi = match dos.dpmi.as_mut() {
         Some(d) => d,
         None => {


### PR DESCRIPTION
`perf` on hosted (`retroos-host --host /`) showed **~48% of CPU** was
re-materializing the GDT/LDT into the SYS frame on *every* guest entry:
`desc::ldt_raw` (32% — heap-allocates a fresh `Vec<u64>` of the whole LDT per
call) + `__memset` + `sysdesc::write_tables`. The SYS-frame tables are arch's
materialized copy of the **active** thread's descriptors, in persistent
guest-physical memory — they only need rewriting when they change.

## Model
A `dirty` flag (defaults **true**) marked on every descriptor change, with the
tables materialized **lazily on entry**. The render loop (no swap, no INT 31h)
stays clean → the copy is skipped entirely.

- `desc.rs`: `Desc.{ldt_limit, dirty}`; `mark_ldt_dirty`/`take_dirty`/`copy_ldt_into`
  (direct copy, **no `Vec`**); `load_ldt`+`set_tls_entry` mark dirty;
  **`ldt_raw` deleted**.
- `sysdesc.rs`: `write_tables` → private `materialize()` + gated `ensure_tables()`.
- `cpu.rs` / `kvm/run.rs`: entry calls `ensure_tables()` (both engines share the path).
- `backend.rs`: `activate()` marks dirty (swap catch-all, DOS+Linux); `on_ldt_changed()`.
- `arch-abi`: defaulted `on_ldt_changed(){}` (arch-metal inherits the no-op — real HW LDT).
- `dpmi/mod.rs`: `machine.on_ldt_changed()` at every exit of `dpmi_enter`/`dpmi_api`.

**Correctness:** first entry → default-dirty; swap → `activate`; DPMI edit →
`on_ldt_changed` at the dispatch boundary; TLS → `set_tls_entry`. Persistent SYS
frames mean a skipped copy leaves the correct tables resident; LDTR/GDTR register
programming stays per-entry.

## Verified (independently rebuilt + re-profiled)
- Hosted + `//:image` + `-kvm` build; clippy clean (metal + host); metal boots to DN.
- Games PASS ×3 including **DOOM** (DPMI/protected-mode — the LDT test).
- `perf`: `ldt_raw` **32% → gone**; `write_tables`/`materialize` absent from the
  profile (run only on swap/DPMI). Total CPU down ~⅓.

Follow-up (separate): the new top cost is TCG's software MMU — `memset` +
`flatview_translate`/`find_memory_mapping`/`tb_invalidate` — inherent emulation
overhead, not the descriptor path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)