### PR TITLE
Volatile RAM write-overlay for real-hardware boots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The ~14 GB runner disk is the CI's real constraint: the restored bazel
+      # disk cache + rust toolchain fetch + build outputs overflowed it, and a
+      # full disk fails in maximally confusing ways (build_tar exit 1 with no
+      # message on master; "No space left on device" mid-toolchain-fetch here).
+      # Drop the preinstalled toolchains this build never uses (~10+ GB back).
+      - name: Free runner disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+            /usr/local/share/boost /opt/hostedtoolcache/CodeQL
+          df -h /
+
       # `nasm` for the apps/tests `.COM` genrules (apps/tests/*/BUILD.bazel shell
       # out to system nasm; the bootloader uses hermetic rules_nasm instead).
       # ubuntu-latest doesn't ship nasm, so //:image's analysis fails without it.
@@ -97,3 +108,22 @@ jobs:
       # New tests are wired up by adding a line to test/run_all.sh.
       - name: End-to-end tests
         run: test/run_all.sh
+
+      # Cap the disk cache BEFORE the post-job cache save: it only ever grows
+      # (every lockfile bump saves a bigger cache under a new key), and once
+      # restored-cache + toolchains + outputs exceed the runner disk, builds
+      # die with ENOSPC in whatever action happens to write next. Keep the
+      # newest ~3 GiB by access time; drop the tail.
+      - name: Trim bazel disk cache
+        if: always()
+        run: |
+          if [ -d ~/.cache/bazel-disk ]; then
+            du -sh ~/.cache/bazel-disk || true
+            # Cache entries are content-hash filenames — no spaces, plain text safe.
+            find ~/.cache/bazel-disk -type f -printf '%A@ %s %p\n' 2>/dev/null | \
+              sort -rn | \
+              awk -v budget=$((3*1024*1024*1024)) '{tot+=$2; if (tot>budget) print $3}' | \
+              xargs -r rm -f
+            du -sh ~/.cache/bazel-disk || true
+          fi
+          df -h /

--- a/kernel/src/kernel/block.rs
+++ b/kernel/src/kernel/block.rs
@@ -7,6 +7,7 @@
 //!     emulated controller) — probed first, bounded, no hang on absent ports.
 //!   - NVMe (UEFI-class machines: the run_uefi.sh mock, modern laptops).
 
+use alloc::{boxed::Box, collections::BTreeMap};
 use core::sync::atomic::{AtomicU8, Ordering};
 use crate::kernel::{hdd, nvme};
 use lib::println;
@@ -16,6 +17,29 @@ const ATA: u8 = 1;
 const NVME: u8 = 2;
 
 static KIND: AtomicU8 = AtomicU8::new(NONE);
+
+/// Volatile write overlay — the real-hardware safety net. When armed (real
+/// metal, where the disk is someone's actual home partition), `write_sectors`
+/// diverts every sector into this kernel-heap map and `read_sectors` patches
+/// them back over the device reads: the filesystems above stay fully writable
+/// (lwext4 journals, savegames, configs), but the device itself is never
+/// written and power-off discards everything. QEMU/hosted runs — where the
+/// disk is a disposable image file — leave it unarmed and write through.
+///
+/// Single kernel thread (same invariant as the fs layer above); accessed via
+/// `&raw mut` like the other kernel statics.
+static mut OVERLAY: Option<BTreeMap<u32, Box<[u8; 512]>>> = None;
+
+fn overlay() -> &'static mut Option<BTreeMap<u32, Box<[u8; 512]>>> {
+    // A static's address is never null, so `as_mut` always yields Some.
+    unsafe { (&raw mut OVERLAY).as_mut().unwrap() }
+}
+
+/// Arm the volatile write overlay. Call once at startup, after the platform
+/// probe and before any filesystem mounts.
+pub fn arm_ram_overlay() {
+    *overlay() = Some(BTreeMap::new());
+}
 
 /// Probe and select the boot disk. Called once from `startup` before the
 /// partition scan.
@@ -32,22 +56,49 @@ pub fn init<A: crate::Arch>(machine: &mut A) {
     }
 }
 
-/// Read `buffer.len().div_ceil(512)` sectors starting at `lba`.
+/// Read `buffer.len().div_ceil(512)` sectors starting at `lba`. Sectors the
+/// armed overlay holds shadow the device contents.
 pub fn read_sectors(lba: u32, buffer: &mut [u8]) -> u32 {
-    match KIND.load(Ordering::Relaxed) {
+    let n = match KIND.load(Ordering::Relaxed) {
         ATA => hdd::read_sectors(lba, buffer),
         NVME => nvme::read_sectors(lba, buffer),
         _ => {
             buffer.fill(0);
             0
         }
+    };
+    if let Some(map) = overlay().as_ref()
+        && !map.is_empty()
+    {
+        for (i, chunk) in buffer.chunks_mut(512).enumerate() {
+            if let Some(s) = map.get(&(lba + i as u32)) {
+                chunk.copy_from_slice(&s[..chunk.len()]);
+            }
+        }
     }
+    n
 }
 
-/// Write `buffer.len().div_ceil(512)` sectors starting at `lba`. Used by the
-/// backing-file overlay to persist writes through the raw disk, bypassing the
-/// read-only ext4 layer entirely. Returns sectors written (0 = no device).
+/// Write `buffer.len().div_ceil(512)` sectors starting at `lba` — into the
+/// volatile overlay when armed (real metal), through to the device otherwise.
+/// Returns sectors written (0 = no device).
 pub fn write_sectors(lba: u32, buffer: &[u8]) -> u32 {
+    if overlay().is_some() {
+        for (i, chunk) in buffer.chunks(512).enumerate() {
+            let sector = lba + i as u32;
+            let mut s = Box::new([0u8; 512]);
+            if chunk.len() == 512 {
+                s.copy_from_slice(chunk);
+            } else {
+                // Partial trailing sector: seed with the current contents
+                // (overlay-aware read; no map borrow is held across it).
+                read_sectors(sector, &mut s[..]);
+                s[..chunk.len()].copy_from_slice(chunk);
+            }
+            overlay().as_mut().unwrap().insert(sector, s);
+        }
+        return buffer.len().div_ceil(512) as u32;
+    }
     match KIND.load(Ordering::Relaxed) {
         ATA => hdd::write_sectors(lba, buffer),
         NVME => nvme::write_sectors(lba, buffer),

--- a/kernel/src/kernel/startup.rs
+++ b/kernel/src/kernel/startup.rs
@@ -34,6 +34,16 @@ pub fn startup<A: crate::Arch>(machine: &mut A, boot: &crate::BootConfig, mut sc
     // derives from this.
     let platform = crate::kernel::platform::probe(machine, boot);
 
+    // Disk-write policy: on real hardware the boot disk is someone's actual
+    // home partition, so writes land in a volatile RAM overlay — everything
+    // above (lwext4 journal, savegames, configs) works normally in-session,
+    // nothing persists. QEMU/hosted runs write through to their image file.
+    // Armed before any mount, so no ext4 write can ever precede it.
+    if platform.host == crate::kernel::platform::Host::Metal {
+        crate::kernel::block::arm_ram_overlay();
+        crate::screenln!(screen, "Disk writes: volatile RAM overlay (real hardware) — changes will NOT persist");
+    }
+
     // The thread table is a plain owned Vec now (fixed MAX_THREADS slots,
     // reused) — startup owns it and threads `&mut threads` down through run →
     // run_program → event_loop. No global; no `&'static mut`.


### PR DESCRIPTION
## Summary

ext4 is writable now (#28), which means a metal-metal boot journals and writes someone's **actual home partition**. Until the write path has earned that trust, real hardware gets a safety net: a volatile RAM write-overlay at the block layer.

- All filesystem I/O already funnels through `block::read/write_sectors` (above ATA and NVMe alike), so the overlay sits in exactly one place: when armed, writes divert into a kernel-heap map and reads patch those sectors back over the device. lwext4 stays fully writable in-session (journal recovery, savegames, configs) — the device is never written; power-off discards.
- Policy from the platform probe (probe once): `Host::Metal` arms it (Bochs/86Box probe as Metal → safe default too) with a loud boot line — *"Disk writes: volatile RAM overlay (real hardware) — changes will NOT persist"*. `Host::Qemu`/`Interp` write through, so image runs keep persistence.
- Armed between probe and mount; the probe's own partition sniffing mounts `read_only=true` with no journal start, so **no write can ever precede arming**. No callers bypass the facade (audited).
- Opting the laptop into direct writes later is a one-line gate change in `startup.rs`.

## Verification

- Force-armed on the hosted backend: full DOOM boot from the image's ext4 root leaves the image **byte-identical** (same run write-through modifies it) while the game loads and runs — mount-time journal writes land in the overlay and subsequent reads stay consistent.
- QEMU + hosted confirmed unarmed after restoring the gate.
- clippy (metal + host), metal ELF, TCG/KVM hosted, and image builds all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FP3kieu81sP7GdKwTNnPDV