### PR TITLE
fix(sound): OPL note retrigger + card-accurate SB/GUS mix balance

### DIFF
--- a/kernel/src/kernel/dos/machine/mod.rs
+++ b/kernel/src/kernel/dos/machine/mod.rs
@@ -854,7 +854,7 @@ impl PcmSource<'_> {
         rate: u32,
         base: u64,
         dsp_base: u64,
-        block: &mut [(i16, i16)],
+        block: &mut [(i32, i32)],
     ) {
         match self {
             Self::SoundBlaster(sb) => sb.mix_into(machine, rate, dsp_base, block),
@@ -872,6 +872,11 @@ const MIX_CANON: crate::kernel::sound::Format = crate::kernel::sound::Format {
 
 /// Frames per pump chunk (bounded stack buffers; a due burst loops).
 const MIX_CHUNK: usize = 128;
+
+/// The mix's one and only clip point.
+fn sat16(v: i32) -> i16 {
+    v.clamp(i16::MIN as i32, i16::MAX as i32) as i16
+}
 
 /// The canonical mix clock. Fixed, and deliberately *not* borrowed from
 /// whichever device happens to be loudest: a DOS game commonly plays 11 kHz
@@ -960,7 +965,14 @@ pub fn audio_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mu
     let rate = MIX_RATE;
     let mut n = mixer.pace.due(machine, rate, dt, MIX_CHUNK);
     let mut base = mixer.pace.pushed() - n;
-    let mut frames = [(0i16, 0i16); MIX_CHUNK];
+    // Sources sum into a WIDE accumulator and the mix is clipped exactly once,
+    // here, on the way out. Saturating each i16 add per source (what we used to
+    // do) clips every source against every other one: a full-scale digital SFX
+    // played over FM music pinned the sum at the rail and flat-topped the music
+    // with it. Each source carries its own card-accurate scale (see vsb.rs's
+    // FM_SCALE_Q16 / DAC_SCALE_Q16 / GUS_SCALE_Q16), which is where the
+    // headroom lives, so the clamp below is a backstop, not the normal path.
+    let mut frames = [(0i32, 0i32); MIX_CHUNK];
     let mut bytes = [0u8; MIX_CHUNK * 4];
     while n > 0 {
         let run = MIX_CHUNK;
@@ -971,6 +983,8 @@ pub fn audio_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mu
             source.mix_into(machine, rate, base, dsp_base, &mut frames[..run]);
         }
         for (i, (l, r)) in frames[..run].iter().enumerate() {
+            let l = sat16((l * vsb::OUTPUT_GAIN_Q16) >> 16);
+            let r = sat16((r * vsb::OUTPUT_GAIN_Q16) >> 16);
             bytes[i * 4..i * 4 + 2].copy_from_slice(&l.to_le_bytes());
             bytes[i * 4 + 2..i * 4 + 4].copy_from_slice(&r.to_le_bytes());
         }

--- a/kernel/src/kernel/dos/machine/opl.rs
+++ b/kernel/src/kernel/dos/machine/opl.rs
@@ -27,6 +27,12 @@ pub(super) const NATIVE_RATE: u32 = 49_716;
 /// all envelopes released — drivers pause between notes and between songs.
 const HANGOVER_MS: u64 = 2_000;
 
+/// Ceiling on queued-but-unapplied register writes (see `pending`). Deep
+/// enough for any real driver's init burst (a full 22-register instrument
+/// load is ~90 writes); a write storm past this gives up the inter-write
+/// gap rather than the write, so the queue can never grow without bound.
+const PENDING_MAX: usize = 4_096;
+
 /// What a guest-visible FM port decodes to.
 pub(super) enum OplPort {
     /// Address latch write; the payload is the register file (bank) the
@@ -74,6 +80,25 @@ pub(super) struct OplFm {
     mix_acc: u32,
     /// Last native frame generated (zero-order hold for `mix`).
     hold: (i16, i16),
+    /// Guest register writes not yet handed to the chip, released one per
+    /// generated frame by `mix_into`.
+    ///
+    /// The chip does not retrigger a note on the key-on write itself: a write
+    /// only flips the slot's `key` bit. The attack is armed inside the chip's
+    /// per-sample envelope step, which fires only when it observes `key != 0`
+    /// while the envelope is already in RELEASE — and RELEASE is itself set by
+    /// an *earlier* per-sample step that saw `key == 0`. A note therefore
+    /// re-attacks only if at least one frame is generated between the driver's
+    /// key-off and its key-on.
+    ///
+    /// Real silicon is clocked continuously at `NATIVE_RATE`, so two OUTs are
+    /// always ≥1 frame apart and that always holds. Our chip is clocked only by
+    /// the mixer pump, so every write inside one pump window would otherwise
+    /// land between the same two frames: a driver that writes key-off, fnum,
+    /// key-on back-to-back (the usual shape) would never re-attack, and the
+    /// note would hang at its sustain level — audible as music that keeps its
+    /// melody but collapses to a fraction of its volume.
+    pending: alloc::collections::VecDeque<(u16, u8)>,
 }
 
 impl OplFm {
@@ -89,6 +114,7 @@ impl OplFm {
             last_write_ms: now,
             mix_acc: 0,
             hold: (0, 0),
+            pending: alloc::collections::VecDeque::new(),
         }
     }
 
@@ -128,7 +154,11 @@ impl OplFm {
                     }
                     return;
                 }
-                self.chip.write_register(self.index, val);
+                if self.pending.len() >= PENDING_MAX {
+                    let (reg, val) = self.pending.pop_front().unwrap();
+                    self.chip.write_register(reg, val);
+                }
+                self.pending.push_back((self.index, val));
             }
         }
     }
@@ -138,6 +168,7 @@ impl OplFm {
     /// The mixer pump keeps the canonical stream open while this holds.
     pub(super) fn audible(&self, now: u64) -> bool {
         self.chip.active_voice_count() > 0
+            || !self.pending.is_empty()
             || now.saturating_sub(self.last_write_ms) < HANGOVER_MS
     }
 }
@@ -145,27 +176,42 @@ impl OplFm {
 /// The mixer pump pulls FM through the canonical mix-source shape.
 impl OplFm {
     /// Voices-only (no write hangover): a silent chip mixes silence — skip
-    /// the work. (`audible` decides whether the *stream* stays open.)
+    /// the work. (`audible` decides whether the *stream* stays open.) Queued
+    /// writes also count: the queue drains a frame at a time from `mix_into`,
+    /// so a chip whose only pending work is a key-on must still be pumped or
+    /// the write would never reach it.
     pub(super) fn mixing(&self) -> bool {
-        self.chip.active_voice_count() > 0
+        self.chip.active_voice_count() > 0 || !self.pending.is_empty()
     }
 
     /// Add FM at the pump's rate: per output frame advance the chip by the
     /// corresponding number of native frames (zero-order hold on the last),
-    /// summing saturating. No sub-block events: the OPL's guest-visible
-    /// timers run on virtual time, not the stream.
-    pub(super) fn mix_into<A: crate::Arch>(&mut self, _machine: &mut A, rate: u32, _base: u64, block: &mut [(i16, i16)]) {
+    /// summing saturating. Each native frame first releases one queued guest
+    /// write, which is what keeps consecutive writes ≥1 frame apart — see
+    /// `pending`. No sub-block events: the OPL's guest-visible timers run on
+    /// virtual time, not the stream.
+    pub(super) fn mix_into<A: crate::Arch>(
+        &mut self,
+        _machine: &mut A,
+        rate: u32,
+        _base: u64,
+        block: &mut [(i32, i32)],
+        gain_q16: (i32, i32),
+    ) {
         let rate = rate.max(4_000); // guest-programmed; never let it stall us
         let mut pair = [0i16; 2];
         for slot in block.iter_mut() {
             self.mix_acc += NATIVE_RATE;
             while self.mix_acc >= rate {
                 self.mix_acc -= rate;
+                if let Some((reg, val)) = self.pending.pop_front() {
+                    self.chip.write_register(reg, val);
+                }
                 let _ = self.chip.generate(&mut pair);
                 self.hold = (pair[0], pair[1]);
             }
-            slot.0 = slot.0.saturating_add(self.hold.0);
-            slot.1 = slot.1.saturating_add(self.hold.1);
+            slot.0 += (self.hold.0 as i32 * gain_q16.0) >> 16;
+            slot.1 += (self.hold.1 as i32 * gain_q16.1) >> 16;
         }
     }
 }

--- a/kernel/src/kernel/dos/machine/vgus.rs
+++ b/kernel/src/kernel/dos/machine/vgus.rs
@@ -802,7 +802,7 @@ impl Gus {
     /// exact session frame they occur at and queued for [`Gus::deliver_events`]
     /// — they become guest-visible when that frame *plays*, not when it is
     /// generated `fill` early.
-    pub(super) fn mix_into<A: crate::Arch>(&mut self, _machine: &mut A, rate: u32, base: u64, block: &mut [(i16, i16)]) {
+    pub(super) fn mix_into<A: crate::Arch>(&mut self, _machine: &mut A, rate: u32, base: u64, block: &mut [(i32, i32)]) {
         if !self.mixing() {
             return;
         }
@@ -814,8 +814,11 @@ impl Gus {
         for (i, slot) in block.iter_mut().enumerate() {
             let mut ev = sampler::Events::default();
             let (l, r) = c.engine.mix_frame(&c.dram, native, rate, &mut ev);
-            slot.0 = slot.0.saturating_add(l);
-            slot.1 = slot.1.saturating_add(r);
+            // Unity — the GF1's output is the mixer's reference level (86Box
+            // `gus_get_buffer` adds it straight in) and the GUS has no guest
+            // master volume; the per-voice ramps already carry it.
+            slot.0 += (l * super::vsb::GUS_SCALE_Q16) >> 16;
+            slot.1 += (r * super::vsb::GUS_SCALE_Q16) >> 16;
             if ev.any() {
                 let at = base + i as u64;
                 match c.events.back_mut() {

--- a/kernel/src/kernel/dos/machine/vsb.rs
+++ b/kernel/src/kernel/dos/machine/vsb.rs
@@ -39,6 +39,143 @@ const PTE_CACHE_DISABLE: u64 = 1 << 4;
 /// buffer programming into canonical PCM (`sound::play`), paced by the sink's
 /// real playback position (virtual time where the sink has no clock), raising
 /// the SB IRQ once per completed DMA block exactly like the real card's
+/// CT1745 (SB16) mixer attenuation table: a 5-bit level in bits 7:3 of the
+/// volume register, 2 dB per step, as a linear amplitude out of 32767. Taken
+/// verbatim from 86Box `src/sound/snd_sb.c` (`sb_att_2dbstep_5bits`), whose
+/// comment notes the 32767 ceiling deliberately leaves ~6 dB of headroom.
+const ATT_2DB_5BIT: [u16; 32] = [
+    25, 32, 41, 51, 65, 82, 103, 130, 164, 206,
+    260, 327, 412, 519, 653, 822, 1036, 1304, 1641, 2067,
+    2602, 3276, 4125, 5192, 6537, 8230, 10362, 13044, 16422, 20674,
+    26027, 32767,
+];
+
+/// Fixed source scales on the card's analog summing node, in Q16. These — not
+/// the mixer registers — set the FM-vs-DAC balance, and both cards' power-on
+/// mixer defaults are *full* volume, so these are what you hear by default.
+/// From 86Box's SB16 mix (`sb_get_buffer_sb16_awe32` / `sb_get_music_buffer_sb16_awe32`):
+///
+/// ```text
+///   DAC: dsp.buffer * voice * master / 3.0
+///   FM : opl_buf    * fm    * master * 0.7171630859375
+/// ```
+///
+/// So FM sits **2.15x above** the DAC at equal digital full scale. Summing both
+/// at unity (what we did before) therefore ran digital SFX ~9.5 dB too hot
+/// against FM music, and pinned the sum at the clipping rail whenever a
+/// full-scale sample played over a track.
+const FM_SCALE_Q16: i32 = 47_000; // 0.7171630859375 == 47000/65536, exactly
+const DAC_SCALE_Q16: i32 = 65_536 / 3;
+
+/// Unity. The GF1's own output is the mixer's reference level (86Box
+/// `gus_get_buffer` adds `gus->buffer[]` straight into the mix), and the
+/// GUS has no guest-visible master volume — the GF1's per-voice volume ramps
+/// already carry it.
+pub(super) const GUS_SCALE_Q16: i32 = 65_536;
+
+/// One knob for overall loudness, applied to the summed mix just before the
+/// single clip. Unity: the headroom already lives in the per-source scales
+/// above (that is exactly what the 32767 table ceiling buys), so rescaling
+/// here would only trade it away. This is the place to change if the whole
+/// machine should be louder or quieter.
+pub(super) const OUTPUT_GAIN_Q16: i32 = 65_536;
+
+/// Combine two Q16 gains without overflowing i32 on the way.
+const fn combine_q16(a: i32, b: i32) -> i32 {
+    ((a as i64 * b as i64) >> 16) as i32
+}
+
+/// The CT1745 (SB16) mixer register file.
+///
+/// Every volume register is a 5-bit level in bits 7:3 (2 dB/step, see
+/// [`ATT_2DB_5BIT`]). The older register maps are *aliases*, exactly as on the
+/// real chip: an SB Pro game writing 0x22/0x04/0x26 and an SB1/2 game writing
+/// 0x02/0x06 both land in the same 0x30-0x35 pairs, so one code path serves
+/// every generation. Games really do set these — they were previously accepted
+/// and dropped, so a game turning its SFX down changed nothing.
+#[derive(Clone, Copy)]
+pub(super) struct SbMixer {
+    regs: [u8; 256],
+}
+
+impl SbMixer {
+    /// Power-on state. `const`: the whole `EmuDsp` is built in a const fn, so
+    /// the defaults are spelled out here rather than via `reset()`.
+    pub(super) const fn new() -> Self {
+        let mut regs = [0u8; 256];
+        regs[0x30] = 0xF8; regs[0x31] = 0xF8; // master L/R
+        regs[0x32] = 0xF8; regs[0x33] = 0xF8; // voice  L/R
+        regs[0x34] = 0xF8; regs[0x35] = 0xF8; // FM     L/R
+        regs[0x36] = 0xF8; regs[0x37] = 0xF8; // CD     L/R
+        regs[0x3B] = 0x80;                    // PC speaker
+        regs[0x04] = 0xEE; regs[0x22] = 0xEE; // legacy views of the same levels
+        regs[0x26] = 0xEE; regs[0x28] = 0xEE;
+        SbMixer { regs }
+    }
+
+    /// Power-on / mixer-index-0 reset. Defaults are 86Box's `sb_ct1745_mixer_reset`:
+    /// master, voice, FM and CD all at maximum (0xF8 → level 31 → unity), line/mic
+    /// muted. A game that never touches the mixer gets full volume — which is why
+    /// the FM/DAC balance has to come from the fixed scales, not from these.
+    pub(super) fn reset(&mut self) {
+        *self = SbMixer::new();
+    }
+
+    pub(super) fn read(&self, index: u8) -> u8 {
+        self.regs[index as usize]
+    }
+
+    pub(super) fn write(&mut self, index: u8, val: u8) {
+        if index == 0x00 {
+            self.reset();
+            return;
+        }
+        self.regs[index as usize] = val;
+        // Legacy maps alias into the SB16 pairs (86Box snd_sb.c, CT1745 write).
+        // `| 0x8` is the chip's low-bit fill when a coarser register is widened
+        // into the 5-bit one. SB1/2 (0x02/0x06) carry one mono nibble in bits
+        // 3:0; SB Pro (0x22/0x04/0x26) carry L in bits 7:4 and R in bits 3:0.
+        let mono = ((val & 0x0F) << 4) | 0x8;
+        let left = (val & 0xF0) | 0x8;
+        let right = ((val & 0x0F) << 4) | 0x8;
+        match index {
+            0x02 => { self.regs[0x30] = mono; self.regs[0x31] = mono; }      // SB1/2 master
+            0x06 => { self.regs[0x34] = mono; self.regs[0x35] = mono; }      // SB1/2 FM
+            0x08 => { self.regs[0x36] = mono; self.regs[0x37] = mono; }      // SB1/2 CD
+            0x22 => { self.regs[0x30] = left; self.regs[0x31] = right; }     // SB Pro master
+            0x04 => { self.regs[0x32] = left; self.regs[0x33] = right; }     // SB Pro voice
+            0x26 => { self.regs[0x34] = left; self.regs[0x35] = right; }     // SB Pro FM
+            0x28 => { self.regs[0x36] = left; self.regs[0x37] = right; }     // SB Pro CD
+            _ => {}
+        }
+    }
+
+    /// Linear gain (Q16, unity = 65536) for a CT1745 volume register.
+    fn level_q16(&self, reg: usize) -> i32 {
+        // The table is an amplitude out of 32767; 86Box divides by 32768, so
+        // Q16 gain is simply the entry doubled.
+        ATT_2DB_5BIT[(self.regs[reg] >> 3) as usize] as i32 * 2
+    }
+
+    /// (left, right) Q16 gain the DSP's PCM is summed at: voice × master ÷ 3.
+    pub(super) fn voice_gain_q16(&self) -> (i32, i32) {
+        let m = (self.level_q16(0x30), self.level_q16(0x31));
+        (
+            combine_q16(combine_q16(self.level_q16(0x32), m.0), DAC_SCALE_Q16),
+            combine_q16(combine_q16(self.level_q16(0x33), m.1), DAC_SCALE_Q16),
+        )
+    }
+
+    /// (left, right) Q16 gain the FM synth is summed at: fm × master × 0.7172.
+    pub(super) fn fm_gain_q16(&self) -> (i32, i32) {
+        let m = (self.level_q16(0x30), self.level_q16(0x31));
+        (
+            combine_q16(combine_q16(self.level_q16(0x34), m.0), FM_SCALE_Q16),
+            combine_q16(combine_q16(self.level_q16(0x35), m.1), FM_SCALE_Q16),
+        )
+    }
+}
+
 /// terminal count. See [`SoundBlaster::audio_tick`].
 #[derive(Clone, Copy)]
 struct EmuDsp {
@@ -60,6 +197,8 @@ struct EmuDsp {
     test_reg: u8,
     /// SB16 mixer register index (port base+4 write); its data port is base+5.
     mixer_index: u8,
+    /// CT1745 mixer register file — the guest's volume settings (see `SbMixer`).
+    mixer: SbMixer,
     /// Mixer reg 0x82 IRQ status: bit0 = 8-bit DMA IRQ pending, bit1 = 16-bit.
     /// Set when the SB IRQ is raised (by playback width); cleared when the guest
     /// acks (reads base+0xE for 8-bit / base+0xF for 16-bit). A 16-bit driver
@@ -149,7 +288,7 @@ impl EmuDsp {
             out: [0; 4], out_len: 0,
             cmd: None, params: [0; 3], param_got: 0, param_need: 0,
             reset_prev: 0, test_reg: 0,
-            mixer_index: 0, irq_status: 0, trigger_irq: 0,
+            mixer_index: 0, mixer: SbMixer::new(), irq_status: 0, trigger_irq: 0,
             playing: false, rate: 22050, bits: 8, stereo: false, block_param: 0,
             single: false,
             buf_gpa: 0, buf_frames: 0, block_frames: 0,
@@ -742,7 +881,9 @@ impl SoundBlaster {
                     2 | 9 => 0x01, 5 => 0x02, 7 => 0x04, 10 => 0x08, _ => 0x04,
                 },
                 0x81 => (1u8 << (self.dma8 & 7)) | (1u8 << (self.dma16 & 7)), // DMA select
-                _ => 0x00,
+                // Everything else is the mixer register file: a game that
+                // read-modify-writes a volume must see back what it set.
+                i => self.emu.mixer.read(i),
             },
             0x0A => self.emu.pop_out(),                // DSP read data
             // DSP write-buffer status: while a single-cycle transfer is in
@@ -794,7 +935,7 @@ impl SoundBlaster {
         }
         match p.wrapping_sub(self.io_base) {
             0x04 => self.emu.mixer_index = val, // mixer register select
-            0x05 => {}                          // mixer data: no mixing modeled
+            0x05 => self.emu.mixer.write(self.emu.mixer_index, val), // mixer data
             0x06 => {
                 // DSP reset: a 1→0 edge triggers the reset handshake.
                 if self.emu.reset_prev == 1 && val == 0 {
@@ -1031,11 +1172,12 @@ impl SoundBlaster {
     }
 
     /// Add the FM synth's frames into the pump block (no-op when silent).
-    fn mix_fm_into<A: crate::Arch>(&mut self, machine: &mut A, rate: u32, base: u64, block: &mut [(i16, i16)]) {
+    fn mix_fm_into<A: crate::Arch>(&mut self, machine: &mut A, rate: u32, base: u64, block: &mut [(i32, i32)]) {
+        let (gl, gr) = self.emu.mixer.fm_gain_q16();
         if let Some(opl) = self.opl.as_mut()
             && opl.mixing()
         {
-            opl.mix_into(machine, rate, base, block);
+            opl.mix_into(machine, rate, base, block, (gl, gr));
         }
     }
 
@@ -1045,7 +1187,7 @@ impl SoundBlaster {
     /// the commit horizon (one ring lap beyond the last *serviced* block,
     /// floored at the next boundary: an unserviced ring keeps cycling and
     /// replays, exactly like the real card) stay silent.
-    fn mix_dsp_into<A: crate::Arch>(&mut self, machine: &mut A, rate: u32, base: u64, block: &mut [(i16, i16)]) {
+    fn mix_dsp_into<A: crate::Arch>(&mut self, machine: &mut A, rate: u32, base: u64, block: &mut [(i32, i32)]) {
         if !self.emu.playing || rate == 0 {
             return; // idle or hangover: the pump's zeros are our silence
         }
@@ -1064,6 +1206,7 @@ impl SoundBlaster {
         // to the DSP frame playing at that instant (zero-order hold — the
         // same thing the sink used to do one stage later, minus the rest of
         // the mix getting dragged down to the DSP's bandwidth with it).
+        let (gl, gr) = self.emu.mixer.voice_gain_q16();
         let dsp_rate = self.emu.rate.max(1) as u64;
         let committed = self.committed_end();
         let first = base * dsp_rate / rate as u64;
@@ -1097,8 +1240,8 @@ impl SoundBlaster {
                 break;
             }
             let (l, r) = fmt.frame(&scratch, (src - first) as usize);
-            slot.0 = slot.0.saturating_add(l);
-            slot.1 = slot.1.saturating_add(r);
+            slot.0 += (l as i32 * gl) >> 16;
+            slot.1 += (r as i32 * gr) >> 16;
         }
     }
 
@@ -1108,7 +1251,7 @@ impl SoundBlaster {
         machine: &mut A,
         rate: u32,
         base: u64,
-        block: &mut [(i16, i16)],
+        block: &mut [(i32, i32)],
     ) {
         self.mix_dsp_into(machine, rate, base, block);
         self.mix_fm_into(machine, rate, base, block);

--- a/lib/sampler/src/lib.rs
+++ b/lib/sampler/src/lib.rs
@@ -46,7 +46,8 @@ pub struct Engine {
     /// [`mix_frame`](Engine::mix_frame).
     mix_acc: u32,
     /// Last native frame generated (zero-order hold for `mix_frame`).
-    hold: (i16, i16),
+    /// Unclipped: the final mixer owns the one clip point (see `step`).
+    hold: (i32, i32),
 }
 
 impl Engine {
@@ -90,8 +91,8 @@ impl Engine {
     pub fn generate(&mut self, mem: &[u8], out: &mut [i16], ev: &mut Events) {
         for frame in out.chunks_exact_mut(2) {
             let (l, r) = self.step(mem, ev);
-            frame[0] = l;
-            frame[1] = r;
+            frame[0] = sat16(l);
+            frame[1] = sat16(r);
         }
     }
 
@@ -104,7 +105,7 @@ impl Engine {
         native_rate: u32,
         out_rate: u32,
         ev: &mut Events,
-    ) -> (i16, i16) {
+    ) -> (i32, i32) {
         let out_rate = out_rate.max(4_000); // caller-programmed; never stall
         self.mix_acc += native_rate;
         while self.mix_acc >= out_rate {
@@ -115,8 +116,13 @@ impl Engine {
     }
 
     /// One native frame: fetch/advance every participating voice, tick its
-    /// ramp, sum saturating.
-    fn step(&mut self, mem: &[u8], ev: &mut Events) -> (i16, i16) {
+    /// ramp, sum into the wide accumulator.
+    ///
+    /// Returned UNCLIPPED. 32 GF1 voices summing at full ramp overflow i16
+    /// easily, and clipping here — before the final mixer has applied its
+    /// master attenuation — would flat-top the wave permanently. The pump owns
+    /// the single clip point.
+    fn step(&mut self, mem: &[u8], ev: &mut Events) -> (i32, i32) {
         let n = (self.active as usize).min(MAX_VOICES);
         let (mut al, mut ar) = (0i32, 0i32);
         for vi in 0..n {
@@ -137,7 +143,7 @@ impl Engine {
                 ramp_tick(v, vi, ev);
             }
         }
-        (sat16(al), sat16(ar))
+        (al, ar)
     }
 }
 

--- a/lib/sampler/src/tests.rs
+++ b/lib/sampler/src/tests.rs
@@ -309,6 +309,16 @@ fn mix_frame_zoh_matches_decimated_generate() {
     for k in 0..16 {
         let (l, r) = a.mix_frame(&mem, 44100, 11025, &mut ev);
         let native = k * 4 + 3; // 4 native frames per pull; hold = the last
-        assert_eq!((l, r), (full[native * 2], full[native * 2 + 1]), "pull {k}");
+        // What's under test is that the ZOH pull lands on the same native frame
+        // as the decimated `generate`. `mix_frame` is now unclipped (the final
+        // mixer owns the one clip point) while `generate` still saturates, and
+        // this fixture's voices do sum past i16 — so compare through the same
+        // saturation rather than against the raw accumulator.
+        let sat = |v: i32| v.clamp(i16::MIN as i32, i16::MAX as i32) as i16;
+        assert_eq!(
+            (sat(l), sat(r)),
+            (full[native * 2], full[native * 2 + 1]),
+            "pull {k}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two defects in the emulated SB/OPL/GUS audio path, both surfacing as wrong loudness.

### 1. FM notes never re-attacked
nuked-opl3 arms a note's attack inside its **per-sample** envelope step (it sees `key==0` → RELEASE on one sample, then `key!=0` while RELEASE on the next), so a retrigger needs ≥1 generated sample between the driver's key-off and key-on. Real silicon is clocked continuously; our chip was clocked only by the mixer pump, so every register write in a pump window landed between the same two samples and a `key-off / fnum / key-on` burst never retriggered — the note hung at its instrument's **sustain level**. Music kept its melody but collapsed to a fraction of its volume (SkyRoads' menu sat at −21 dB).

Fixed by queueing guest writes and releasing one per generated frame.

### 2. No mix balance and no headroom
Mixer volume registers were accepted and dropped, and all sources summed at unity with saturating `i16` adds. A full-scale 8-bit DSP sample is the entire output range while FM peaks far lower, so digital SFX ran ~9.5 dB hot and **pinned the sum at the clipping rail** over music (Doom and SkyRoads both clipped).

- Implement the CT1745 mixer (`SbMixer`) with 86Box's 2 dB/step attenuation table and legacy-register aliasing (SB1/2 + SB Pro maps alias into the SB16 pairs, as on the real chip).
- Apply the card's fixed source scales — `DAC × voice × master / 3`, `FM × fm × master × 0.7172`, `GUS` unity — so FM sits **2.15× above the DAC**, exactly as hardware does.
- Sources now sum into an `i32` accumulator clipped **once** at the pump output (this also required widening the GUS sampler, which was clipping to `i16` internally, a second hidden clip point).
- `OUTPUT_GAIN_Q16` is the single overall-loudness knob, at unity.

Constants sourced from 86Box `snd_sb.c` / `snd_gus.c`.

## Verification

| | peak | clipped |
|---|---|---|
| SkyRoads intro (FM+DSP) before | 32768 | 597 |
| SkyRoads intro after | 15089 | **0** |
| Doom (GUS music + SB SFX) before | 32768 | 167 |
| Doom after | 12847 | **0** |

SkyRoads menu no longer collapses to sustain level. `//arch-interp:all` and `//lib:sampler_test` pass; metal kernel and `//:image` build.

**Not yet verified**: the real COMMAND.COM + LOADFIX.CFG shell launch path — all checks used `--cmd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)