### PR TITLE
IRQ-driven audio: HDA/AC97 completion-IRQ production, raster display, GM bank ROM

### DIFF
--- a/arch-abi/src/arch.rs
+++ b/arch-abi/src/arch.rs
@@ -246,6 +246,15 @@ pub trait Arch: Sized + GuestBytes {
         None
     }
 
+    /// Route and unmask a device's wired interrupt `line` (a PCI INTx line the
+    /// driver read from config space, or a fixed ISA line) so it reaches the CPU
+    /// and arrives via `drain` as `Irq::Hw(line)`. On metal: an IOAPIC entry in
+    /// APIC mode, an 8259 unmask in PIC mode — the same legacy path the fixed ISA
+    /// lines already use. No-op where there is no interrupt hardware.
+    fn route_device_irq(&mut self, line: u8) {
+        let _ = line;
+    }
+
     /// Arm hardware write-watchpoints at up to two guest-linear addresses
     /// (`None`/missing entry disables): a `#DB` fires when the guest writes one,
     /// for catching memory corruption. Real on metal (programs the debug

--- a/arch-abi/src/arch.rs
+++ b/arch-abi/src/arch.rs
@@ -234,11 +234,11 @@ pub trait Arch: Sized + GuestBytes {
     fn rearm_irq(&mut self, line: u8);
 
     /// Allocate an MSI target for a device that should raise the canonical
-    /// `Irq::Hw(source)` event. Returns the `(message_address, message_data)`
+    /// `Irq::Msi(source)` event. Returns the `(message_address, message_data)`
     /// pair to program into the device's PCI MSI capability, or `None` when
     /// message-signalled interrupts are unavailable (no local APIC, or a
     /// backend with no real interrupt hardware). The backend guarantees that a
-    /// write matching the returned pair delivers as `Irq::Hw(source)` through
+    /// write matching the returned pair delivers as `Irq::Msi(source)` through
     /// the ordinary `drain` path — the caller never learns the vector or APIC
     /// id, keeping interrupt delivery canonical above the arch boundary.
     fn msi_alloc(&mut self, source: u8) -> Option<(u64, u32)> {
@@ -252,6 +252,13 @@ pub trait Arch: Sized + GuestBytes {
     /// APIC mode, an 8259 unmask in PIC mode — the same legacy path the fixed ISA
     /// lines already use. No-op where there is no interrupt hardware.
     fn route_device_irq(&mut self, line: u8) {
+        let _ = line;
+    }
+
+    /// Route an ISA IRQ line (edge-triggered, active-high). Kept separate from
+    /// PCI INTx because the latter is level-triggered, active-low at the I/O
+    /// APIC; treating both as the same electrical signal loses interrupts.
+    fn route_isa_irq(&mut self, line: u8) {
         let _ = line;
     }
 

--- a/arch-abi/src/arch.rs
+++ b/arch-abi/src/arch.rs
@@ -233,6 +233,19 @@ pub trait Arch: Sized + GuestBytes {
     /// deferred guest-visible device ack.
     fn rearm_irq(&mut self, line: u8);
 
+    /// Allocate an MSI target for a device that should raise the canonical
+    /// `Irq::Hw(source)` event. Returns the `(message_address, message_data)`
+    /// pair to program into the device's PCI MSI capability, or `None` when
+    /// message-signalled interrupts are unavailable (no local APIC, or a
+    /// backend with no real interrupt hardware). The backend guarantees that a
+    /// write matching the returned pair delivers as `Irq::Hw(source)` through
+    /// the ordinary `drain` path — the caller never learns the vector or APIC
+    /// id, keeping interrupt delivery canonical above the arch boundary.
+    fn msi_alloc(&mut self, source: u8) -> Option<(u64, u32)> {
+        let _ = source;
+        None
+    }
+
     /// Arm hardware write-watchpoints at up to two guest-linear addresses
     /// (`None`/missing entry disables): a `#DB` fires when the guest writes one,
     /// for catching memory corruption. Real on metal (programs the debug

--- a/arch-abi/src/lib.rs
+++ b/arch-abi/src/lib.rs
@@ -572,4 +572,11 @@ pub enum Irq {
     /// policy-free — the kernel decides if it's a device it owns and when
     /// the line can be rearmed after the guest-visible device ack.
     Hw(u8),
+    /// A message-signalled interrupt allocated by [`Arch::msi_alloc`].
+    ///
+    /// This is deliberately distinct from [`Irq::Hw`]: an MSI source is a
+    /// kernel-owned vector identity, not an ISA IRQ/GSI line. Conflating the
+    /// two lets (for example) an HDA MSI called "11" steal a real device's
+    /// wired IRQ 11.
+    Msi(u8),
 }

--- a/arch-metal/src/backend.rs
+++ b/arch-metal/src/backend.rs
@@ -81,6 +81,7 @@ impl Arch for Metal {
     // ── IRQ lines ──
     fn set_irq_line(&mut self, _asserted: bool) {} // real 8259 drives INTR
     fn rearm_irq(&mut self, line: u8) { super::calls::arch_rearm_irq(line) }
+    fn msi_alloc(&mut self, source: u8) -> Option<(u64, u32)> { super::irq::msi_target(source) }
     fn set_debug_watch(&mut self, addrs: Option<(u32, u32)>) { super::calls::arch_set_debug_watch(addrs) }
 
     // ── Arch calls: paging / fork / LDT / DMA ──

--- a/arch-metal/src/backend.rs
+++ b/arch-metal/src/backend.rs
@@ -82,6 +82,7 @@ impl Arch for Metal {
     fn set_irq_line(&mut self, _asserted: bool) {} // real 8259 drives INTR
     fn rearm_irq(&mut self, line: u8) { super::calls::arch_rearm_irq(line) }
     fn msi_alloc(&mut self, source: u8) -> Option<(u64, u32)> { super::irq::msi_target(source) }
+    fn route_device_irq(&mut self, line: u8) { super::irq::route_device_irq(line) }
     fn set_debug_watch(&mut self, addrs: Option<(u32, u32)>) { super::calls::arch_set_debug_watch(addrs) }
 
     // ── Arch calls: paging / fork / LDT / DMA ──

--- a/arch-metal/src/backend.rs
+++ b/arch-metal/src/backend.rs
@@ -83,6 +83,7 @@ impl Arch for Metal {
     fn rearm_irq(&mut self, line: u8) { super::calls::arch_rearm_irq(line) }
     fn msi_alloc(&mut self, source: u8) -> Option<(u64, u32)> { super::irq::msi_target(source) }
     fn route_device_irq(&mut self, line: u8) { super::irq::route_device_irq(line) }
+    fn route_isa_irq(&mut self, line: u8) { super::irq::route_isa_irq(line) }
     fn set_debug_watch(&mut self, addrs: Option<(u32, u32)>) { super::calls::arch_set_debug_watch(addrs) }
 
     // ── Arch calls: paging / fork / LDT / DMA ──

--- a/arch-metal/src/descriptors.rs
+++ b/arch-metal/src/descriptors.rs
@@ -451,17 +451,19 @@ pub fn setup_descriptor_tables(kernel_stack_top: u32) {
         //            which are DPL=3 so user `INT3`/`INTO` can reach them. Vector
         //            5 (#BR) is CPU-raised by BOUND and stays DPL=0.
         // 0x20-0x2F: PIC IRQs (DPL=0)
-        // 0x30-0xFF: user-callable (DPL=3) — includes 0x80 syscall, 0x31 DPMI, 0xF0 VM86 stubs
+        // 0x30-0xF7: user-callable (DPL=3) — includes 0x80 syscall, 0x31 DPMI,
+        //             0xF0 VM86 stubs
+        // 0xF8-0xFF: kernel-only MSI vectors
         let vector_base_32 = int_vector.as_ptr() as u32;
         for i in 0..256 {
-            let dpl = if i == 3 || i == 4 || i >= 0x30 { 3 } else { 0 };
+            let dpl = if i == 3 || i == 4 || (0x30..0xF8).contains(&i) { 3 } else { 0 };
             let handler = vector_base_32 + (i as u32) * 8;
             IDT32.entries[i] = IdtEntry32::interrupt_gate(handler, dpl);
         }
 
         // Setup 64-bit IDT entries (same vector table, same DPL policy)
         for i in 0..256 {
-            let dpl = if i == 3 || i == 4 || i >= 0x30 { 3 } else { 0 };
+            let dpl = if i == 3 || i == 4 || (0x30..0xF8).contains(&i) { 3 } else { 0 };
             let handler = vector_base_32 + (i as u32) * 8;
             IDT64.entries[i] = IdtEntry64::interrupt_gate(handler, dpl);
         }

--- a/arch-metal/src/descriptors.rs
+++ b/arch-metal/src/descriptors.rs
@@ -340,10 +340,10 @@ const GDT_TSS32: usize = 7;       // 0x38
 /// the KERNEL's ESP31:16 in the live user ESP — the classic espfix leak.
 /// 16-bit DPMI code that saves/restores full ESP (DOS/16M's stack-switch
 /// glue: `mov [slot], esp` … `lds esi, [slot]`) then stores a kernel-stack
-/// pointer and faults dereferencing it. The exit path switches to this alias
-/// + `movzx esp, sp` before the final pops, so the numeric kernel ESP at
-/// IRET is < 0x10000 and the leaked bits are 0 — what every 16-bit-era DPMI
-/// host effectively provided.
+/// pointer and faults dereferencing it. The exit path switches to this
+/// alias and does `movzx esp, sp` before the final pops, so the numeric
+/// kernel ESP at IRET is < 0x10000 and the leaked bits are 0 — what every
+/// 16-bit-era DPMI host effectively provided.
 const GDT_ESPFIX_SS: usize = 9;   // 0x48 — was reserved
 #[allow(dead_code)] const GDT_RING1_CS: usize = 10;   // 0x50
 #[allow(dead_code)] const GDT_RING1_DS: usize = 11;   // 0x58

--- a/arch-metal/src/descriptors.rs
+++ b/arch-metal/src/descriptors.rs
@@ -334,6 +334,17 @@ const GDT_TSS32: usize = 7;       // 0x38
 // extenders #GP on the seg-load. The DPMI spec allows hosts to either
 // pre-define selector 40h *or* handle the GP — pre-defining is simpler.
 #[allow(dead_code)] const GDT_BIOS_DATA: usize = 8;   // 0x40 — BIOS Data Area alias
+/// 0x48 — espfix SS: ring-0 data alias of the trap stack (ARCH_STACK, the
+/// TSS.sp0 stack; kernel.ld 64K-aligns it so it spans exactly one 64K
+/// window). IRET to a 16-bit (B=0) stack segment restores only SP and leaves
+/// the KERNEL's ESP31:16 in the live user ESP — the classic espfix leak.
+/// 16-bit DPMI code that saves/restores full ESP (DOS/16M's stack-switch
+/// glue: `mov [slot], esp` … `lds esi, [slot]`) then stores a kernel-stack
+/// pointer and faults dereferencing it. The exit path switches to this alias
+/// + `movzx esp, sp` before the final pops, so the numeric kernel ESP at
+/// IRET is < 0x10000 and the leaked bits are 0 — what every 16-bit-era DPMI
+/// host effectively provided.
+const GDT_ESPFIX_SS: usize = 9;   // 0x48 — was reserved
 #[allow(dead_code)] const GDT_RING1_CS: usize = 10;   // 0x50
 #[allow(dead_code)] const GDT_RING1_DS: usize = 11;   // 0x58
 const GDT_LDT: usize = 12;        // 0x60
@@ -430,18 +441,31 @@ static mut SYSCALL_USER_RSP: u64 = 0;
 static mut SYSCALL_KERNEL_RSP: u64 = 0;
 
 /// Setup GDT, IDT, and TSS
-pub fn setup_descriptor_tables(kernel_stack_top: u32) {
+pub fn setup_descriptor_tables(arch_stack_top: u32) {
     unsafe {
         let tss_limit = core::mem::size_of::<Tss>() as u32 - 1;
 
         // Setup TSS32 with packed SS:ESP, VGA IOPB, and interrupt redirection
-        TSS32.sp0 = ((KERNEL_DS as u64) << 32) | (kernel_stack_top as u64);
+        TSS32.sp0 = ((KERNEL_DS as u64) << 32) | (arch_stack_top as u64);
         setup_vm86_bitmaps(&raw mut TSS32);
         let tss32_addr = core::ptr::addr_of!(TSS32) as u64;
         GDT[GDT_TSS32] = GdtEntry::tss_low(tss32_addr, tss_limit);
 
+        // espfix SS (see GDT_ESPFIX_SS): alias the ring-0 trap stack (the
+        // TSS.sp0 stack — ARCH_STACK) so the exit path can make the numeric
+        // ESP small before IRET to a 16-bit-stack guest. kernel.ld 64K-aligns
+        // ARCH_STACK, so the whole stack sits in one 64K window and every
+        // ESP's low 16 bits are exactly its offset from the window base.
+        assert!(
+            arch_stack_top & 0xFFFF_0000
+                == arch_stack_top.saturating_sub(0x3FF0) & 0xFFFF_0000,
+            "espfix: trap stack straddles a 64K window (kernel.ld ARCH_STACK)"
+        );
+        GDT[GDT_ESPFIX_SS] =
+            GdtEntry::segment32(false, 0).with_base(arch_stack_top & 0xFFFF_0000);
+
         // Setup TSS64 with clean 64-bit address
-        TSS64.sp0 = kernel_stack_top as u64;
+        TSS64.sp0 = arch_stack_top as u64;
         let tss64_addr = core::ptr::addr_of!(TSS64) as u64;
         GDT[GDT_TSS64_LO] = GdtEntry::tss_low(tss64_addr, tss_limit);
         // GDT[GDT_TSS64_HI] stays null (base bits 63:32 = 0 for <4GB)

--- a/arch-metal/src/irq.rs
+++ b/arch-metal/src/irq.rs
@@ -50,17 +50,28 @@ static mut MOUSE_PACKET_IDX: u8 = 0;
 pub fn drain(mut f: impl FnMut(Irq)) {
     // The ring-0 interrupt top half writes QUEUE while the ring-1 kernel drains
     // it. Move into a local under a short interrupt mask, then restore IF before
-    // invoking arbitrary kernel callbacks.
-    let mut events = [Irq::Tick; 256];
+    // invoking arbitrary kernel callbacks. Keep the scratch uninitialized:
+    // this path runs after every guest exit, while the queue is almost always
+    // empty. Initializing 256 fake Tick entries per exit made a polling guest
+    // write gigabytes of dead stack traffic per second.
+    let mut events = [core::mem::MaybeUninit::<Irq>::uninit(); 256];
     let restore_if = crate::x86::interrupts_enabled();
     crate::x86::cli();
     let q = &raw mut QUEUE;
-    let n = unsafe { (*q).read(&mut events) };
+    let mut n = 0;
+    unsafe {
+        while n < events.len() {
+            let Some(event) = (*q).pop() else { break };
+            events[n].write(event);
+            n += 1;
+        }
+    }
     if restore_if {
         crate::x86::sti();
     }
-    for event in events.into_iter().take(n) {
-        f(event);
+    for event in &events[..n] {
+        // Every element below `n` was initialized by the pop loop above.
+        f(unsafe { event.assume_init_read() });
     }
 }
 

--- a/arch-metal/src/irq.rs
+++ b/arch-metal/src/irq.rs
@@ -755,6 +755,19 @@ pub fn msi_target(source: u8) -> Option<(u64, u32)> {
     Some((addr, data))
 }
 
+/// Route and unmask a wired device IRQ `line` so it reaches the CPU — the same
+/// legacy path the fixed ISA lines take at init: an IOAPIC entry in APIC mode,
+/// an 8259 unmask in PIC mode. Routed edge-triggered like the ISA lines; a level
+/// PCI-INTx source is deasserted by the driver clearing its status register in
+/// its interrupt handler, so no level-trigger IOAPIC setup is needed.
+pub fn route_device_irq(line: u8) {
+    if lapic_timer_active() {
+        ioapic_route(line, IRQ_OFFSET + line);
+    } else {
+        unmask_irq(line);
+    }
+}
+
 /// Get timer ticks
 pub fn get_ticks() -> u64 {
     unsafe { core::ptr::read_volatile(&raw const TIMER_TICKS) }

--- a/arch-metal/src/irq.rs
+++ b/arch-metal/src/irq.rs
@@ -735,6 +735,26 @@ pub fn rearm_irq(irq: u8) {
     unmask_irq(irq);
 }
 
+/// Build an MSI `(message_address, message_data)` that delivers `source` as
+/// vector `IRQ_OFFSET + source`, i.e. straight into `handle_irq`'s generic
+/// `Irq::Hw(source)` arm (APIC branch: read device, single LAPIC EOI). MSI is
+/// edge-triggered and LAPIC-delivered, so it needs no PIC mask/unmask and no
+/// IOAPIC routing — only that the LAPIC is up. `source` must be an otherwise
+/// unused line so it doesn't alias a wired ISA IRQ.
+///
+/// xAPIC physical-mode format: address `0xFEE0_0000 | (apic_id << 12)`, data =
+/// the low-8-bit vector (delivery mode fixed, edge). Returns `None` in PIC-only
+/// mode (no LAPIC → MSI cannot be delivered; the device must fall back to a
+/// wired line or polling).
+pub fn msi_target(source: u8) -> Option<(u64, u32)> {
+    if !lapic_timer_active() {
+        return None;
+    }
+    let addr = LAPIC_PHYS | ((bsp_apic_id() as u64) << 12);
+    let data = (IRQ_OFFSET + source) as u32;
+    Some((addr, data))
+}
+
 /// Get timer ticks
 pub fn get_ticks() -> u64 {
     unsafe { core::ptr::read_volatile(&raw const TIMER_TICKS) }

--- a/arch-metal/src/irq.rs
+++ b/arch-metal/src/irq.rs
@@ -25,6 +25,11 @@ pub const IRQ_OFFSET: u8 = 32;
 /// constructs and queues these.
 pub use arch_abi::Irq;
 
+/// Private IDT range reserved for kernel MSI sources. These gates are DPL0,
+/// unlike the guest-callable software-interrupt range below them.
+pub const MSI_VECTOR_BASE: u8 = 0xF8;
+pub const MSI_SOURCE_COUNT: u8 = 8;
+
 /// Global IRQ event queue for discrete events (keyboard).
 /// Timer ticks use a separate counter to avoid flooding and evicting keys.
 static mut QUEUE: Pipe<Irq, 256> = Pipe::new(Irq::Tick);
@@ -42,9 +47,21 @@ static mut MOUSE_PACKET: [u8; 3] = [0; 3];
 static mut MOUSE_PACKET_IDX: u8 = 0;
 
 /// Drain all queued IRQ events, calling f for each.
-pub fn drain(f: impl FnMut(Irq)) {
+pub fn drain(mut f: impl FnMut(Irq)) {
+    // The ring-0 interrupt top half writes QUEUE while the ring-1 kernel drains
+    // it. Move into a local under a short interrupt mask, then restore IF before
+    // invoking arbitrary kernel callbacks.
+    let mut events = [Irq::Tick; 256];
+    let restore_if = crate::x86::interrupts_enabled();
+    crate::x86::cli();
     let q = &raw mut QUEUE;
-    unsafe { (*q).drain(f); }
+    let n = unsafe { (*q).read(&mut events) };
+    if restore_if {
+        crate::x86::sti();
+    }
+    for event in events.into_iter().take(n) {
+        f(event);
+    }
 }
 
 /// Push a keyboard scancode into the queue from a non-IRQ source — the xHCI
@@ -329,6 +346,9 @@ fn legacy_intr_and_pit() {
 const IOAPIC_PHYS: u64 = 0xFEC0_0000;
 const IOAPIC_MMIO_VA: usize = 0xFFF0_2000; // next page after LAPIC (F0000)/HPET (F1000)
 static mut IOAPIC_READY: bool = false;
+/// GSI lines configured as level-triggered PCI INTx. Their redirection entries
+/// are masked in the top half until the kernel driver clears the device source.
+static mut IOAPIC_LEVEL_LINES: u32 = 0;
 
 /// Indirect register access: select the register via IOREGSEL (+0x00), then
 /// read/write its value through IOWIN (+0x10).
@@ -336,6 +356,27 @@ fn ioapic_write(reg: u32, val: u32) {
     unsafe {
         core::ptr::write_volatile(IOAPIC_MMIO_VA as *mut u32, reg);
         core::ptr::write_volatile((IOAPIC_MMIO_VA + 0x10) as *mut u32, val);
+    }
+}
+
+fn ioapic_read(reg: u32) -> u32 {
+    unsafe {
+        core::ptr::write_volatile(IOAPIC_MMIO_VA as *mut u32, reg);
+        core::ptr::read_volatile((IOAPIC_MMIO_VA + 0x10) as *const u32)
+    }
+}
+
+fn ioapic_mask(gsi: u8, masked: bool) {
+    let restore_if = crate::x86::interrupts_enabled();
+    crate::x86::cli();
+    let idx = 0x10 + 2 * gsi as u32;
+    let low = ioapic_read(idx);
+    ioapic_write(
+        idx,
+        if masked { low | (1 << 16) } else { low & !(1 << 16) },
+    );
+    if restore_if {
+        crate::x86::sti();
     }
 }
 
@@ -356,7 +397,9 @@ fn bsp_apic_id() -> u32 {
 /// destination, edge-triggered, active-high, unmasked. ISA IRQs map 1:1 to GSIs
 /// for the keyboard (1) and mouse (12); the timer (often overridden to GSI2) is
 /// not routed here — the LAPIC timer owns the tick.
-fn ioapic_route(gsi: u8, vector: u8) {
+fn ioapic_route(gsi: u8, vector: u8, level_low: bool) {
+    let restore_if = crate::x86::interrupts_enabled();
+    crate::x86::cli();
     unsafe {
         if !IOAPIC_READY {
             map_mmio_page(IOAPIC_MMIO_VA, IOAPIC_PHYS);
@@ -366,9 +409,13 @@ fn ioapic_route(gsi: u8, vector: u8) {
     let idx = 0x10 + 2 * gsi as u32;
     // High dword: destination APIC ID in bits 56-63 (bits 24-31 of this word).
     ioapic_write(idx + 1, bsp_apic_id() << 24);
-    // Low dword: vector in bits 0-7; all other fields 0 (fixed / physical /
-    // edge / active-high) and bit 16 (mask) clear = unmasked.
-    ioapic_write(idx, vector as u32);
+    // Low dword: vector, fixed/physical delivery, unmasked. PCI INTx uses
+    // polarity-low (bit13) + level-triggered (bit15); ISA uses edge/high.
+    let electrical = if level_low { (1 << 13) | (1 << 15) } else { 0 };
+    ioapic_write(idx, vector as u32 | electrical);
+    if restore_if {
+        crate::x86::sti();
+    }
 }
 
 /// Probe whether an 8042 keyboard controller is present. A board with no i8042
@@ -429,7 +476,7 @@ pub fn init_interrupts() {
         let _ = inb(0x60);
     }
     if apic {
-        ioapic_route(1, IRQ_OFFSET + 1); // keyboard GSI1
+        ioapic_route(1, IRQ_OFFSET + 1, false); // keyboard GSI1
     } else {
         unmask_irq(1);
     }
@@ -442,9 +489,9 @@ pub fn init_interrupts() {
         // it: ISA IRQs map 1:1 to GSIs, and the IOAPIC entries are edge-
         // triggered like the 8259, so an idle line costs nothing.
         if apic {
-            ioapic_route(12, IRQ_OFFSET + 12); // mouse GSI12
-            ioapic_route(5, IRQ_OFFSET + 5);   // ISA SB (QEMU sb16 default)
-            ioapic_route(7, IRQ_OFFSET + 7);   // ISA SB alternate line
+            ioapic_route(12, IRQ_OFFSET + 12, false); // mouse GSI12
+            ioapic_route(5, IRQ_OFFSET + 5, false);   // ISA SB (QEMU sb16 default)
+            ioapic_route(7, IRQ_OFFSET + 7, false);   // ISA SB alternate line
         } else {
             unmask_irq(12);
             unmask_irq(5);
@@ -638,7 +685,18 @@ pub fn timer_selftest(screen: &mut lib::vga::Screen) {
 
 /// Handle an IRQ: PIC ACK, read hardware data, push typed event to queue.
 pub fn handle_irq(regs: &mut Regs) {
-    let irq = (regs.int_num - IRQ_OFFSET as u64) as u8;
+    let vector = regs.int_num as u8;
+    if vector >= MSI_VECTOR_BASE {
+        let source = vector - MSI_VECTOR_BASE;
+        unsafe {
+            let q = &raw mut QUEUE;
+            (*q).push(Irq::Msi(source));
+        }
+        // MSI is LAPIC-delivered and edge-triggered.
+        lapic_write(LAPIC_EOI, 0);
+        return;
+    }
+    let irq = vector - IRQ_OFFSET;
 
     // APIC mode: the tick is the LAPIC timer (vector 0x20 from the local APIC)
     // and keyboard/mouse arrive through the I/O APIC — the 8259 is bypassed
@@ -646,6 +704,14 @@ pub fn handle_irq(regs: &mut Regs) {
     // the PIC mask/ack dance below applies. (`lapic_timer_active()` is the
     // APIC-mode flag: it is set iff setup_lapic_timer succeeded.)
     if lapic_timer_active() {
+        let level_line = irq < 32
+            && unsafe { core::ptr::read_volatile(&raw const IOAPIC_LEVEL_LINES) }
+                & (1u32 << irq) != 0;
+        if level_line {
+            // Prevent a level source from immediately retriggering after EOI;
+            // the deferred kernel driver clears it, then `rearm_irq` unmasks.
+            ioapic_mask(irq, true);
+        }
         match irq {
             0 => {
                 unsafe {
@@ -726,43 +792,66 @@ pub fn handle_irq(regs: &mut Regs) {
 /// ack `Irq::Hw` line). Called from the kernel once the guest has acked
 /// the device so the next interrupt can be delivered.
 pub fn rearm_irq(irq: u8) {
-    // APIC mode delivers Hw lines edge-triggered through the IOAPIC and acks
-    // inline (LAPIC EOI in handle_irq) — nothing was masked, and the bypassed
-    // 8259's IMR is not ours to touch.
     if lapic_timer_active() {
+        if irq < 32
+            && unsafe { core::ptr::read_volatile(&raw const IOAPIC_LEVEL_LINES) }
+                & (1u32 << irq) != 0
+        {
+            ioapic_mask(irq, false);
+        }
         return;
     }
     unmask_irq(irq);
 }
 
-/// Build an MSI `(message_address, message_data)` that delivers `source` as
-/// vector `IRQ_OFFSET + source`, i.e. straight into `handle_irq`'s generic
-/// `Irq::Hw(source)` arm (APIC branch: read device, single LAPIC EOI). MSI is
+/// Build an MSI `(message_address, message_data)` that delivers `source` as a
+/// private kernel vector and queues `Irq::Msi(source)`. MSI is
 /// edge-triggered and LAPIC-delivered, so it needs no PIC mask/unmask and no
-/// IOAPIC routing — only that the LAPIC is up. `source` must be an otherwise
-/// unused line so it doesn't alias a wired ISA IRQ.
+/// IOAPIC routing — only that the LAPIC is up. `source` is an identity in the
+/// backend's private MSI namespace.
 ///
 /// xAPIC physical-mode format: address `0xFEE0_0000 | (apic_id << 12)`, data =
 /// the low-8-bit vector (delivery mode fixed, edge). Returns `None` in PIC-only
 /// mode (no LAPIC → MSI cannot be delivered; the device must fall back to a
 /// wired line or polling).
 pub fn msi_target(source: u8) -> Option<(u64, u32)> {
-    if !lapic_timer_active() {
+    if !lapic_timer_active() || source >= MSI_SOURCE_COUNT {
         return None;
     }
     let addr = LAPIC_PHYS | ((bsp_apic_id() as u64) << 12);
-    let data = (IRQ_OFFSET + source) as u32;
+    let data = (MSI_VECTOR_BASE + source) as u32;
     Some((addr, data))
 }
 
-/// Route and unmask a wired device IRQ `line` so it reaches the CPU — the same
-/// legacy path the fixed ISA lines take at init: an IOAPIC entry in APIC mode,
-/// an 8259 unmask in PIC mode. Routed edge-triggered like the ISA lines; a level
-/// PCI-INTx source is deasserted by the driver clearing its status register in
-/// its interrupt handler, so no level-trigger IOAPIC setup is needed.
+/// Route and unmask a PCI INTx line. INTx is level-triggered, active-low at the
+/// I/O APIC. The top half masks it before EOI; the deferred driver clears the
+/// device source and calls `rearm_irq` to unmask it.
 pub fn route_device_irq(line: u8) {
     if lapic_timer_active() {
-        ioapic_route(line, IRQ_OFFSET + line);
+        ioapic_route(line, IRQ_OFFSET + line, true);
+        if line < 32 {
+            unsafe {
+                let p = &raw mut IOAPIC_LEVEL_LINES;
+                core::ptr::write_volatile(p, core::ptr::read_volatile(p) | (1u32 << line));
+            }
+        }
+    } else {
+        // PCI-to-ISA bridges present INTx to the 8259 as a level-triggered IRQ.
+        // Program the Edge/Level Control Register before unmasking it.
+        let (elcr, bit) = if line < 8 {
+            (0x4D0, line)
+        } else {
+            (0x4D1, line - 8)
+        };
+        outb(elcr, inb(elcr) | (1 << bit));
+        unmask_irq(line);
+    }
+}
+
+/// Route and unmask an ISA edge-triggered, active-high line.
+pub fn route_isa_irq(line: u8) {
+    if lapic_timer_active() {
+        ioapic_route(line, IRQ_OFFSET + line, false);
     } else {
         unmask_irq(line);
     }

--- a/arch-metal/src/traps.rs
+++ b/arch-metal/src/traps.rs
@@ -691,7 +691,7 @@ fn isr_handler_ring3(regs: &mut Regs) {
             if try_handle_page_fault(regs.err_code, legacy_mode).is_some() { return; }
             KE::PageFault { addr: x86::read_cr2() }
         }
-        32..=47 => { handle_irq(regs); KE::Irq }
+        32..=47 | 0xF8..=0xFF => { handle_irq(regs); KE::Irq }
         // Vectors 3/4 (#BP/#OF) are only reachable from user INT3/INTO, so
         // they're soft ints. Other n<32 are genuine CPU exceptions.
         3 | 4 => KE::SoftInt(int_num as u8),
@@ -746,7 +746,7 @@ fn isr_handler_ring1(regs: &mut Regs) {
                 panic_with_regs("Unhandled page fault in kernel", regs);
             }
         }
-        32..=47 => handle_irq(regs),
+        32..=47 | 0xF8..=0xFF => handle_irq(regs),
         0x80 => arch_dispatch(regs),
         _ => panic_with_regs("Unexpected interrupt in kernel", regs),
     }
@@ -928,7 +928,7 @@ fn handle_ring0(int_num: u64, error: u64, cs: u64, eip: u64) {
                 panic!("Unhandled page fault in arch: addr={:#x} err={:#x}", x86::read_cr2(), error);
             }
         }
-        32..=47 => {
+        32..=47 | 0xF8..=0xFF => {
             let mut regs = Regs::empty();
             regs.int_num = int_num;
             handle_irq(&mut regs);

--- a/arch-metal/src/x86.rs
+++ b/arch-metal/src/x86.rs
@@ -409,6 +409,15 @@ pub(super) fn cli() {
     }
 }
 
+#[inline]
+pub(super) fn interrupts_enabled() -> bool {
+    let flags: u32;
+    unsafe {
+        asm!("pushfd", "pop {0:e}", out(reg) flags, options(nomem));
+    }
+    flags & (1 << 9) != 0
+}
+
 /// Halt CPU until next interrupt
 #[inline]
 pub fn hlt() {

--- a/kernel/kernel.ld
+++ b/kernel/kernel.ld
@@ -52,9 +52,16 @@ SECTIONS
         KERNEL_STACK_GUARD = .;     . += 0x1000;   /* 4 KB */
         KERNEL_STACK       = .;     . += 0x10000;  /* 64 KB */
         KERNEL_STACK_TOP   = .;
-        . = ALIGN(4K);
-        ARCH_STACK_GUARD   = .;     . += 0x1000;   /* 4 KB */
-        ARCH_STACK         = .;     . += 0x4000;   /* 16 KB */
+        /* espfix invariant (see GDT_ESPFIX_SS in arch-metal/descriptors.rs):
+         * ARCH_STACK is the ring-0 trap stack (TSS.sp0) — 64K-ALIGN it so
+         * the whole 16 KB stack sits inside one 64K segment window and every
+         * ESP's low 16 bits equal its offset from the window base, letting
+         * the exit path truncate ESP against the aliased SS. The guard page
+         * stays directly below the aligned base. */
+        . += 0x1000;
+        . = ALIGN(64K);
+        ARCH_STACK_GUARD   = . - 0x1000;
+        ARCH_STACK         = .;     . += 0x4000;   /* 16 KB, 64K-aligned */
         ARCH_STACK_TOP     = .;
     }
     _end = .;

--- a/kernel/src/arch/entry.asm
+++ b/kernel/src/arch/entry.asm
@@ -39,9 +39,14 @@ dd 0, 0, 0, 0, 0
 ; Video request (flags bit 2). On UEFI-class machines (no VGA text mode) the
 ; loader hands back a linear framebuffer in the info struct; our own legacy
 ; bootloader ignores the header and boots in VGA text mode as before.
+; Width/height 0 = no preference (multiboot spec): the loader's gfxmode=auto
+; then picks the panel's NATIVE mode. A concrete request here (1024x768
+; historically) made GRUB pick a 4:3 GOP mode on the 16:10 laptop, which the
+; panel's scaler stretched to full screen — fat pixels, wrong aspect, no
+; pillarbox. Depth stays a real request: fbcon renders 32bpp only.
 dd 0          ; mode_type: 0 = linear graphics
-dd 1024       ; width  (a request — the loader picks the nearest GOP mode)
-dd 768        ; height
+dd 0          ; width  (0 = no preference -> loader picks native)
+dd 0          ; height
 dd 32         ; depth
 
 ; =============================================================================

--- a/kernel/src/arch/entry.asm
+++ b/kernel/src/arch/entry.asm
@@ -248,6 +248,25 @@ isr_return:
     jmp 0x10:exit_interrupt_64
 
 exit_interrupt_32:
+    ; espfix (see GDT_ESPFIX_SS in descriptors.rs): IRET to a 16-bit (B=0)
+    ; stack segment restores only SP, leaving the kernel's ESP31:16 in the
+    ; guest's live ESP — which 16-bit DPMI code (DOS/16M stack-switch glue)
+    ; saves with `mov [slot], esp` and later dereferences. Run the pops +
+    ; IRET on the trap-stack alias segment (base = the 64K-aligned
+    ; ARCH_STACK window, kernel.ld) with a 16-bit-truncated ESP: same linear bytes,
+    ; numeric ESP < 0x10000, so the leaked half is 0. Done for every
+    ; CROSS-privilege exit — the aligned stack spans exactly one 64K window,
+    ; and 32-bit/VM86/ring-1 IRETs pop full SS:ESP so the switch is harmless
+    ; there. Same-ring ring-0 returns (saved CS RPL=0) must skip: their IRET
+    ; pops no SS:ESP, so the interrupted kernel code would resume on the
+    ; alias with a truncated ESP, breaking its flat-SS assumptions. MOV SS
+    ; blocks interrupts for the following instruction (IF is 0 here anyway).
+    test byte [esp + 200], 3    ; saved CS at Raw32 offset 200; RPL==0 → ring 0
+    jz .no_espfix
+    mov ax, 0x48                ; ESPFIX_SS_SEL (ring-0 trap-stack alias)
+    mov ss, ax
+    movzx esp, sp
+.no_espfix:
     ; ESP at Raw32 offset 0. Pop in reverse of entry_wrapper_32.
     pop gs
     pop fs

--- a/kernel/src/arch/fbcon.rs
+++ b/kernel/src/arch/fbcon.rs
@@ -363,8 +363,6 @@ static DOS_PAINTED: core::sync::atomic::AtomicBool =
 /// `display_tick` path which presents the same aperture during runtime.
 fn flush() {
     let Some(g) = geom() else { return };
-    // Console pixels bypass the incremental DOS blitter.
-    crate::kernel::display::damage();
     // A DOS frame painted over us: wipe and repaint the whole console.
     if DOS_PAINTED.swap(false, core::sync::atomic::Ordering::Relaxed) {
     let out = unsafe { core::slice::from_raw_parts_mut(g.va as *mut u32, g.len) };

--- a/kernel/src/arch/fbcon.rs
+++ b/kernel/src/arch/fbcon.rs
@@ -50,6 +50,8 @@ struct Geom {
     len: usize,
     /// Convert the renderer's canonical 0x00RRGGBB pixels to the GOP layout.
     format: PixelFormat,
+    /// QEMU-TCG needs strong-UC stores for display dirty tracking.
+    slow: bool,
 }
 static mut GEOM: Option<Geom> = None;
 
@@ -155,6 +157,7 @@ pub fn framebuffer() -> Option<crate::kernel::display::Framebuffer> {
         width: g.stride,
         height: g.len / g.stride,
         format: g.format.to_display(),
+        slow: g.slow,
     })
 }
 
@@ -295,6 +298,7 @@ pub fn init(info: &arch::MultibootInfo, screen: &mut lib::vga::Screen) {
         origin,
         len: stride * height,
         format,
+        slow: qemu_tcg,
     });
 
     // Wipe the boot splash (the pre-paging life-sign strip boot_kernel
@@ -359,6 +363,8 @@ static DOS_PAINTED: core::sync::atomic::AtomicBool =
 /// `display_tick` path which presents the same aperture during runtime.
 fn flush() {
     let Some(g) = geom() else { return };
+    // Console pixels bypass the incremental DOS blitter.
+    crate::kernel::display::damage();
     // A DOS frame painted over us: wipe and repaint the whole console.
     if DOS_PAINTED.swap(false, core::sync::atomic::Ordering::Relaxed) {
     let out = unsafe { core::slice::from_raw_parts_mut(g.va as *mut u32, g.len) };

--- a/kernel/src/arch/fbcon.rs
+++ b/kernel/src/arch/fbcon.rs
@@ -52,6 +52,8 @@ struct Geom {
     format: PixelFormat,
     /// QEMU-TCG needs strong-UC stores for display dirty tracking.
     slow: bool,
+    /// Bare metal (no hypervisor): wide NT stores for device-row copies.
+    wide: bool,
 }
 static mut GEOM: Option<Geom> = None;
 
@@ -158,6 +160,7 @@ pub fn framebuffer() -> Option<crate::kernel::display::Framebuffer> {
         height: g.len / g.stride,
         format: g.format.to_display(),
         slow: g.slow,
+        wide: g.wide,
     })
 }
 
@@ -299,6 +302,7 @@ pub fn init(info: &arch::MultibootInfo, screen: &mut lib::vga::Screen) {
         len: stride * height,
         format,
         slow: qemu_tcg,
+        wide: (cpuid1_ecx >> 31) & 1 == 0, // no hypervisor = real WC aperture
     });
 
     // Wipe the boot splash (the pre-paging life-sign strip boot_kernel

--- a/kernel/src/kernel/console.rs
+++ b/kernel/src/kernel/console.rs
@@ -66,8 +66,17 @@ fn drain_dos<A: crate::Arch>(
             } else {
                 unsafe { (*dp).process_key(machine, regs, sc) };
             }
-        } else if !blocked {
-            crate::kernel::dos::queue_irq(machine, unsafe { &mut *dp }, regs, evt);
+        } else {
+            // A sink completion interrupt is the kernel's, not the guest's:
+            // offer every Hw line to the audio router first.
+            if let crate::Irq::Hw(line) = evt
+                && crate::kernel::sound::on_hw_irq(machine, line)
+            {
+                continue;
+            }
+            if !blocked {
+                crate::kernel::dos::queue_irq(machine, unsafe { &mut *dp }, regs, evt);
+            }
         }
     }
     }
@@ -108,10 +117,14 @@ fn drain_linux<A: crate::Arch>(
         let mut _events: alloc::vec::Vec<crate::Irq> = alloc::vec::Vec::new();
         machine.drain(&mut |evt| _events.push(evt));
         for evt in _events {
-        if let crate::Irq::Key(sc) = evt
-            && !monitor_key(machine, regs, sc, None)
-        {
-            unsafe { (*lp).process_key(machine, &(*ktp).fds, sc) };
+        if let crate::Irq::Key(sc) = evt {
+            if !monitor_key(machine, regs, sc, None) {
+                unsafe { (*lp).process_key(machine, &(*ktp).fds, sc) };
+            }
+        } else if let crate::Irq::Hw(line) = evt {
+            // Same audio-sink IRQ routing as the DOS drain (see `drain_dos`):
+            // the sink is the kernel's regardless of the focused personality.
+            crate::kernel::sound::on_hw_irq(machine, line);
         }
     }
     }

--- a/kernel/src/kernel/console.rs
+++ b/kernel/src/kernel/console.rs
@@ -112,10 +112,10 @@ fn dispatch_linux<A: crate::Arch>(
     let lp = linux as *mut thread::LinuxState;
     {
         for evt in events {
-        if let crate::Irq::Key(sc) = evt {
-            if !monitor_key(machine, regs, sc, None) {
-                unsafe { (*lp).process_key(machine, &(*ktp).fds, sc) };
-            }
+        if let crate::Irq::Key(sc) = evt
+            && !monitor_key(machine, regs, sc, None)
+        {
+            unsafe { (*lp).process_key(machine, &(*ktp).fds, sc) };
         }
     }
     }

--- a/kernel/src/kernel/console.rs
+++ b/kernel/src/kernel/console.rs
@@ -21,35 +21,38 @@ use crate::kernel::thread;
 /// F12 scancode (press) — open the host monitor.
 pub const F12_PRESS: u8 = 0x58;
 
-/// Drain pending input into the console owner.
-pub fn drain<A: crate::Arch>(
+/// Route already-drained input/guest events into the console owner. Kernel
+/// device IRQs were consumed earlier by `irq_dispatch`.
+pub fn dispatch<A: crate::Arch>(
     machine: &mut A,
     regs: &mut Regs,
     kt: &mut thread::KernelThread<A>,
     personality: &mut thread::Personality<A>,
+    events: alloc::vec::Vec<crate::Irq>,
 ) {
     match personality {
         thread::Personality::Dos(dos) => {
             let blocked = kt.state == thread::ThreadState::Blocked;
-            drain_dos(machine, regs, blocked, dos);
+            dispatch_dos(machine, regs, blocked, dos, events);
         }
-        thread::Personality::Linux(linux) => drain_linux(machine, regs, kt, linux),
+        thread::Personality::Linux(linux) => {
+            dispatch_linux(machine, regs, kt, linux, events)
+        }
     }
 }
 
 /// DOS owner: `blocked` selects the stdin-pipe path (owner is wait4-parked
 /// behind a foreground Linux child).
-fn drain_dos<A: crate::Arch>(
+fn dispatch_dos<A: crate::Arch>(
     machine: &mut A,
     regs: &mut Regs,
     blocked: bool,
     dos: &mut thread::DosState<A>,
+    events: alloc::vec::Vec<crate::Irq>,
 ) {
     let dp = dos as *mut thread::DosState<A>;
     {
-        let mut _events: alloc::vec::Vec<crate::Irq> = alloc::vec::Vec::new();
-        machine.drain(&mut |evt| _events.push(evt));
-        for evt in _events {
+        for evt in events {
         if let crate::Irq::Key(sc) = evt {
             if monitor_key(machine, regs, sc, Some(unsafe { &*dp })) {
                 continue; // eaten by the F12 monitor
@@ -67,13 +70,6 @@ fn drain_dos<A: crate::Arch>(
                 unsafe { (*dp).process_key(machine, regs, sc) };
             }
         } else {
-            // A sink completion interrupt is the kernel's, not the guest's:
-            // offer every Hw line to the audio router first.
-            if let crate::Irq::Hw(line) = evt
-                && crate::kernel::sound::on_hw_irq(machine, line)
-            {
-                continue;
-            }
             if !blocked {
                 crate::kernel::dos::queue_irq(machine, unsafe { &mut *dp }, regs, evt);
             }
@@ -105,26 +101,21 @@ fn monitor_key<A: crate::Arch>(
 }
 
 /// Linux owner: keys → cooked fd input.
-fn drain_linux<A: crate::Arch>(
+fn dispatch_linux<A: crate::Arch>(
     machine: &mut A,
     regs: &mut Regs,
     kt: &mut thread::KernelThread<A>,
     linux: &mut thread::LinuxState,
+    events: alloc::vec::Vec<crate::Irq>,
 ) {
     let ktp = kt as *mut thread::KernelThread<A>;
     let lp = linux as *mut thread::LinuxState;
     {
-        let mut _events: alloc::vec::Vec<crate::Irq> = alloc::vec::Vec::new();
-        machine.drain(&mut |evt| _events.push(evt));
-        for evt in _events {
+        for evt in events {
         if let crate::Irq::Key(sc) = evt {
             if !monitor_key(machine, regs, sc, None) {
                 unsafe { (*lp).process_key(machine, &(*ktp).fds, sc) };
             }
-        } else if let crate::Irq::Hw(line) = evt {
-            // Same audio-sink IRQ routing as the DOS drain (see `drain_dos`):
-            // the sink is the kernel's regardless of the focused personality.
-            crate::kernel::sound::on_hw_irq(machine, line);
         }
     }
     }

--- a/kernel/src/kernel/display.rs
+++ b/kernel/src/kernel/display.rs
@@ -51,7 +51,6 @@ pub fn present() {
 pub struct Scratch {
     pal: lib::vga_render::Pal,
     pal_cache: [u8; 768],
-    src: alloc::vec::Vec<u32>,
     row: alloc::vec::Vec<u32>,
     /// Geometry the beam is armed for `(w, h, out_w, out_h)`; any change
     /// restarts the sweep at the top — a mode switch repaints everything,
@@ -79,7 +78,6 @@ impl Scratch {
         Scratch {
             pal: lib::vga_render::Pal::new(),
             pal_cache: [0; 768],
-            src: alloc::vec::Vec::new(),
             row: alloc::vec::Vec::new(),
             geo: (0, 0, 0, 0),
             sy: 0,
@@ -213,19 +211,15 @@ pub fn raster(
         return (0, false); // no downscaling path
     }
 
-    // Each source pixel covers `xbase` or `xbase + 1` output pixels; the
-    // stretcher fills the wider constant every time and steps by the true
-    // amount, so it overshoots at most `xbase + 1` past the content edge.
-    let (xbase, xrem) = (out_w / w, out_w % w);
     let (ybase, yrem) = (out_h / h, out_h % h);
     let bx = (fb.width - out_w) / 2; // left border width
     let by = (fb.height - out_h) / 2; // top border height
-    let slack = xbase + 1;
+    // `render_row_stretched` overwrites a constant ceil(out_w/w) run per
+    // source pixel; the buffer carries that much slack past the content.
+    let slack = out_w.div_ceil(w);
 
     if s.geo != (w, h, out_w, out_h) || s.row.len() != out_w + slack {
         s.geo = (w, h, out_w, out_h);
-        s.src.clear();
-        s.src.resize(w, 0);
         s.row.clear();
         s.row.resize(out_w + slack, 0);
         s.sy = 0;
@@ -278,13 +272,7 @@ pub fn raster(
             }
             continue;
         }
-        lib::vga_render::render_row(frame, s.sy, &s.pal, &mut s.src);
-        let (mut o, mut xerr) = (0usize, 0usize);
-        for &v in &s.src {
-            s.row[o..o + xbase + 1].fill(v);
-            xerr += xrem;
-            o += xbase + if xerr >= w { xerr -= w; 1 } else { 0 };
-        }
+        lib::vga_render::render_row_stretched(frame, s.sy, &s.pal, &mut s.row, out_w);
         s.yerr += yrem;
         let rows = ybase + if s.yerr >= h { s.yerr -= h; 1 } else { 0 };
         for _ in 0..rows {

--- a/kernel/src/kernel/display.rs
+++ b/kernel/src/kernel/display.rs
@@ -222,17 +222,24 @@ pub fn raster(
     let by = (fb.height - out_h) / 2; // top border height
     let slack = xbase + 1;
 
-    if s.geo != (w, h, out_w, out_h) || s.row.len() != fb.width + slack {
+    if s.geo != (w, h, out_w, out_h) || s.row.len() != out_w + slack {
         s.geo = (w, h, out_w, out_h);
         s.src.clear();
         s.src.resize(w, 0);
         s.row.clear();
-        s.row.resize(fb.width + slack, 0); // border pixels stay black
+        s.row.resize(out_w + slack, 0);
         s.sy = 0;
         s.oy = 0;
         s.yerr = 0;
         s.acc = 0;
         s.last_ms = now_ms;
+        // Mode switch: reclaim the whole panel ONCE — pillarbox bars and
+        // letterbox bands included, whatever the previous mode or a console
+        // print left there. From here the sweep copies only the picture
+        // span, so the bars cost nothing per frame.
+        unsafe {
+            core::ptr::write_bytes(fb.va as *mut u32, 0, fb.stride * fb.height);
+        }
     }
 
     // Step credit from elapsed virtual time: a sweep is `h` painted rows
@@ -272,35 +279,24 @@ pub fn raster(
             continue;
         }
         lib::vga_render::render_row(frame, s.sy, &s.pal, &mut s.src);
-        let (mut o, mut xerr) = (bx, 0usize);
+        let (mut o, mut xerr) = (0usize, 0usize);
         for &v in &s.src {
             s.row[o..o + xbase + 1].fill(v);
             xerr += xrem;
             o += xbase + if xerr >= w { xerr -= w; 1 } else { 0 };
         }
-        // Re-blacken the stretcher's overshoot: that strip is right border.
-        s.row[bx + out_w..].fill(0);
         s.yerr += yrem;
         let rows = ybase + if s.yerr >= h { s.yerr -= h; 1 } else { 0 };
         for _ in 0..rows {
-            let d = (by + s.oy) * fb.stride;
+            let d = (by + s.oy) * fb.stride + bx;
             unsafe {
-                copy_pixels(out.as_mut_ptr().add(d), s.row.as_ptr(), fb.width);
+                copy_pixels(out.as_mut_ptr().add(d), s.row.as_ptr(), out_w);
             }
-            copied += fb.width;
+            copied += out_w;
             s.oy += 1;
         }
         s.sy += 1;
         if s.sy == h {
-            // Letterbox bands (rare geometry — 4:3 content on a 4:3-or-wider
-            // panel pillarboxes instead, and the row copy above covers those
-            // borders every row): painted once per sweep, entering blank.
-            for y in (0..by).chain(by + out_h..fb.height) {
-                unsafe {
-                    core::ptr::write_bytes(out.as_mut_ptr().add(y * fb.stride), 0, fb.width);
-                }
-                copied += fb.width;
-            }
             // Frame complete: the beam enters vertical blank (the retrace
             // 0x3DA now reports) and the caller presents.
             wrapped = true;

--- a/kernel/src/kernel/display.rs
+++ b/kernel/src/kernel/display.rs
@@ -29,11 +29,16 @@ pub struct Framebuffer {
     pub width: usize,
     pub height: usize,
     pub format: PixelFormat,
+    /// Full-frame writes are unusually expensive (QEMU-TCG's strong-UC GOP
+    /// mapping), so emulated VGA should use a conservative refresh cadence.
+    pub slow: bool,
 }
 
 /// Backend hook: the frame is finished, show it. Installed by the entry crate
 /// like the portio/hostfs/socket hooks.
 static mut PRESENT: fn() = || {};
+static DAMAGE_EPOCH: core::sync::atomic::AtomicU32 =
+    core::sync::atomic::AtomicU32::new(1);
 
 pub fn set_present_hook(f: fn()) {
     unsafe { PRESENT = f };
@@ -43,13 +48,36 @@ pub fn present() {
     (unsafe { PRESENT })();
 }
 
-/// Scratch for the blit: the palette in framebuffer format, one source row and
-/// one stretched output row.
+/// Tell the incremental blitter that something outside it wrote the display
+/// (the framebuffer console, for example), so its next frame repaints fully.
+pub fn damage() {
+    DAMAGE_EPOCH.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+}
+
+/// Scratch for the blit: the palette in framebuffer format, one source row,
+/// one stretched output row, and the previous source image for dirty spans.
 pub struct Scratch {
     pal: lib::vga_render::Pal,
     pal_cache: [u8; 768],
     src: alloc::vec::Vec<u32>,
     row: alloc::vec::Vec<u32>,
+    prev: alloc::vec::Vec<u32>,
+    prev_w: usize,
+    prev_h: usize,
+    prev_out_w: usize,
+    prev_out_h: usize,
+    damage_epoch: u32,
+    overlay: bool,
+    input_vram: alloc::vec::Vec<u8>,
+    input_planes: alloc::vec::Vec<u8>,
+    input_mode: Option<lib::vga_render::VgaMode>,
+    input_ac: [u8; 21],
+    input_palette: [u8; 768],
+    input_cga_palette: [u32; 4],
+    input_blink: bool,
+    input_start_offset: usize,
+    input_pixel_pan: usize,
+    input_line_compare: usize,
 }
 
 impl Default for Scratch {
@@ -65,7 +93,70 @@ impl Scratch {
             pal_cache: [0; 768],
             src: alloc::vec::Vec::new(),
             row: alloc::vec::Vec::new(),
+            prev: alloc::vec::Vec::new(),
+            prev_w: 0,
+            prev_h: 0,
+            prev_out_w: 0,
+            prev_out_h: 0,
+            damage_epoch: 0,
+            overlay: false,
+            input_vram: alloc::vec::Vec::new(),
+            input_planes: alloc::vec::Vec::new(),
+            input_mode: None,
+            input_ac: [0; 21],
+            input_palette: [0; 768],
+            input_cga_palette: [0; 4],
+            input_blink: false,
+            input_start_offset: 0,
+            input_pixel_pan: 0,
+            input_line_compare: 0,
         }
+    }
+}
+
+#[cfg(target_arch = "x86")]
+core::arch::global_asm!(
+    r#"
+    .global retroos_fb_copy32
+    .type retroos_fb_copy32, @function
+retroos_fb_copy32:
+    push esi
+    push edi
+    mov edi, dword ptr [esp + 12]
+    mov esi, dword ptr [esp + 16]
+    mov ecx, dword ptr [esp + 20]
+    cld
+    rep movsd
+    pop edi
+    pop esi
+    ret
+    .size retroos_fb_copy32, .-retroos_fb_copy32
+"#
+);
+
+#[cfg(target_arch = "x86")]
+unsafe extern "C" {
+    fn retroos_fb_copy32(dst: *mut u32, src: *const u32, len: usize);
+}
+
+/// Copy framebuffer pixels in their native 32-bit unit. The freestanding
+/// runtime's generic `memcpy` is `rep movsb`; using MOVSD here quarters the
+/// architectural transfer count and lets x86/QEMU recognize the bulk store.
+#[inline]
+unsafe fn copy_pixels(dst: *mut u32, src: *const u32, len: usize) {
+    #[cfg(target_arch = "x86")]
+    unsafe {
+        retroos_fb_copy32(dst, src, len);
+    }
+    #[cfg(target_arch = "x86_64")]
+    unsafe {
+        core::arch::asm!(
+            "rep movsd",
+            inout("rcx") len => _,
+            inout("rsi") src => _,
+            inout("rdi") dst => _,
+            options(nostack)
+        );
     }
 }
 
@@ -81,10 +172,15 @@ impl Scratch {
 /// and nothing recomputed per output pixel — run lengths come from a Bresenham
 /// accumulator and the fill is a fixed width with the cursor advanced by the
 /// true amount, so the overshoot is harmlessly overwritten.
-pub fn blit(s: &mut Scratch, fb: &Framebuffer, frame: &lib::vga_render::Frame) {
+pub fn blit(
+    s: &mut Scratch,
+    fb: &Framebuffer,
+    frame: &lib::vga_render::Frame,
+    overlay: bool,
+) -> usize {
     let (w, h) = lib::vga_render::dimensions(frame.mode);
     if w == 0 || h == 0 {
-        return;
+        return 0;
     }
     let (out_w, out_h) = if fb.width * 3 >= fb.height * 4 {
         ((fb.height * 4 / 3).min(fb.width), fb.height)
@@ -92,8 +188,37 @@ pub fn blit(s: &mut Scratch, fb: &Framebuffer, frame: &lib::vga_render::Frame) {
         (fb.width, (fb.width * 3 / 4).min(fb.height))
     };
     if out_w < w || out_h < h {
-        return; // no downscaling path
+        return 0; // no downscaling path
     }
+    let epoch = DAMAGE_EPOCH.load(core::sync::atomic::Ordering::Relaxed);
+    let external_damage = s.damage_epoch != epoch || (s.overlay && !overlay);
+    let same_input = s.input_mode == Some(frame.mode)
+        && s.input_blink == frame.blink
+        && s.input_start_offset == frame.start_offset
+        && s.input_pixel_pan == frame.pixel_pan
+        && s.input_line_compare == frame.line_compare
+        && s.input_cga_palette == frame.cga_palette
+        && s.input_ac == *frame.ac
+        && s.input_palette == *frame.palette
+        && s.input_vram == frame.vram
+        && s.input_planes == frame.planes;
+    if same_input && !external_damage {
+        s.overlay = overlay;
+        return 0;
+    }
+    s.input_vram.clear();
+    s.input_vram.extend_from_slice(frame.vram);
+    s.input_planes.clear();
+    s.input_planes.extend_from_slice(frame.planes);
+    s.input_mode = Some(frame.mode);
+    s.input_ac = *frame.ac;
+    s.input_palette = *frame.palette;
+    s.input_cga_palette = frame.cga_palette;
+    s.input_blink = frame.blink;
+    s.input_start_offset = frame.start_offset;
+    s.input_pixel_pan = frame.pixel_pan;
+    s.input_line_compare = frame.line_compare;
+
     let origin = (fb.height - out_h) / 2 * fb.stride + (fb.width - out_w) / 2;
     s.pal.sync(frame.palette, fb.format, &mut s.pal_cache);
 
@@ -103,25 +228,66 @@ pub fn blit(s: &mut Scratch, fb: &Framebuffer, frame: &lib::vga_render::Frame) {
     let (ybase, yrem) = (out_h / h, out_h % h);
     s.src.resize(w, 0);
     s.row.resize(out_w + xbase + 1, 0);
+    let full = s.prev_w != w
+        || s.prev_h != h
+        || s.prev_out_w != out_w
+        || s.prev_out_h != out_h
+        || s.prev.len() != w * h
+        || external_damage;
+    if s.prev.len() != w * h {
+        s.prev.resize(w * h, 0);
+    }
+    s.prev_w = w;
+    s.prev_h = h;
+    s.prev_out_w = out_w;
+    s.prev_out_h = out_h;
+    s.damage_epoch = epoch;
+    s.overlay = overlay;
 
     let out = unsafe {
         core::slice::from_raw_parts_mut(fb.va as *mut u32, fb.stride * fb.height)
     };
+    let mut copied = 0usize;
     let (mut oy, mut yerr) = (0usize, 0usize);
     for sy in 0..h {
         lib::vga_render::render_row(frame, sy, &s.pal, &mut s.src);
+        let prev = &mut s.prev[sy * w..(sy + 1) * w];
+        let changed = if full {
+            Some((0, w))
+        } else {
+            let first = s.src.iter().zip(prev.iter()).position(|(a, b)| a != b);
+            first.map(|first| {
+                let last = s.src.iter().zip(prev.iter()).rposition(|(a, b)| a != b).unwrap();
+                (first, last + 1)
+            })
+        };
+        prev.copy_from_slice(&s.src);
+
+        yerr += yrem;
+        let rows = ybase + if yerr >= h { yerr -= h; 1 } else { 0 };
+        let Some((first, end)) = changed else {
+            oy += rows;
+            continue;
+        };
         let (mut o, mut xerr) = (0usize, 0usize);
         for &v in &s.src {
             s.row[o..o + xbase + 1].fill(v);
             xerr += xrem;
             o += xbase + if xerr >= w { xerr -= w; 1 } else { 0 };
         }
-        yerr += yrem;
-        let rows = ybase + if yerr >= h { yerr -= h; 1 } else { 0 };
+        // The scaler's Bresenham boundaries are floor(x*out_w/w). Expand only
+        // the destination span covered by changed source pixels.
+        let x0 = first * out_w / w;
+        let x1 = (end * out_w).div_ceil(w).min(out_w);
+        let len = x1 - x0;
         for _ in 0..rows {
             let d = origin + oy * fb.stride;
-            out[d..d + out_w].copy_from_slice(&s.row[..out_w]);
+            unsafe {
+                copy_pixels(out.as_mut_ptr().add(d + x0), s.row.as_ptr().add(x0), len);
+            }
+            copied += len;
             oy += 1;
         }
     }
+    copied
 }

--- a/kernel/src/kernel/display.rs
+++ b/kernel/src/kernel/display.rs
@@ -137,15 +137,37 @@ unsafe fn copy_pixels(dst: *mut u32, src: *const u32, len: usize) {
     }
 }
 
-/// Cheap pre-gate for [`raster`]: would the beam paint anything now? Lets the
+/// Vertical-blank length in beam steps: ~6% of the sweep, close enough to
+/// the real VGA's vertical blanking for code that races the beam or batches
+/// DAC loads into the window.
+fn vblank_rows(h: usize) -> usize {
+    (h / 16).max(1)
+}
+
+/// The beam's guest-visible vertical-retrace state, when a beam is actively
+/// sweeping this display: `Some(in_retrace)`. `None` when no raster is live
+/// on this scratch (window sink, unfocused thread, real VGA) — the caller
+/// falls back to its clock fabrication. This is what makes the fabricated
+/// 0x3DA truthful: "in retrace" means the frame really has finished
+/// painting, so retrace-raced VRAM updates land exactly as on hardware.
+pub fn beam_vretrace(s: &Scratch, now_ms: u64) -> Option<bool> {
+    let h = s.geo.1;
+    if h == 0 || now_ms.saturating_sub(s.last_ms) > 100 {
+        return None;
+    }
+    Some(s.sy >= h)
+}
+
+/// Cheap pre-gate for [`raster`]: would the beam step at all now? Lets the
 /// event loop skip the scanout entirely on the (vast majority of) passes
-/// where no row is due yet.
+/// where no step is due yet.
 pub fn raster_pending(s: &Scratch, now_ms: u64, period_ms: u64) -> bool {
-    let h = s.geo.1 as u64;
+    let h = s.geo.1;
     if h == 0 {
         return true; // not armed yet: run once to arm the geometry
     }
-    s.acc + now_ms.saturating_sub(s.last_ms) * h >= period_ms
+    let total = (h + vblank_rows(h)) as u64;
+    s.acc + now_ms.saturating_sub(s.last_ms) * total >= period_ms
 }
 
 /// Advance the raster beam and paint the band of device rows now due.
@@ -211,11 +233,14 @@ pub fn raster(
         s.last_ms = now_ms;
     }
 
-    // Row credit from elapsed virtual time: h source rows per period, at most
-    // one frame of debt, at most a bounded band per call.
+    // Step credit from elapsed virtual time: a sweep is `h` painted rows
+    // plus a vertical-blank tail, all steps together spanning one period —
+    // at most one frame of debt, at most a bounded band per call.
+    let vb = vblank_rows(h);
+    let total = (h + vb) as u64;
     let dt = now_ms.saturating_sub(s.last_ms);
     s.last_ms = now_ms;
-    s.acc = (s.acc + dt * h as u64).min(h as u64 * period_ms);
+    s.acc = (s.acc + dt * total).min(total * period_ms);
     let due = (s.acc / period_ms) as usize;
     let paint = due.min((h / 8).max(1));
     if paint == 0 {
@@ -233,6 +258,17 @@ pub fn raster(
     let mut copied = 0usize;
     let mut wrapped = false;
     for _ in 0..paint {
+        if s.sy >= h {
+            // Vertical blank: the beam idles below the frame. 0x3DA reads
+            // this phase via `beam_vretrace`; nothing is painted.
+            s.sy += 1;
+            if s.sy == h + vb {
+                s.sy = 0;
+                s.oy = 0;
+                s.yerr = 0;
+            }
+            continue;
+        }
         lib::vga_render::render_row(frame, s.sy, &s.pal, &mut s.src);
         let (mut o, mut xerr) = (bx, 0usize);
         for &v in &s.src {
@@ -256,16 +292,15 @@ pub fn raster(
         if s.sy == h {
             // Letterbox bands (rare geometry — 4:3 content on a 4:3-or-wider
             // panel pillarboxes instead, and the row copy above covers those
-            // borders every row): painted once per sweep, at the retrace.
+            // borders every row): painted once per sweep, entering blank.
             for y in (0..by).chain(by + out_h..fb.height) {
                 unsafe {
                     core::ptr::write_bytes(out.as_mut_ptr().add(y * fb.stride), 0, fb.width);
                 }
                 copied += fb.width;
             }
-            s.sy = 0;
-            s.oy = 0;
-            s.yerr = 0;
+            // Frame complete: the beam enters vertical blank (the retrace
+            // 0x3DA now reports) and the caller presents.
             wrapped = true;
         }
     }

--- a/kernel/src/kernel/display.rs
+++ b/kernel/src/kernel/display.rs
@@ -37,8 +37,6 @@ pub struct Framebuffer {
 /// Backend hook: the frame is finished, show it. Installed by the entry crate
 /// like the portio/hostfs/socket hooks.
 static mut PRESENT: fn() = || {};
-static DAMAGE_EPOCH: core::sync::atomic::AtomicU32 =
-    core::sync::atomic::AtomicU32::new(1);
 
 pub fn set_present_hook(f: fn()) {
     unsafe { PRESENT = f };
@@ -48,36 +46,26 @@ pub fn present() {
     (unsafe { PRESENT })();
 }
 
-/// Tell the incremental blitter that something outside it wrote the display
-/// (the framebuffer console, for example), so its next frame repaints fully.
-pub fn damage() {
-    DAMAGE_EPOCH.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-}
-
-/// Scratch for the blit: the palette in framebuffer format, one source row,
-/// one stretched output row, and the previous source image for dirty spans.
+/// Scratch for the raster: the palette in framebuffer format, one rendered
+/// source row, one full device row (borders + scaled content), and the beam.
 pub struct Scratch {
     pal: lib::vga_render::Pal,
     pal_cache: [u8; 768],
     src: alloc::vec::Vec<u32>,
     row: alloc::vec::Vec<u32>,
-    prev: alloc::vec::Vec<u32>,
-    prev_w: usize,
-    prev_h: usize,
-    prev_out_w: usize,
-    prev_out_h: usize,
-    damage_epoch: u32,
-    overlay: bool,
-    input_vram: alloc::vec::Vec<u8>,
-    input_planes: alloc::vec::Vec<u8>,
-    input_mode: Option<lib::vga_render::VgaMode>,
-    input_ac: [u8; 21],
-    input_palette: [u8; 768],
-    input_cga_palette: [u32; 4],
-    input_blink: bool,
-    input_start_offset: usize,
-    input_pixel_pan: usize,
-    input_line_compare: usize,
+    /// Geometry the beam is armed for `(w, h, out_w, out_h)`; any change
+    /// restarts the sweep at the top — a mode switch repaints everything,
+    /// borders included, within one refresh period by construction.
+    geo: (usize, usize, usize, usize),
+    /// Beam position: next source row, and its output-row Bresenham state.
+    sy: usize,
+    oy: usize,
+    yerr: usize,
+    /// Fractional row credit: accrues `elapsed_ms × h`, spends `period_ms`
+    /// per source row, capped at one frame of debt (a long stall skips
+    /// frames instead of fast-forwarding the beam).
+    acc: u64,
+    last_ms: u64,
 }
 
 impl Default for Scratch {
@@ -93,23 +81,12 @@ impl Scratch {
             pal_cache: [0; 768],
             src: alloc::vec::Vec::new(),
             row: alloc::vec::Vec::new(),
-            prev: alloc::vec::Vec::new(),
-            prev_w: 0,
-            prev_h: 0,
-            prev_out_w: 0,
-            prev_out_h: 0,
-            damage_epoch: 0,
-            overlay: false,
-            input_vram: alloc::vec::Vec::new(),
-            input_planes: alloc::vec::Vec::new(),
-            input_mode: None,
-            input_ac: [0; 21],
-            input_palette: [0; 768],
-            input_cga_palette: [0; 4],
-            input_blink: false,
-            input_start_offset: 0,
-            input_pixel_pan: 0,
-            input_line_compare: 0,
+            geo: (0, 0, 0, 0),
+            sy: 0,
+            oy: 0,
+            yerr: 0,
+            acc: 0,
+            last_ms: 0,
         }
     }
 }
@@ -160,27 +137,48 @@ unsafe fn copy_pixels(dst: *mut u32, src: *const u32, len: usize) {
     }
 }
 
-/// Blit a frame — ANY mode — scaled into the framebuffer's 4:3 rectangle.
+/// Cheap pre-gate for [`raster`]: would the beam paint anything now? Lets the
+/// event loop skip the scanout entirely on the (vast majority of) passes
+/// where no row is due yet.
+pub fn raster_pending(s: &Scratch, now_ms: u64, period_ms: u64) -> bool {
+    let h = s.geo.1 as u64;
+    if h == 0 {
+        return true; // not armed yet: run once to arm the geometry
+    }
+    s.acc + now_ms.saturating_sub(s.last_ms) * h >= period_ms
+}
+
+/// Advance the raster beam and paint the band of device rows now due.
 ///
-/// DOS modes are authored for a 4:3 display with non-square pixels, so fitting
-/// the source to 4:3 rather than scaling both axes equally reproduces each
-/// mode's pixel aspect: 320x200 stretched 6/5 tall, 320x240 square.
+/// The frame is presented the way the hardware presented it: a beam sweeps
+/// the display top to bottom once per refresh period, re-rendering every
+/// pixel from the live VGA state as it passes — scaled content and borders
+/// alike. There is no diff, no damage tracking and no idle path: correctness
+/// never depends on knowing what changed (nothing can leak through a crash
+/// or a mode switch), and the work per call is bounded, so the event loop
+/// never stalls on a frame regardless of panel size. The games' own
+/// present model (update VRAM during vertical retrace) composes with this
+/// exactly as on a real VGA.
 ///
-/// One pass per SOURCE row: the renderer draws that row straight into the
-/// framebuffer's pixel format, it is stretched once, then copied to every
-/// output row it covers. No full-frame intermediate, no per-mode special case,
-/// and nothing recomputed per output pixel — run lengths come from a Bresenham
-/// accumulator and the fill is a fixed width with the cursor advanced by the
-/// true amount, so the overshoot is harmlessly overwritten.
-pub fn blit(
+/// DOS modes are authored for a 4:3 display with non-square pixels, so the
+/// source is fitted to the framebuffer's 4:3 rectangle: 320x200 stretched
+/// 6/5 tall, 320x240 square. One pass per SOURCE row: the renderer draws the
+/// row in the framebuffer's pixel format, it is stretched once into a full
+/// device row (black borders at both ends), and that row is copied to every
+/// output row it covers — run lengths from a Bresenham accumulator.
+///
+/// Returns `(pixels_written, wrapped)`; `wrapped` marks the beam finishing a
+/// frame — the vertical retrace — where the caller presents.
+pub fn raster(
     s: &mut Scratch,
     fb: &Framebuffer,
     frame: &lib::vga_render::Frame,
-    overlay: bool,
-) -> usize {
+    now_ms: u64,
+    period_ms: u64,
+) -> (usize, bool) {
     let (w, h) = lib::vga_render::dimensions(frame.mode);
     if w == 0 || h == 0 {
-        return 0;
+        return (0, false);
     }
     let (out_w, out_h) = if fb.width * 3 >= fb.height * 4 {
         ((fb.height * 4 / 3).min(fb.width), fb.height)
@@ -188,106 +186,88 @@ pub fn blit(
         (fb.width, (fb.width * 3 / 4).min(fb.height))
     };
     if out_w < w || out_h < h {
-        return 0; // no downscaling path
+        return (0, false); // no downscaling path
     }
-    let epoch = DAMAGE_EPOCH.load(core::sync::atomic::Ordering::Relaxed);
-    let external_damage = s.damage_epoch != epoch || (s.overlay && !overlay);
-    let same_input = s.input_mode == Some(frame.mode)
-        && s.input_blink == frame.blink
-        && s.input_start_offset == frame.start_offset
-        && s.input_pixel_pan == frame.pixel_pan
-        && s.input_line_compare == frame.line_compare
-        && s.input_cga_palette == frame.cga_palette
-        && s.input_ac == *frame.ac
-        && s.input_palette == *frame.palette
-        && s.input_vram == frame.vram
-        && s.input_planes == frame.planes;
-    if same_input && !external_damage {
-        s.overlay = overlay;
-        return 0;
-    }
-    s.input_vram.clear();
-    s.input_vram.extend_from_slice(frame.vram);
-    s.input_planes.clear();
-    s.input_planes.extend_from_slice(frame.planes);
-    s.input_mode = Some(frame.mode);
-    s.input_ac = *frame.ac;
-    s.input_palette = *frame.palette;
-    s.input_cga_palette = frame.cga_palette;
-    s.input_blink = frame.blink;
-    s.input_start_offset = frame.start_offset;
-    s.input_pixel_pan = frame.pixel_pan;
-    s.input_line_compare = frame.line_compare;
 
-    let origin = (fb.height - out_h) / 2 * fb.stride + (fb.width - out_w) / 2;
-    s.pal.sync(frame.palette, fb.format, &mut s.pal_cache);
-
-    // Each source pixel covers `xbase` or `xbase + 1` output pixels; fill the
-    // wider constant every time and step by the true amount.
+    // Each source pixel covers `xbase` or `xbase + 1` output pixels; the
+    // stretcher fills the wider constant every time and steps by the true
+    // amount, so it overshoots at most `xbase + 1` past the content edge.
     let (xbase, xrem) = (out_w / w, out_w % w);
     let (ybase, yrem) = (out_h / h, out_h % h);
-    s.src.resize(w, 0);
-    s.row.resize(out_w + xbase + 1, 0);
-    let full = s.prev_w != w
-        || s.prev_h != h
-        || s.prev_out_w != out_w
-        || s.prev_out_h != out_h
-        || s.prev.len() != w * h
-        || external_damage;
-    if s.prev.len() != w * h {
-        s.prev.resize(w * h, 0);
+    let bx = (fb.width - out_w) / 2; // left border width
+    let by = (fb.height - out_h) / 2; // top border height
+    let slack = xbase + 1;
+
+    if s.geo != (w, h, out_w, out_h) || s.row.len() != fb.width + slack {
+        s.geo = (w, h, out_w, out_h);
+        s.src.clear();
+        s.src.resize(w, 0);
+        s.row.clear();
+        s.row.resize(fb.width + slack, 0); // border pixels stay black
+        s.sy = 0;
+        s.oy = 0;
+        s.yerr = 0;
+        s.acc = 0;
+        s.last_ms = now_ms;
     }
-    s.prev_w = w;
-    s.prev_h = h;
-    s.prev_out_w = out_w;
-    s.prev_out_h = out_h;
-    s.damage_epoch = epoch;
-    s.overlay = overlay;
+
+    // Row credit from elapsed virtual time: h source rows per period, at most
+    // one frame of debt, at most a bounded band per call.
+    let dt = now_ms.saturating_sub(s.last_ms);
+    s.last_ms = now_ms;
+    s.acc = (s.acc + dt * h as u64).min(h as u64 * period_ms);
+    let due = (s.acc / period_ms) as usize;
+    let paint = due.min((h / 8).max(1));
+    if paint == 0 {
+        return (0, false);
+    }
+    s.acc -= paint as u64 * period_ms;
+
+    // Palette synced per band, not per frame: a mid-frame DAC write shears
+    // across the sweep exactly like the raster effects it was written for.
+    s.pal.sync(frame.palette, fb.format, &mut s.pal_cache);
 
     let out = unsafe {
         core::slice::from_raw_parts_mut(fb.va as *mut u32, fb.stride * fb.height)
     };
     let mut copied = 0usize;
-    let (mut oy, mut yerr) = (0usize, 0usize);
-    for sy in 0..h {
-        lib::vga_render::render_row(frame, sy, &s.pal, &mut s.src);
-        let prev = &mut s.prev[sy * w..(sy + 1) * w];
-        let changed = if full {
-            Some((0, w))
-        } else {
-            let first = s.src.iter().zip(prev.iter()).position(|(a, b)| a != b);
-            first.map(|first| {
-                let last = s.src.iter().zip(prev.iter()).rposition(|(a, b)| a != b).unwrap();
-                (first, last + 1)
-            })
-        };
-        prev.copy_from_slice(&s.src);
-
-        yerr += yrem;
-        let rows = ybase + if yerr >= h { yerr -= h; 1 } else { 0 };
-        let Some((first, end)) = changed else {
-            oy += rows;
-            continue;
-        };
-        let (mut o, mut xerr) = (0usize, 0usize);
+    let mut wrapped = false;
+    for _ in 0..paint {
+        lib::vga_render::render_row(frame, s.sy, &s.pal, &mut s.src);
+        let (mut o, mut xerr) = (bx, 0usize);
         for &v in &s.src {
             s.row[o..o + xbase + 1].fill(v);
             xerr += xrem;
             o += xbase + if xerr >= w { xerr -= w; 1 } else { 0 };
         }
-        // The scaler's Bresenham boundaries are floor(x*out_w/w). Expand only
-        // the destination span covered by changed source pixels.
-        let x0 = first * out_w / w;
-        let x1 = (end * out_w).div_ceil(w).min(out_w);
-        let len = x1 - x0;
+        // Re-blacken the stretcher's overshoot: that strip is right border.
+        s.row[bx + out_w..].fill(0);
+        s.yerr += yrem;
+        let rows = ybase + if s.yerr >= h { s.yerr -= h; 1 } else { 0 };
         for _ in 0..rows {
-            let d = origin + oy * fb.stride;
+            let d = (by + s.oy) * fb.stride;
             unsafe {
-                copy_pixels(out.as_mut_ptr().add(d + x0), s.row.as_ptr().add(x0), len);
+                copy_pixels(out.as_mut_ptr().add(d), s.row.as_ptr(), fb.width);
             }
-            copied += len;
-            oy += 1;
+            copied += fb.width;
+            s.oy += 1;
+        }
+        s.sy += 1;
+        if s.sy == h {
+            // Letterbox bands (rare geometry — 4:3 content on a 4:3-or-wider
+            // panel pillarboxes instead, and the row copy above covers those
+            // borders every row): painted once per sweep, at the retrace.
+            for y in (0..by).chain(by + out_h..fb.height) {
+                unsafe {
+                    core::ptr::write_bytes(out.as_mut_ptr().add(y * fb.stride), 0, fb.width);
+                }
+                copied += fb.width;
+            }
+            s.sy = 0;
+            s.oy = 0;
+            s.yerr = 0;
+            wrapped = true;
         }
     }
-    copied
+    (copied, wrapped)
 }

--- a/kernel/src/kernel/display.rs
+++ b/kernel/src/kernel/display.rs
@@ -32,6 +32,12 @@ pub struct Framebuffer {
     /// Full-frame writes are unusually expensive (QEMU-TCG's strong-UC GOP
     /// mapping), so emulated VGA should use a conservative refresh cadence.
     pub slow: bool,
+    /// Bare metal: device-row copies use 16-byte non-temporal stores. Real
+    /// WC apertures never engage the CPU's fast-string path, so rep movsd
+    /// issues one 4-byte store per cycle there; under a hypervisor the
+    /// framebuffer is host-RAM-backed (effectively WB) and rep movsd's
+    /// fast-string/helper paths win instead — both measured.
+    pub wide: bool,
 }
 
 /// Backend hook: the frame is finished, show it. Installed by the entry crate
@@ -106,25 +112,81 @@ retroos_fb_copy32:
     pop esi
     ret
     .size retroos_fb_copy32, .-retroos_fb_copy32
+
+    .global retroos_fb_copy32_wide
+    .type retroos_fb_copy32_wide, @function
+    /* Wide device-row copy: 16-byte non-temporal stores to the WC
+     * framebuffer — four times fewer store instructions than rep movsd.
+     * The kernel swaps FPU/SSE state only at thread switch, so the guest's
+     * live XMM registers are resident here: xmm0 is spilled around the
+     * copy. Head loop aligns the destination to 16 (movntdq requires it);
+     * the sfence keeps the NT stores ordered before the caller's
+     * present-time WC drain. */
+retroos_fb_copy32_wide:
+    push esi
+    push edi
+    mov edi, dword ptr [esp + 12]
+    mov esi, dword ptr [esp + 16]
+    mov ecx, dword ptr [esp + 20]
+    cld
+    sub esp, 16
+    movdqu [esp], xmm0
+1:  test edi, 15
+    jz 2f
+    test ecx, ecx
+    jz 4f
+    movsd
+    dec ecx
+    jmp 1b
+2:  mov eax, ecx
+    shr eax, 2
+    jz 4f
+    and ecx, 3
+3:  movdqu xmm0, [esi]
+    movntdq [edi], xmm0
+    add esi, 16
+    add edi, 16
+    dec eax
+    jnz 3b
+4:  rep movsd
+    movdqu xmm0, [esp]
+    add esp, 16
+    sfence
+    pop edi
+    pop esi
+    ret
+    .size retroos_fb_copy32_wide, .-retroos_fb_copy32_wide
 "#
 );
 
 #[cfg(target_arch = "x86")]
 unsafe extern "C" {
     fn retroos_fb_copy32(dst: *mut u32, src: *const u32, len: usize);
+    fn retroos_fb_copy32_wide(dst: *mut u32, src: *const u32, len: usize);
 }
 
 /// Copy framebuffer pixels in their native 32-bit unit. The freestanding
 /// runtime's generic `memcpy` is `rep movsb`; using MOVSD here quarters the
 /// architectural transfer count and lets x86/QEMU recognize the bulk store.
+///
+/// `wide` selects 16-byte non-temporal stores (real hardware: ERMS fast
+/// strings never engage on the WC framebuffer, so rep movsd issues one
+/// 4-byte store per cycle — the wide path quarters the issue count). Under
+/// TCG (`fb.slow`) rep movsd IS the fast path — one helper call — so the
+/// caller keeps `wide` off there.
 #[inline]
-unsafe fn copy_pixels(dst: *mut u32, src: *const u32, len: usize) {
+unsafe fn copy_pixels(dst: *mut u32, src: *const u32, len: usize, wide: bool) {
     #[cfg(target_arch = "x86")]
     unsafe {
-        retroos_fb_copy32(dst, src, len);
+        if wide {
+            retroos_fb_copy32_wide(dst, src, len);
+        } else {
+            retroos_fb_copy32(dst, src, len);
+        }
     }
     #[cfg(target_arch = "x86_64")]
     unsafe {
+        let _ = wide; // 64-bit metal: measure before adding the SSE path
         core::arch::asm!(
             "rep movsd",
             inout("rcx") len => _,
@@ -278,7 +340,7 @@ pub fn raster(
         for _ in 0..rows {
             let d = (by + s.oy) * fb.stride + bx;
             unsafe {
-                copy_pixels(out.as_mut_ptr().add(d), s.row.as_ptr(), out_w);
+                copy_pixels(out.as_mut_ptr().add(d), s.row.as_ptr(), out_w, fb.wide);
             }
             copied += out_w;
             s.oy += 1;

--- a/kernel/src/kernel/display.rs
+++ b/kernel/src/kernel/display.rs
@@ -137,11 +137,13 @@ unsafe fn copy_pixels(dst: *mut u32, src: *const u32, len: usize) {
     }
 }
 
-/// Vertical-blank length in beam steps: ~6% of the sweep, close enough to
-/// the real VGA's vertical blanking for code that races the beam or batches
-/// DAC loads into the window.
+/// Vertical-blank length in beam steps (source rows). The 70 Hz VGA CRTC
+/// scans 449 lines per frame with 400 visible and 49 blanked, so the blank
+/// tail is 49/400 of the visible height — ≈10.9% of the period, ~1.56 ms.
+/// `h·49/400` gives the hardware-exact fraction for both the 200-line
+/// (double-scanned) and 400-line mode families.
 fn vblank_rows(h: usize) -> usize {
-    (h / 16).max(1)
+    (h * 49 / 400).max(1)
 }
 
 /// The beam's guest-visible vertical-retrace state, when a beam is actively

--- a/kernel/src/kernel/dos/dos.rs
+++ b/kernel/src/kernel/dos/dos.rs
@@ -428,14 +428,26 @@ pub(super) fn pmdos_int21_handler<A: crate::Arch>(machine: &mut A, kt: &mut thre
         s
     } else { [0u64; 7] };
 
+    let al_in = regs.rax as u8;
     let action = int_21h(machine, kt, dos, regs);
 
     if mask16 {
+        // Pointer-returning calls hand a 32-bit LINEAR through LOW_MEM_SEL
+        // (ES:EBX / DS:ESI): there the high half IS the return value, so
+        // restoring the client's stale half would corrupt the pointer —
+        // DOS/16M's DPMILOAD stores the whole DS:ESI from AH=5D06 (LDS ESI)
+        // and dereferenced a stale-half kernel address (DUKE3D music SEGV).
+        let keep_ebx = matches!(ah, 0x2F | 0x34 | 0x52);
+        let keep_esi = ah == 0x5D && al_in == 0x06;
         regs.rax = (regs.rax & !HI) | saved_hi[0];
-        regs.rbx = (regs.rbx & !HI) | saved_hi[1];
+        if !keep_ebx {
+            regs.rbx = (regs.rbx & !HI) | saved_hi[1];
+        }
         regs.rcx = (regs.rcx & !HI) | saved_hi[2];
         regs.rdx = (regs.rdx & !HI) | saved_hi[3];
-        regs.rsi = (regs.rsi & !HI) | saved_hi[4];
+        if !keep_esi {
+            regs.rsi = (regs.rsi & !HI) | saved_hi[4];
+        }
         regs.rdi = (regs.rdi & !HI) | saved_hi[5];
         regs.rbp = (regs.rbp & !HI) | saved_hi[6];
     }
@@ -1052,7 +1064,11 @@ fn int_21h<A: crate::Arch>(machine: &mut A, kt: &mut thread::KernelThread<A>, do
         0x34 => {
             if dos.dpmi.is_some() && regs.frame.rflags as u32 & machine::VM_FLAG == 0 {
                 regs.es = dpmi::LOW_MEM_SEL as u64;
-                regs.rbx = (regs.rbx & !0xFFFF) | ((LOW_MEM_BASE + core::mem::offset_of!(LowMem, boot_psp) as u32) + INDOS_FLAG_OFFSET as u32) as u64;
+                // Full 32-bit write: the offset via LOW_MEM_SEL is a linear
+                // address, and PM clients may capture the whole register (LES
+                // EBX). A 16-bit merge leaks the caller's stale high half into
+                // the pointer (DOS/16M saved such a DS:ESI and faulted on it).
+                regs.rbx = ((LOW_MEM_BASE + core::mem::offset_of!(LowMem, boot_psp) as u32) + INDOS_FLAG_OFFSET as u32) as u64;
             } else {
                 regs.es = ((LOW_MEM_BASE + core::mem::offset_of!(LowMem, boot_psp) as u32) >> 4) as u64;
                 regs.rbx = (regs.rbx & !0xFFFF) | INDOS_FLAG_OFFSET as u64;
@@ -1116,7 +1132,9 @@ fn int_21h<A: crate::Arch>(machine: &mut A, kt: &mut thread::KernelThread<A>, do
             let dta = dos.dta;
             if dos.dpmi.is_some() && regs.frame.rflags as u32 & machine::VM_FLAG == 0 {
                 regs.es = dpmi::LOW_MEM_SEL as u64;
-                regs.rbx = (regs.rbx & !0xFFFF) | dta as u64;
+                // Full 32-bit write (see AH=34): a linear offset — and the DTA
+                // commonly exceeds 0xFFFF, which the 16-bit merge also mangled.
+                regs.rbx = dta as u64;
             } else {
                 regs.es = (dta >> 4) as u64;
                 regs.rbx = (regs.rbx & !0xFFFF) | (dta & 0x0F) as u64;
@@ -2025,7 +2043,8 @@ fn int_21h<A: crate::Arch>(machine: &mut A, kt: &mut thread::KernelThread<A>, do
             let lol_addr = LOW_MEM_BASE + core::mem::offset_of!(LowMem, lol) as u32;
             if dos.dpmi.is_some() && regs.frame.rflags as u32 & machine::VM_FLAG == 0 {
                 regs.es = dpmi::LOW_MEM_SEL as u64;
-                regs.rbx = (regs.rbx & !0xFFFF) | lol_addr as u64;
+                // Full 32-bit write (see AH=34): the offset is a linear address.
+                regs.rbx = lol_addr as u64;
             } else {
                 regs.es = (lol_addr >> 4) as u64;
                 regs.rbx = (regs.rbx & !0xFFFF) | (lol_addr & 0xF) as u64;
@@ -2289,7 +2308,11 @@ fn int_21h<A: crate::Arch>(machine: &mut A, kt: &mut thread::KernelThread<A>, do
                     let syspsp_addr = LOW_MEM_BASE + core::mem::offset_of!(LowMem, boot_psp) as u32;
                     if dos.dpmi.is_some() && regs.frame.rflags as u32 & machine::VM_FLAG == 0 {
                         regs.ds = dpmi::LOW_MEM_SEL as u64;
-                        regs.rsi = (regs.rsi & !0xFFFF) | syspsp_addr as u64;
+                        // Full 32-bit write (see AH=34): DOS/16M's DPMILOAD
+                        // stores this DS:ESI whole (LDS ESI) and dereferences
+                        // it later — a stale ESI31:16 became a kernel address
+                        // (the DUKE3D music-start SEGV).
+                        regs.rsi = syspsp_addr as u64;
                     } else {
                         regs.ds = (syspsp_addr >> 4) as u64;
                         regs.rsi &= !0xFFFF;

--- a/kernel/src/kernel/dos/dpmi/mod.rs
+++ b/kernel/src/kernel/dos/dpmi/mod.rs
@@ -547,9 +547,11 @@ fn dpmi_api_inner<A: crate::Arch>(machine: &mut A, dos: &mut thread::DosState<A>
         0x0203 => {
             let exc = regs.rbx as u8;
             if (exc as usize) < 15 {
-                dpmi.exc_vectors[exc as usize] = (regs.rcx as u16, regs.rdx as u32);
+                // 16-bit client: DX only — EDX-high is stale (cf. 0205/0303).
+                let off = if dpmi.client_use32 { regs.rdx as u32 } else { regs.rdx as u16 as u32 };
+                dpmi.exc_vectors[exc as usize] = (regs.rcx as u16, off);
                 dos_trace!("[DPMI] 0203 set exception {:02X} = {:04X}:{:08X}",
-                    exc, regs.rcx as u16, regs.rdx as u32);
+                    exc, regs.rcx as u16, off);
                 clear_carry(regs);
             } else {
                 set_carry(regs);
@@ -665,11 +667,25 @@ fn dpmi_api_inner<A: crate::Arch>(machine: &mut A, dos: &mut thread::DosState<A>
             let slot = dpmi.callbacks.iter().position(|c| c.is_none());
             match slot {
                 Some(i) => {
+                    // 16-bit client: DS:SI / ES:DI — the high halves of
+                    // ESI/EDI are legally stale garbage and MUST NOT enter
+                    // the stored offsets (cf. 0205's use32 handling). DOS/16M
+                    // registered its RM call structure with a leftover dirty
+                    // EDI-high, making struct_addr a kernel-stack address:
+                    // every callback then read/wrote the RmCallStruct inside
+                    // the kernel stack and handed the wild ES:EDI to the
+                    // handler, which dereferenced it → the DUKE3D music-start
+                    // SEGV at [ESI+0x14].
+                    let (pm_off, struct_off) = if dpmi.client_use32 {
+                        (regs.rsi as u32, regs.rdi as u32)
+                    } else {
+                        (regs.rsi as u16 as u32, regs.rdi as u16 as u32)
+                    };
                     dpmi.callbacks[i] = Some((
                         regs.ds as u16,
-                        regs.rsi as u32,
+                        pm_off,
                         regs.es as u16,
-                        regs.rdi as u32,
+                        struct_off,
                     ));
                     // Return real-mode address: the control view of the stub
                     // array, CTRL_STUB_SEG:ctrl_slot_off(SLOT_CB_ENTRY_BASE + i).

--- a/kernel/src/kernel/dos/dpmi/rm_calls.rs
+++ b/kernel/src/kernel/dos/dpmi/rm_calls.rs
@@ -233,8 +233,14 @@ pub(in crate::kernel::dos) fn callback_entry<A: crate::Arch>(machine: &mut A, do
     // DPMI 0.9 §6.1.1: DS:(E)SI must point at the RM stack location
     // where the caller's return addresses are pushed — handler reads
     // CS:IP from there. Capture before push_continuation_and_switch_to_pm_side mutates regs.
+    // 16-bit SP, not sp32(): the real-mode caller only maintains SP, and ESP's
+    // high half legally carries stale garbage (VM86 pushes/pops move SP while
+    // ESP31:16 keeps whatever an earlier PM context left there). Folding those
+    // bits in aimed DS:ESI at a kernel address — DUKE3D's DOS/16M callback
+    // handler read [ESI+0x14] and SEGV'd on the first timer tick after its
+    // music started.
     let rm_ss_sp_linear = (regs.stack_seg() as u32).wrapping_shl(4)
-        .wrapping_add(regs.sp32());
+        .wrapping_add(regs.sp32() & 0xFFFF);
 
     let pm_save_at = mode_transitions::push_continuation_and_switch_to_pm_side(machine, dos, regs, Some(struct_addr));
 

--- a/kernel/src/kernel/dos/machine/mod.rs
+++ b/kernel/src/kernel/dos/machine/mod.rs
@@ -491,43 +491,31 @@ pub fn emulate_inb<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, port: u1
     // separate path (arch::inl/outl), not this emulator.
     let port = port & 0x3FF;
     match port {
-        // VGA Input Status Register 1. Under QEMU its 0x3DA bit 3 doesn't sweep
-        // a raster in our setup (passthrough hangs Wolf3D's VL_WaitVBL), so
-        // under QEMU *only* we fabricate bit 3 and bit 0; Bochs / real hardware
-        // pass through (see the is_qemu gate below). The fabricated values:
-        //
-        //  - bit 3 (vertical retrace) — 70 Hz frame phase (mode 13h refresh,
-        //    14.286 ms / frame), asserted for 8/32 phase-steps ≈ 3.6 ms/frame.
-        //    Drives frame-level pacing (Wolf3D VL_WaitVBL, Build vsync).
-        //
-        //  - bit 0 (display-disabled / blanking) — per-read counter toggling
-        //    every 8 reads. Models *horizontal* blanking, which on real VGA
-        //    pulses at ~31.5 kHz (every scanline); frame-scale blanking
-        //    makes Build engine's per-DAC-entry snow-avoidance wait too slow. Runs of 8
-        //    ones/zeros also satisfy "6+ consecutive bit0=X" idioms
-        //    (Wolf3D's VL_SetScreen pre-CRTC-write wait, etc.) Vsync ⊂
-        //    blanking, so bit 0 is forced 1 whenever bit 3 is set.
+        // VGA Input Status Register 1: bit 3 (vertical retrace) and bit 0
+        // (blanking). Where the kernel's raster beam presents the display,
+        // bit 3 is the beam's own vertical blank — genuine state of the one
+        // VGA model, not a fabrication (see `input_status1`). Where no beam
+        // sweeps, a free-running 70 Hz phase fills in; Bochs / real VGA
+        // hardware pass the register through (QEMU's own 0x3DA bit 3 doesn't
+        // sweep in our setup — a passthrough hangs Wolf3D's VL_WaitVBL).
         //
         // The real `inb(0x3DA)` is retained for its hardware side-effect:
         // resetting the VGA attribute-controller flip-flop.
         0x3DA => {
             // Reading 0x3DA returns Input Status #1 AND resets the attribute-
             // controller write flip-flop — mirror that side effect either way.
-            // No card: the per-thread emulated flip-flop, fabricated status.
             if !vga::vga_present() {
                 pc.vga.ac_state.pending_data = false;
-                return fabricated_status1(machine);
+                return input_status1(machine, &pc.present_scratch2);
             }
             let real = machine.inb(0x3DA);
             unsafe { VGA_AC_STATE.pending_data = false; }
-            // QEMU's 0x3DA bit 3 (vsync) doesn't sweep a raster in our setup, so
-            // a passthrough hangs Wolf3D's VL_WaitVBL — under QEMU we fabricate.
-            // Bochs and real hardware drive 0x3DA from a real raster, so use the
-            // genuine bits there (flip-flop already handled above).
+            // Bochs and real hardware drive 0x3DA from a real raster, so use
+            // the genuine bits there (flip-flop already handled above).
             if crate::kernel::platform::get().host != crate::kernel::platform::Host::Qemu {
                 return real;
             }
-            fabricated_status1(machine)
+            input_status1(machine, &pc.present_scratch2)
         }
         // VGA ports — pass through to hardware, or the emulated register file
         // when no card is present (see vga::vga_present).
@@ -761,13 +749,28 @@ fn seg_base_for<A: crate::Arch>(regs: &Regs, sel: u16) -> u32 {
     }
 }
 
-/// Fabricated VGA Input Status #1 (see the `emulate_inb` 0x3DA arm for why):
-/// bit 3 = vertical retrace on a 70 Hz frame phase, bit 0 = blanking from a
-/// per-read counter, vsync forcing blanking.
-fn fabricated_status1<A: crate::Arch>(machine: &mut A) -> u8 {
+/// VGA Input Status #1 for the emulated card (see the `emulate_inb` 0x3DA
+/// arm): bit 3 = vertical retrace, bit 0 = blanking, vsync forcing blanking.
+///
+/// Bit 3 is the raster beam's OWN vertical blank whenever a beam is sweeping
+/// this display — the genuine state of the emulated VGA, not a fabrication:
+/// "in retrace" means the frame really finished painting, so retrace-raced
+/// VRAM updates and DAC loads land exactly as on hardware. Only displays
+/// without a live beam (window sink, unfocused thread) fall back to a
+/// fabricated free-running 70 Hz phase, asserted 8/32 steps ≈ 3.6 ms/frame.
+///
+/// Bit 0 (display-disabled / blanking) — per-read counter toggling every 8
+/// reads. Models *horizontal* blanking, which on real VGA pulses at
+/// ~31.5 kHz (every scanline); frame-scale blanking makes Build engine's
+/// per-DAC-entry snow-avoidance wait too slow. Runs of 8 ones/zeros also
+/// satisfy "6+ consecutive bit0=X" idioms (Wolf3D's VL_SetScreen
+/// pre-CRTC-write wait, etc.)
+fn input_status1<A: crate::Arch>(machine: &mut A, beam: &crate::kernel::display::Scratch) -> u8 {
     let ticks = machine.get_ticks();
-    let phase = ((ticks.wrapping_mul(70 * 32)) / 1000) as u32 & 31;
-    let vr = phase >= 24;
+    let vr = crate::kernel::display::beam_vretrace(beam, ticks).unwrap_or_else(|| {
+        let phase = ((ticks.wrapping_mul(70 * 32)) / 1000) as u32 & 31;
+        phase >= 24
+    });
     use core::sync::atomic::{AtomicU32, Ordering};
     static DA_READ_COUNT: AtomicU32 = AtomicU32::new(0);
     let hbl = (DA_READ_COUNT.fetch_add(1, Ordering::Relaxed) >> 3) & 1 != 0;

--- a/kernel/src/kernel/dos/machine/mod.rs
+++ b/kernel/src/kernel/dos/machine/mod.rs
@@ -1000,13 +1000,19 @@ pub fn audio_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mu
     // frontier. Stamping incoming MIDI with it decouples note onset from block
     // size (a note lands at its true sub-block frame, not the block start).
     let pushed = mixer.pace.pushed();
-    if mixer.midi_ms == 0 {
+    if !mixer.streaming {
+        // No output session: there is no sub-block position to spread
+        // arrivals into — the next produced frame IS the arrival frame.
+        // Letting the clock free-run here stamped a program's first notes
+        // "seconds since launch" into the future, and the synth dutifully
+        // held them: Dark Forces' fanfare ~3 s after the logo, DOOM's title
+        // music ~2 s late — the GM start delay.
         mixer.midi_frame = pushed;
-        mixer.midi_ms = now;
+    } else {
+        mixer.midi_frame = (mixer.midi_frame
+            + now.saturating_sub(mixer.midi_ms) * MIX_RATE as u64 / 1000)
+            .max(pushed);
     }
-    mixer.midi_frame = (mixer.midi_frame
-        + now.saturating_sub(mixer.midi_ms) * MIX_RATE as u64 / 1000)
-        .max(pushed);
     mixer.midi_ms = now;
     // MPU-401: drain the port's MIDI bytes into the synth (stamped at the arrival
     // frame) and satisfy a bounded number of its instrument requests (a .PAT

--- a/kernel/src/kernel/dos/machine/mod.rs
+++ b/kernel/src/kernel/dos/machine/mod.rs
@@ -954,6 +954,11 @@ pub struct Mixer {
     dsp_epoch: u64,
     streaming: bool,
     last_ms: u64,
+    /// MIDI-arrival frame clock: a real-time (get_ticks) counter in the mixer's
+    /// production frame numbering, never behind the production frontier. Incoming
+    /// MIDI bytes are stamped with it so note onset is independent of block size.
+    midi_frame: u64,
+    midi_ms: u64,
 }
 
 impl Mixer {
@@ -963,6 +968,8 @@ impl Mixer {
             dsp_epoch: 0,
             streaming: false,
             last_ms: 0,
+            midi_frame: 0,
+            midi_ms: 0,
         }
     }
 }
@@ -981,9 +988,25 @@ pub fn audio_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mu
     sb.deliver_trigger_irq(vpic);
     sb.deliver_probe_irq(machine, vpic);
     gus.tick(machine, vpic);
-    // MPU-401: drain the port's MIDI bytes into the synth and satisfy a
-    // bounded number of its instrument requests (a .PAT read per request).
-    mpu.tick();
+    // Advance the MIDI-arrival clock in the production frame numbering: extend it
+    // by the real time elapsed (get_ticks, ms → frames), but never behind the
+    // production frontier (`pushed`). Between production passes this spreads
+    // arrivals across the interval; at a pass boundary it re-aligns to the new
+    // frontier. Stamping incoming MIDI with it decouples note onset from block
+    // size (a note lands at its true sub-block frame, not the block start).
+    let pushed = mixer.pace.pushed();
+    if mixer.midi_ms == 0 {
+        mixer.midi_frame = pushed;
+        mixer.midi_ms = now;
+    }
+    mixer.midi_frame = (mixer.midi_frame
+        + now.saturating_sub(mixer.midi_ms) * MIX_RATE as u64 / 1000)
+        .max(pushed);
+    mixer.midi_ms = now;
+    // MPU-401: drain the port's MIDI bytes into the synth (stamped at the arrival
+    // frame) and satisfy a bounded number of its instrument requests (a .PAT
+    // read per request).
+    mpu.tick(mixer.midi_frame);
 
     // The pump runs on the millisecond, not on the slice. A DOS program that
     // drives an emulated device hard (the GUS driver writes GF1 registers by
@@ -1010,6 +1033,7 @@ pub fn audio_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mu
         }
         mixer.pace.reset();
         mixer.dsp_epoch = 0;
+        mixer.midi_ms = 0; // re-seed the MIDI clock on the next active session
         return;
     }
     // Source activity does not define the output session. In particular, an

--- a/kernel/src/kernel/dos/machine/mod.rs
+++ b/kernel/src/kernel/dos/machine/mod.rs
@@ -979,6 +979,8 @@ impl Mixer {
 /// every guest-visible clock from the sink's drain position.
 pub fn audio_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mut Regs) {
     let _ = regs;
+    let profiling = crate::kernel::startup::profile_enabled();
+    let prof_start = if profiling { machine.rdtsc() } else { 0 };
     let PcMachine { sb, gus, mpu, spk, vpic, mixer, .. } = pc;
     let now = machine.get_ticks();
     let dt = now.saturating_sub(mixer.last_ms).min(100);
@@ -1016,9 +1018,14 @@ pub fn audio_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mu
     // the pipe (tens of ms deep) had nothing to do 97% of the time. One read
     // per millisecond is two orders of magnitude inside the pipe's depth.
     if dt == 0 {
+        if profiling {
+            crate::kernel::startup::bill_audio(
+                machine.rdtsc().wrapping_sub(prof_start), 0, 0, 0, 0);
+        }
         return;
     }
     mixer.last_ms = now;
+    let prof_devices = if profiling { machine.rdtsc() } else { 0 };
 
     // ── the pump ──
     let dsp_on = sb.dsp_owns_sink();
@@ -1026,14 +1033,20 @@ pub fn audio_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mu
     let opl_on = sb.opl_audible(now);
     let midi_on = mpu.mixing();
     let spk_on = spk.audible(MIX_RATE);
-    if !dsp_on && !gus_on && !opl_on && !midi_on && !spk_on {
-        if mixer.streaming {
-            crate::kernel::sound::stop(machine, false); // pause, keep configured
-            mixer.streaming = false;
+    // Idle sources do NOT stop the sink: once a session streams, it stays
+    // alive and idle gaps pump silence. Stopping here paused/re-primed the
+    // hardware stream on every gap (menu→demo music transitions), and an HDA
+    // stream restarted without SRST can come back dead — freezing the drain
+    // clock every guest audio cursor and IRQ is slaved to. Warm-reboot codec
+    // safety is not this path's job: every shutdown/reboot/panic path calls
+    // `hda::emergency_quiesce`. Only a session that never started skips out.
+    if !dsp_on && !gus_on && !opl_on && !midi_on && !spk_on && !mixer.streaming {
+        if profiling {
+            crate::kernel::startup::bill_audio(
+                prof_devices.wrapping_sub(prof_start),
+                machine.rdtsc().wrapping_sub(prof_devices),
+                0, 0, 0);
         }
-        mixer.pace.reset();
-        mixer.dsp_epoch = 0;
-        mixer.midi_ms = 0; // re-seed the MIDI clock on the next active session
         return;
     }
     // Source activity does not define the output session. In particular, an
@@ -1045,7 +1058,9 @@ pub fn audio_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mu
     }
     let rate = MIX_RATE;
     let mut n = mixer.pace.due(machine, rate, dt, MIX_CHUNK);
+    let generated = n;
     let mut base = mixer.pace.pushed() - n;
+    let prof_setup = if profiling { machine.rdtsc() } else { 0 };
     // Sources sum into a WIDE accumulator and the mix is clipped exactly once,
     // here, on the way out. Saturating each i16 add per source (what we used to
     // do) clips every source against every other one: a full-scale digital SFX
@@ -1086,6 +1101,7 @@ pub fn audio_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mu
         n -= run as u64;
     }
     mixer.streaming = true;
+    let prof_pump = if profiling { machine.rdtsc() } else { 0 };
 
     // ── guest clocks & event delivery, on the drain clock ──
     // GUS events are stamped in mix frames; the DSP's cursor, DMA counts and
@@ -1101,6 +1117,15 @@ pub fn audio_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mu
     sb.dsp_clock_tick(machine, vpic, to_dsp(drained), to_dsp(pushed));
     gus.deliver_events(vpic);
 
+    if profiling {
+        let prof_end = machine.rdtsc();
+        crate::kernel::startup::bill_audio(
+            prof_devices.wrapping_sub(prof_start),
+            prof_setup.wrapping_sub(prof_devices),
+            prof_pump.wrapping_sub(prof_setup),
+            prof_end.wrapping_sub(prof_pump),
+            generated);
+    }
 }
 
 pub fn queue_irq<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mut Regs, event: crate::Irq) {

--- a/kernel/src/kernel/dos/machine/mod.rs
+++ b/kernel/src/kernel/dos/machine/mod.rs
@@ -957,11 +957,6 @@ pub struct Mixer {
     dsp_epoch: u64,
     streaming: bool,
     last_ms: u64,
-    /// MIDI-arrival frame clock: a real-time (get_ticks) counter in the mixer's
-    /// production frame numbering, never behind the production frontier. Incoming
-    /// MIDI bytes are stamped with it so note onset is independent of block size.
-    midi_frame: u64,
-    midi_ms: u64,
 }
 
 impl Mixer {
@@ -971,8 +966,6 @@ impl Mixer {
             dsp_epoch: 0,
             streaming: false,
             last_ms: 0,
-            midi_frame: 0,
-            midi_ms: 0,
         }
     }
 }
@@ -993,31 +986,18 @@ pub fn audio_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mu
     sb.deliver_trigger_irq(vpic);
     sb.deliver_probe_irq(machine, vpic);
     gus.tick(machine, vpic);
-    // Advance the MIDI-arrival clock in the production frame numbering: extend it
-    // by the real time elapsed (get_ticks, ms → frames), but never behind the
-    // production frontier (`pushed`). Between production passes this spreads
-    // arrivals across the interval; at a pass boundary it re-aligns to the new
-    // frontier. Stamping incoming MIDI with it decouples note onset from block
-    // size (a note lands at its true sub-block frame, not the block start).
-    let pushed = mixer.pace.pushed();
-    if !mixer.streaming {
-        // No output session: there is no sub-block position to spread
-        // arrivals into — the next produced frame IS the arrival frame.
-        // Letting the clock free-run here stamped a program's first notes
-        // "seconds since launch" into the future, and the synth dutifully
-        // held them: Dark Forces' fanfare ~3 s after the logo, DOOM's title
-        // music ~2 s late — the GM start delay.
-        mixer.midi_frame = pushed;
-    } else {
-        mixer.midi_frame = (mixer.midi_frame
-            + now.saturating_sub(mixer.midi_ms) * MIX_RATE as u64 / 1000)
-            .max(pushed);
-    }
-    mixer.midi_ms = now;
-    // MPU-401: drain the port's MIDI bytes into the synth (stamped at the arrival
-    // frame) and satisfy a bounded number of its instrument requests (a .PAT
-    // read per request).
-    mpu.tick(machine, mixer.midi_frame);
+    // MPU-401: drain the port's MIDI bytes into the synth and advance the
+    // instrument loader. Bytes are stamped at the production frontier — the
+    // frame the NEXT produced block starts at — which is the only number
+    // line the mixer has: this tick's pump renders them immediately, so a
+    // note sounds within one millisecond of its OUT. (An arrival-clock
+    // integrator used to "spread" stamps between pumps, but the pump runs
+    // per millisecond and all of a tick's bytes share one stamp anyway; the
+    // integrator's only observable behaviour was free-running ahead while
+    // no session streamed, stamping a program's first notes seconds into
+    // the future — the GM start delay: Dark Forces' fanfare ~3 s after the
+    // logo, DOOM's title music ~2 s late.)
+    mpu.tick(machine, mixer.pace.pushed());
 
     // The pump runs on the millisecond, not on the slice. A DOS program that
     // drives an emulated device hard (the GUS driver writes GF1 registers by

--- a/kernel/src/kernel/dos/machine/mod.rs
+++ b/kernel/src/kernel/dos/machine/mod.rs
@@ -1074,8 +1074,10 @@ pub fn audio_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mu
             source.mix_into(machine, rate, base, dsp_base, &mut frames[..run]);
         }
         for (i, (l, r)) in frames[..run].iter().enumerate() {
-            let l = sat16((l * out_gain) >> 16);
-            let r = sat16((r * out_gain) >> 16);
+            let l = sat16(((i64::from(*l) * i64::from(out_gain)) >> 16)
+                .clamp(i32::MIN as i64, i32::MAX as i64) as i32);
+            let r = sat16(((i64::from(*r) * i64::from(out_gain)) >> 16)
+                .clamp(i32::MIN as i64, i32::MAX as i64) as i32);
             bytes[i * 4..i * 4 + 2].copy_from_slice(&l.to_le_bytes());
             bytes[i * 4 + 2..i * 4 + 4].copy_from_slice(&r.to_le_bytes());
         }
@@ -1144,6 +1146,9 @@ pub fn queue_irq<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mut
                 pc.vpic.raise(pc.sb.irq);
             }
         }
+        // MSI identities are kernel-owned and never map onto the guest's ISA
+        // PIC. An unclaimed one is spurious, not a guest interrupt line.
+        Irq::Msi(_) => {}
     }
 }
 

--- a/kernel/src/kernel/dos/machine/mod.rs
+++ b/kernel/src/kernel/dos/machine/mod.rs
@@ -959,6 +959,12 @@ pub struct Mixer {
     /// MIDI bytes are stamped with it so note onset is independent of block size.
     midi_frame: u64,
     midi_ms: u64,
+    /// Last buffer-granular drain value, the ms it changed, and the size of that
+    /// step (the sink buffer, learned) — for smoothing the SB DSP's guest-visible
+    /// cursor between completion points (below).
+    drained_coarse: u64,
+    drained_ms: u64,
+    drain_step: u64,
 }
 
 impl Mixer {
@@ -970,6 +976,9 @@ impl Mixer {
             last_ms: 0,
             midi_frame: 0,
             midi_ms: 0,
+            drained_coarse: 0,
+            drained_ms: 0,
+            drain_step: 0,
         }
     }
 }
@@ -1034,6 +1043,9 @@ pub fn audio_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mu
         mixer.pace.reset();
         mixer.dsp_epoch = 0;
         mixer.midi_ms = 0; // re-seed the MIDI clock on the next active session
+        mixer.drained_coarse = 0;
+        mixer.drained_ms = 0;
+        mixer.drain_step = 0;
         return;
     }
     // Source activity does not define the output session. In particular, an
@@ -1091,9 +1103,25 @@ pub fn audio_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mu
     // into the DSP's rate on the way in.
     let drained = mixer.pace.drained();
     let pushed = mixer.pace.pushed();
+    // Smooth the drain for the SB DSP's guest-visible cursor. `drained` advances
+    // one whole buffer per completion interrupt; feeding that straight in makes
+    // `advance_clock` leap past several block boundaries at once, so `blocks_done`
+    // bursts ahead of the one-per-tick guest IRQ service → backlog and SFX
+    // crackle. A real SB's DMA cursor advances evenly, so interpolate between the
+    // completion points with real time, re-anchored whenever `drained` steps. The
+    // fraction is capped at the last observed step (the buffer size, learned from
+    // the step itself) so the cursor never crosses the next, unconfirmed boundary
+    // — keeping it monotonic — and the whole thing is capped at `pushed`.
+    if drained != mixer.drained_coarse {
+        mixer.drain_step = drained - mixer.drained_coarse;
+        mixer.drained_coarse = drained;
+        mixer.drained_ms = now;
+    }
+    let frac = (now.saturating_sub(mixer.drained_ms) * rate as u64 / 1000).min(mixer.drain_step);
+    let drained_smooth = (drained + frac).min(pushed);
     let dsp_rate = sb.dsp_rate().max(1) as u64;
     let to_dsp = |mix: u64| mix.saturating_sub(mixer.dsp_epoch) * dsp_rate / rate as u64;
-    sb.dsp_clock_tick(machine, vpic, to_dsp(drained), to_dsp(pushed));
+    sb.dsp_clock_tick(machine, vpic, to_dsp(drained_smooth), to_dsp(pushed));
     gus.deliver_events(vpic);
 
 }

--- a/kernel/src/kernel/dos/machine/mod.rs
+++ b/kernel/src/kernel/dos/machine/mod.rs
@@ -959,12 +959,6 @@ pub struct Mixer {
     /// MIDI bytes are stamped with it so note onset is independent of block size.
     midi_frame: u64,
     midi_ms: u64,
-    /// Last buffer-granular drain value, the ms it changed, and the size of that
-    /// step (the sink buffer, learned) — for smoothing the SB DSP's guest-visible
-    /// cursor between completion points (below).
-    drained_coarse: u64,
-    drained_ms: u64,
-    drain_step: u64,
 }
 
 impl Mixer {
@@ -976,9 +970,6 @@ impl Mixer {
             last_ms: 0,
             midi_frame: 0,
             midi_ms: 0,
-            drained_coarse: 0,
-            drained_ms: 0,
-            drain_step: 0,
         }
     }
 }
@@ -1043,9 +1034,6 @@ pub fn audio_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mu
         mixer.pace.reset();
         mixer.dsp_epoch = 0;
         mixer.midi_ms = 0; // re-seed the MIDI clock on the next active session
-        mixer.drained_coarse = 0;
-        mixer.drained_ms = 0;
-        mixer.drain_step = 0;
         return;
     }
     // Source activity does not define the output session. In particular, an
@@ -1101,27 +1089,14 @@ pub fn audio_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mu
     // GUS events are stamped in mix frames; the DSP's cursor, DMA counts and
     // block IRQs are all counted in *its* frames, so the drain point converts
     // into the DSP's rate on the way in.
+    // `drained` is already smoothed at the source (Pace interpolates the sink's
+    // per-buffer completions with real time), so the SB cursor derived from it
+    // advances evenly and production, `pushed`, and the cursor all move together.
     let drained = mixer.pace.drained();
     let pushed = mixer.pace.pushed();
-    // Smooth the drain for the SB DSP's guest-visible cursor. `drained` advances
-    // one whole buffer per completion interrupt; feeding that straight in makes
-    // `advance_clock` leap past several block boundaries at once, so `blocks_done`
-    // bursts ahead of the one-per-tick guest IRQ service → backlog and SFX
-    // crackle. A real SB's DMA cursor advances evenly, so interpolate between the
-    // completion points with real time, re-anchored whenever `drained` steps. The
-    // fraction is capped at the last observed step (the buffer size, learned from
-    // the step itself) so the cursor never crosses the next, unconfirmed boundary
-    // — keeping it monotonic — and the whole thing is capped at `pushed`.
-    if drained != mixer.drained_coarse {
-        mixer.drain_step = drained - mixer.drained_coarse;
-        mixer.drained_coarse = drained;
-        mixer.drained_ms = now;
-    }
-    let frac = (now.saturating_sub(mixer.drained_ms) * rate as u64 / 1000).min(mixer.drain_step);
-    let drained_smooth = (drained + frac).min(pushed);
     let dsp_rate = sb.dsp_rate().max(1) as u64;
     let to_dsp = |mix: u64| mix.saturating_sub(mixer.dsp_epoch) * dsp_rate / rate as u64;
-    sb.dsp_clock_tick(machine, vpic, to_dsp(drained_smooth), to_dsp(pushed));
+    sb.dsp_clock_tick(machine, vpic, to_dsp(drained), to_dsp(pushed));
     gus.deliver_events(vpic);
 
 }

--- a/kernel/src/kernel/dos/machine/mod.rs
+++ b/kernel/src/kernel/dos/machine/mod.rs
@@ -972,32 +972,33 @@ impl Mixer {
 
 /// Advance emulated sound by one event-loop quantum (no-op for the parts a
 /// real card serves): deliver device IRQs, run the mixer pump, then derive
+/// Per-slice device service — the audio work whose LATENCY contract is the
+/// event-loop slice, not the millisecond pump: the SB's latched 0xF2/0xF3
+/// trigger IRQ, single-cycle DMA probe completions (MI2's driver expects
+/// the completion back-to-back; a 1 ms floor loses it — see 35e3b27), the
+/// GF1 rate timers + DMA-TC IRQ, and the MPU byte drain (stamped at the
+/// production frontier — the frame the next produced block starts at, so a
+/// note sounds within one millisecond of its OUT; a free-running arrival
+/// clock here once stamped a program's first notes seconds ahead, the GM
+/// start delay). Called on every event-loop slice, including the ticks==0
+/// fast path that skips the pump entirely.
+pub fn audio_service<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine) {
+    let PcMachine { sb, gus, mpu, vpic, mixer, .. } = pc;
+    sb.deliver_trigger_irq(vpic);
+    sb.deliver_probe_irq(machine, vpic);
+    gus.tick(machine, vpic);
+    mpu.tick(machine, mixer.pace.pushed());
+}
+
 /// every guest-visible clock from the sink's drain position.
 pub fn audio_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mut Regs) {
     let _ = regs;
     let profiling = crate::kernel::startup::profile_enabled();
     let prof_start = if profiling { machine.rdtsc() } else { 0 };
+    audio_service(machine, pc);
     let PcMachine { sb, gus, mpu, spk, vpic, mixer, .. } = pc;
     let now = machine.get_ticks();
     let dt = now.saturating_sub(mixer.last_ms).min(100);
-
-    // Device ticks that run regardless of playback: the SB's latched
-    // 0xF2/0xF3 trigger IRQ, the GF1 rate timers + DMA-TC IRQ.
-    sb.deliver_trigger_irq(vpic);
-    sb.deliver_probe_irq(machine, vpic);
-    gus.tick(machine, vpic);
-    // MPU-401: drain the port's MIDI bytes into the synth and advance the
-    // instrument loader. Bytes are stamped at the production frontier — the
-    // frame the NEXT produced block starts at — which is the only number
-    // line the mixer has: this tick's pump renders them immediately, so a
-    // note sounds within one millisecond of its OUT. (An arrival-clock
-    // integrator used to "spread" stamps between pumps, but the pump runs
-    // per millisecond and all of a tick's bytes share one stamp anyway; the
-    // integrator's only observable behaviour was free-running ahead while
-    // no session streamed, stamping a program's first notes seconds into
-    // the future — the GM start delay: Dark Forces' fanfare ~3 s after the
-    // logo, DOOM's title music ~2 s late.)
-    mpu.tick(machine, mixer.pace.pushed());
 
     // The pump runs on the millisecond, not on the slice. A DOS program that
     // drives an emulated device hard (the GUS driver writes GF1 registers by

--- a/kernel/src/kernel/dos/machine/mod.rs
+++ b/kernel/src/kernel/dos/machine/mod.rs
@@ -1008,7 +1008,7 @@ pub fn audio_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &mu
     // MPU-401: drain the port's MIDI bytes into the synth (stamped at the arrival
     // frame) and satisfy a bounded number of its instrument requests (a .PAT
     // read per request).
-    mpu.tick(mixer.midi_frame);
+    mpu.tick(machine, mixer.midi_frame);
 
     // The pump runs on the millisecond, not on the slice. A DOS program that
     // drives an emulated device hard (the GUS driver writes GF1 registers by

--- a/kernel/src/kernel/dos/machine/vga.rs
+++ b/kernel/src/kernel/dos/machine/vga.rs
@@ -1685,10 +1685,10 @@ impl VgaState {
     }
 }
 
-/// VGA refresh throttle, off the same tick clock the 0x3DA vertical-retrace
-/// fabrication reads. Normal/WC displays follow the ~70-Hz VGA cadence;
-/// QEMU-TCG's strong-UC GOP mapping uses the older proven 20-Hz cap so
-/// full-frame device writes cannot consume the entire event loop.
+/// Whole-frame throttle for the hosted window sink, off the same tick clock
+/// the 0x3DA vertical-retrace fabrication reads. The direct-framebuffer path
+/// does not use this: its raster paces itself per row inside
+/// `display::raster`.
 fn frame_due(now_ticks: u64, hz: u64) -> bool {
     let frame = (now_ticks.wrapping_mul(hz) / 1000) as u32;
     static LAST: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(u32::MAX);
@@ -1711,56 +1711,64 @@ pub fn display_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &
     if vga_present() || (direct.is_none() && !vga_render::present_sink_installed()) {
         return;
     }
-    let refresh_hz = if direct.is_some_and(|fb| fb.slow) { 20 } else { 70 };
-    if !frame_due(now_ticks, refresh_hz) {
-        return;
-    }
-    crate::kernel::startup::bill_present();
     let prof = crate::kernel::startup::profile_enabled();
-    let p0 = if prof { machine.rdtsc() } else { 0 };
-    // Nothing here allocates per frame: both buffers live in PcMachine and are
-    // grown once, on the first frame of a mode. `render` clears the region it
-    // writes, so the buffer needs no pre-zeroing either.
-    let Some(frame) = pc.vga.scanout(machine, regs, &mut pc.present_scratch) else { return };
-    let p1 = if prof { machine.rdtsc() } else { 0 };
-    // One path for every mode: the renderer draws a source row directly in the
-    // framebuffer's pixel format, the blit stretches and copies it. No special
-    // case, no full-frame intermediate.
-    let copied;
-    if let crate::kernel::platform::Display::Framebuffer(fb) =
-        crate::kernel::platform::get().display
-    {
-        let overlay = crate::kernel::osd::is_open();
-        copied = crate::kernel::display::blit(
-            &mut pc.present_scratch2, &fb, &frame, overlay);
-        // The F12 monitor composites onto the finished frame — after the guest
-        // is drawn, before present — so it appears over any video mode.
-        if overlay {
+    if let Some(fb) = direct {
+        // Direct framebuffer: the raster beam. Bounded work per pass, every
+        // pixel repainted every period — pacing lives in `display::raster`;
+        // the pre-gate skips the scanout when no band is due.
+        let period_ms: u64 = if fb.slow { 50 } else { 14 };
+        if !crate::kernel::display::raster_pending(&pc.present_scratch2, now_ticks, period_ms) {
+            return;
+        }
+        let p0 = if prof { machine.rdtsc() } else { 0 };
+        // Nothing here allocates per band: the buffers live in PcMachine and
+        // grow once, on the first frame of a mode.
+        let Some(frame) = pc.vga.scanout(machine, regs, &mut pc.present_scratch) else { return };
+        let p1 = if prof { machine.rdtsc() } else { 0 };
+        let (copied, wrapped) = crate::kernel::display::raster(
+            &mut pc.present_scratch2, &fb, &frame, now_ticks, period_ms);
+        // The F12 monitor composites over whatever the beam just painted, so
+        // it stays intact across the sweep in any video mode.
+        if copied > 0 && crate::kernel::osd::is_open() {
             let out = unsafe {
                 core::slice::from_raw_parts_mut(fb.va as *mut u32, fb.stride * fb.height)
             };
             crate::kernel::osd::paint(out, fb.stride, fb.width, fb.height, fb.format);
         }
-        crate::kernel::display::present();
-    } else {
-        // Window sink (hosted): still takes a whole rendered frame.
-        let (w, h) = vga_render::dimensions(frame.mode);
-        let need = w * h;
-        copied = need;
-        if pc.present_fb.len() < need {
-            pc.present_fb.resize(need, 0);
+        if wrapped {
+            crate::kernel::startup::bill_present();
+            crate::kernel::display::present();
         }
-        let fb = &mut pc.present_fb[..need];
-        vga_render::render(&frame, fb);
-        if crate::kernel::osd::is_open() {
-            // `render` writes native 0x00RRGGBB into a tightly-packed w×h buffer.
-            crate::kernel::osd::paint(fb, w, w, h, vga_render::PixelFormat::NATIVE);
+        if prof {
+            let p4 = machine.rdtsc();
+            crate::kernel::startup::bill_display(
+                p1.wrapping_sub(p0), 0, 0, p4.wrapping_sub(p1), copied);
         }
-        vga_render::present(w, h, fb);
+        return;
     }
+    // Window sink (hosted): still takes a whole rendered frame per period.
+    if !frame_due(now_ticks, 70) {
+        return;
+    }
+    crate::kernel::startup::bill_present();
+    let p0 = if prof { machine.rdtsc() } else { 0 };
+    let Some(frame) = pc.vga.scanout(machine, regs, &mut pc.present_scratch) else { return };
+    let p1 = if prof { machine.rdtsc() } else { 0 };
+    let (w, h) = vga_render::dimensions(frame.mode);
+    let need = w * h;
+    if pc.present_fb.len() < need {
+        pc.present_fb.resize(need, 0);
+    }
+    let fb = &mut pc.present_fb[..need];
+    vga_render::render(&frame, fb);
+    if crate::kernel::osd::is_open() {
+        // `render` writes native 0x00RRGGBB into a tightly-packed w×h buffer.
+        crate::kernel::osd::paint(fb, w, w, h, vga_render::PixelFormat::NATIVE);
+    }
+    vga_render::present(w, h, fb);
     if prof {
         let p4 = machine.rdtsc();
         crate::kernel::startup::bill_display(
-            p1.wrapping_sub(p0), 0, 0, p4.wrapping_sub(p1), copied);
+            p1.wrapping_sub(p0), 0, 0, p4.wrapping_sub(p1), need);
     }
 }

--- a/kernel/src/kernel/dos/machine/vga.rs
+++ b/kernel/src/kernel/dos/machine/vga.rs
@@ -1742,7 +1742,7 @@ pub fn display_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &
         if prof {
             let p4 = machine.rdtsc();
             crate::kernel::startup::bill_display(
-                p1.wrapping_sub(p0), 0, 0, p4.wrapping_sub(p1), copied);
+                p1.wrapping_sub(p0), 1, p4.wrapping_sub(p1), copied);
         }
         return;
     }
@@ -1769,6 +1769,6 @@ pub fn display_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &
     if prof {
         let p4 = machine.rdtsc();
         crate::kernel::startup::bill_display(
-            p1.wrapping_sub(p0), 0, 0, p4.wrapping_sub(p1), need);
+            p1.wrapping_sub(p0), 1, p4.wrapping_sub(p1), need);
     }
 }

--- a/kernel/src/kernel/dos/machine/vga.rs
+++ b/kernel/src/kernel/dos/machine/vga.rs
@@ -1685,10 +1685,12 @@ impl VgaState {
     }
 }
 
-/// VGA refresh throttle: true at most once per ~70 Hz emulated frame, off the
-/// same tick clock the 0x3DA vertical-retrace fabrication reads.
-fn frame_due(now_ticks: u64) -> bool {
-    let frame = (now_ticks.wrapping_mul(70) / 1000) as u32;
+/// VGA refresh throttle, off the same tick clock the 0x3DA vertical-retrace
+/// fabrication reads. Normal/WC displays follow the ~70-Hz VGA cadence;
+/// QEMU-TCG's strong-UC GOP mapping uses the older proven 20-Hz cap so
+/// full-frame device writes cannot consume the entire event loop.
+fn frame_due(now_ticks: u64, hz: u64) -> bool {
+    let frame = (now_ticks.wrapping_mul(hz) / 1000) as u32;
     static LAST: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(u32::MAX);
     LAST.swap(frame, Ordering::Relaxed) != frame
 }
@@ -1709,7 +1711,8 @@ pub fn display_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &
     if vga_present() || (direct.is_none() && !vga_render::present_sink_installed()) {
         return;
     }
-    if !frame_due(now_ticks) {
+    let refresh_hz = if direct.is_some_and(|fb| fb.slow) { 20 } else { 70 };
+    if !frame_due(now_ticks, refresh_hz) {
         return;
     }
     crate::kernel::startup::bill_present();
@@ -1723,13 +1726,16 @@ pub fn display_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &
     // One path for every mode: the renderer draws a source row directly in the
     // framebuffer's pixel format, the blit stretches and copies it. No special
     // case, no full-frame intermediate.
+    let copied;
     if let crate::kernel::platform::Display::Framebuffer(fb) =
         crate::kernel::platform::get().display
     {
-        crate::kernel::display::blit(&mut pc.present_scratch2, &fb, &frame);
+        let overlay = crate::kernel::osd::is_open();
+        copied = crate::kernel::display::blit(
+            &mut pc.present_scratch2, &fb, &frame, overlay);
         // The F12 monitor composites onto the finished frame — after the guest
         // is drawn, before present — so it appears over any video mode.
-        if crate::kernel::osd::is_open() {
+        if overlay {
             let out = unsafe {
                 core::slice::from_raw_parts_mut(fb.va as *mut u32, fb.stride * fb.height)
             };
@@ -1740,6 +1746,7 @@ pub fn display_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &
         // Window sink (hosted): still takes a whole rendered frame.
         let (w, h) = vga_render::dimensions(frame.mode);
         let need = w * h;
+        copied = need;
         if pc.present_fb.len() < need {
             pc.present_fb.resize(need, 0);
         }
@@ -1754,6 +1761,6 @@ pub fn display_tick<A: crate::Arch>(machine: &mut A, pc: &mut PcMachine, regs: &
     if prof {
         let p4 = machine.rdtsc();
         crate::kernel::startup::bill_display(
-            p1.wrapping_sub(p0), 0, 0, p4.wrapping_sub(p1), 0);
+            p1.wrapping_sub(p0), 0, 0, p4.wrapping_sub(p1), copied);
     }
 }

--- a/kernel/src/kernel/dos/machine/vmpu.rs
+++ b/kernel/src/kernel/dos/machine/vmpu.rs
@@ -167,8 +167,10 @@ impl Mpu {
     }
 
     /// Per-quantum service: drain the port's MIDI bytes into the synth, then
-    /// satisfy a bounded number of its instrument requests.
-    pub fn tick(&mut self) {
+    /// satisfy a bounded number of its instrument requests. `arrival_frame` is
+    /// the current mix-frame the bytes arrived at — the synth applies each at
+    /// that frame so note onset timing is independent of the mix block size.
+    pub fn tick(&mut self, arrival_frame: u64) {
         if !self.present {
             return;
         }
@@ -184,7 +186,7 @@ impl Mpu {
         }
         while let Some(b) = self.card.take() {
             if let Some(s) = self.synth.as_mut() {
-                s.write(b);
+                s.write_at(arrival_frame, b);
             }
         }
         for _ in 0..LOADS_PER_TICK {
@@ -202,7 +204,12 @@ impl Mpu {
 
     /// Whether the synth currently owes the sink audio.
     pub(super) fn mixing(&self) -> bool {
-        self.synth.as_ref().is_some_and(|s| s.mixing())
+        // Also true while stamped bytes are still queued: they will start notes
+        // at a future frame, so the producer must keep the stream running until
+        // they are consumed (otherwise production stops before they render).
+        self.synth
+            .as_ref()
+            .is_some_and(|s| s.mixing() || s.has_pending())
     }
 
     /// Sum the GM synth into the pump block. The scale is mix policy, like
@@ -213,12 +220,12 @@ impl Mpu {
         &mut self,
         _machine: &mut A,
         rate: u32,
-        _base: u64,
+        base: u64,
         block: &mut [(i32, i32)],
     ) {
         let g = super::vsb::GM_SCALE_Q16;
         if let Some(s) = self.synth.as_mut() {
-            s.mix_into(rate, (g, g), block);
+            s.mix_into(rate, base, (g, g), block);
         }
     }
 }

--- a/kernel/src/kernel/dos/machine/vmpu.rs
+++ b/kernel/src/kernel/dos/machine/vmpu.rs
@@ -25,10 +25,31 @@
 use super::*;
 use crate::kernel::dos::dfs::{DFS_PATH_MAX, DfsState};
 
-/// Patch reads per audio quantum. A bank load is dozens of files; letting them
-/// all land in one tick stalls the mixer, and spreading them costs only the
-/// first bar of a song.
-const LOADS_PER_TICK: usize = 2;
+/// Bytes of instrument file read per audio quantum. A bank load is megabytes;
+/// whole-file reads stalled the event loop for a real disk's latency per
+/// instrument (music started seconds late; the stall also bunched PIT ticks
+/// under DOS/4GW). One bounded chunk of one file per tick keeps every tick
+/// short while the bank streams in over a few hundred ticks.
+const LOAD_CHUNK: usize = 16 * 1024;
+
+/// The GM device models a ROM-bank instrument (an SC-55 does not stream its
+/// piano from disk), so the whole bank preloads from the first tick the
+/// synth exists — by the first note of any song the instruments are already
+/// resident. Ids above the GM melodic+percussion range have no stem and are
+/// skipped instantly.
+const PRELOAD_IDS: u16 = 256;
+
+/// One instrument file mid-read: the chunked loader's only in-flight state.
+struct PatchLoad {
+    id: u16,
+    handle: i32,
+    size: usize,
+    buf: alloc::vec::Vec<u8>,
+    start_ms: u64,
+    /// Explicitly demanded by the synth (vs background bank preload):
+    /// failures are worth a log line.
+    demanded: bool,
+}
 
 /// Where the bank lives when the guest declares no `ULTRADIR`. We ship the
 /// set at this path, so this is not a guess that could mask a bad read.
@@ -49,6 +70,13 @@ pub struct Mpu {
     /// Patch ids we tried and could not read, so a missing instrument costs
     /// one failed open rather than one per note.
     denied: [u64; 4],
+    /// Patch ids already installed in the synth (the loader's own record, so
+    /// the preload sweep skips what a demand load already brought in).
+    loaded: [u64; 4],
+    /// The chunked loader's in-flight file, if any.
+    loading: Option<PatchLoad>,
+    /// Next id the background bank preload will fetch; `PRELOAD_IDS` = done.
+    preload: u16,
 }
 
 impl Mpu {
@@ -61,6 +89,9 @@ impl Mpu {
             dir: [0; 64],
             dir_len: 0,
             denied: [0; 4],
+            loaded: [0; 4],
+            loading: None,
+            preload: PRELOAD_IDS,
         };
         m.set_dir(DEFAULT_ULTRADIR);
         m
@@ -110,6 +141,11 @@ impl Mpu {
         self.card.reset();
         self.synth = None;
         self.denied = [0; 4];
+        self.loaded = [0; 4];
+        if let Some(ld) = self.loading.take() {
+            crate::kernel::vfs::close_vfs_handle(ld.handle);
+        }
+        self.preload = PRELOAD_IDS;
         self.present = false;
     }
 
@@ -133,12 +169,22 @@ impl Mpu {
         i < self.denied.len() && self.denied[i] & (1 << (id & 63)) != 0
     }
 
-    /// Read one instrument off the disk and install it. `false` when the file
-    /// is missing or unparseable — the id is then denied and never retried.
-    fn load_patch(&mut self, id: u16) -> bool {
-        let Some(stem) = sound::midi::patch_stem(id) else {
-            return false;
-        };
+    fn mark_loaded(&mut self, id: u16) {
+        let i = (id as usize) >> 6;
+        if i < self.loaded.len() {
+            self.loaded[i] |= 1 << (id & 63);
+        }
+    }
+
+    fn is_loaded(&self, id: u16) -> bool {
+        let i = (id as usize) >> 6;
+        i < self.loaded.len() && self.loaded[i] & (1 << (id & 63)) != 0
+    }
+
+    /// Open one instrument's `.PAT` for the chunked loader. `None` when the
+    /// id has no stem or the file is missing/empty — the caller denies it.
+    fn open_patch(&mut self, id: u16) -> Option<(i32, usize)> {
+        let stem = sound::midi::patch_stem(id)?;
         // "<ULTRADIR>\MIDI\<STEM>.PAT", uppercase — DOS canonical case.
         let mut dos = [0u8; DFS_PATH_MAX];
         let mut n = 0usize;
@@ -156,14 +202,93 @@ impl Mpu {
         put(b".PAT", &mut dos, &mut n);
 
         let mut vfs_buf = [0u8; DFS_PATH_MAX];
-        let Ok(vlen) = DfsState::to_vfs_open(&dos[..n], &mut vfs_buf) else {
-            return false;
-        };
-        let Ok(bytes) = crate::kernel::exec::load_file_resolved(&vfs_buf[..vlen]) else {
-            return false;
-        };
-        let Some(synth) = self.synth.as_mut() else { return false };
-        synth.load_patch(id, &bytes)
+        let vlen = DfsState::to_vfs_open(&dos[..n], &mut vfs_buf).ok()?;
+        let handle = crate::kernel::vfs::open_to_handle(&vfs_buf[..vlen]);
+        if handle < 0 {
+            return None;
+        }
+        let size = crate::kernel::vfs::file_size_by_handle(handle) as usize;
+        if size == 0 {
+            crate::kernel::vfs::close_vfs_handle(handle);
+            return None;
+        }
+        Some((handle, size))
+    }
+
+    /// Advance the in-flight instrument read, or start the next one — the
+    /// synth's explicit requests first, then the background bank preload.
+    /// At most one bounded chunk of one file per tick: the bank streams in
+    /// without the event loop ever stalling for a whole file read.
+    fn service_loads<A: crate::Arch>(&mut self, machine: &mut A) {
+        if let Some(mut ld) = self.loading.take() {
+            let off = ld.buf.len();
+            let want = (ld.size - off).min(LOAD_CHUNK);
+            ld.buf.resize(off + want, 0);
+            let got = crate::kernel::vfs::read_by_handle(ld.handle, &mut ld.buf[off..off + want]);
+            if got != want as i32 {
+                crate::kernel::vfs::close_vfs_handle(ld.handle);
+                self.deny(ld.id);
+                crate::dbg_println!("[mpu] patch {}: short read", ld.id);
+                return;
+            }
+            if ld.buf.len() < ld.size {
+                self.loading = Some(ld);
+                return; // next chunk next tick
+            }
+            crate::kernel::vfs::close_vfs_handle(ld.handle);
+            let Some(synth) = self.synth.as_mut() else { return };
+            if synth.load_patch(ld.id, &ld.buf) {
+                self.mark_loaded(ld.id);
+                if ld.demanded {
+                    crate::dbg_println!(
+                        "[mpu] patch {} loaded in {} ms ({} KB)",
+                        ld.id,
+                        machine.get_ticks().saturating_sub(ld.start_ms),
+                        ld.size / 1024,
+                    );
+                }
+            } else {
+                self.deny(ld.id);
+                if ld.demanded {
+                    crate::dbg_println!("[mpu] no patch for id {}", ld.id);
+                }
+            }
+            return;
+        }
+        // Nothing in flight: demanded instruments jump the preload queue.
+        loop {
+            let (id, demanded) = {
+                let Some(s) = self.synth.as_mut() else { return };
+                if let Some(id) = s.take_patch_request() {
+                    (id, true)
+                } else if self.preload < PRELOAD_IDS {
+                    let id = self.preload;
+                    self.preload += 1;
+                    (id, false)
+                } else {
+                    return;
+                }
+            };
+            if self.denied(id) || self.is_loaded(id) {
+                continue;
+            }
+            let Some((handle, size)) = self.open_patch(id) else {
+                self.deny(id);
+                if demanded {
+                    crate::dbg_println!("[mpu] no patch for id {}", id);
+                }
+                continue;
+            };
+            self.loading = Some(PatchLoad {
+                id,
+                handle,
+                size,
+                buf: alloc::vec::Vec::with_capacity(size),
+                start_ms: machine.get_ticks(),
+                demanded,
+            });
+            return;
+        }
     }
 
     /// Per-quantum service: drain the port's MIDI bytes into the synth, then
@@ -183,32 +308,16 @@ impl Mpu {
             let mut s = sound::midi::Synth::new_boxed();
             s.init();
             self.synth = Some(s);
+            // ROM-bank device: start streaming the whole bank in now, so the
+            // instruments are resident before the first song's first note.
+            self.preload = 0;
         }
         while let Some(b) = self.card.take() {
             if let Some(s) = self.synth.as_mut() {
                 s.write_at(arrival_frame, b);
             }
         }
-        for _ in 0..LOADS_PER_TICK {
-            let Some(s) = self.synth.as_mut() else { break };
-            let Some(id) = s.take_patch_request() else { break };
-            if self.denied(id) {
-                continue;
-            }
-            // Timed to the wall clock: notes stay silent until their patch is
-            // resident, so a slow bank read IS an audible music-start delay.
-            let t0 = machine.get_ticks();
-            if !self.load_patch(id) {
-                self.deny(id);
-                crate::dbg_println!("[mpu] no patch for id {}", id);
-            } else {
-                crate::dbg_println!(
-                    "[mpu] patch {} loaded in {} ms",
-                    id,
-                    machine.get_ticks().saturating_sub(t0)
-                );
-            }
-        }
+        self.service_loads(machine);
     }
 
     /// Whether the synth currently owes the sink audio.

--- a/kernel/src/kernel/dos/machine/vmpu.rs
+++ b/kernel/src/kernel/dos/machine/vmpu.rs
@@ -2,58 +2,14 @@
 //!
 //! Two library cards behind one port pair: [`sound::mpu401::Mpu401`] is the
 //! wire (UART mode at `P<port>`, 0x330 by convention) and
-//! [`sound::midi::Synth`] is the sound generator. Everything here is the part
-//! neither of them may have — presence, the port base from `BLASTER=`, and
-//! above all **the filesystem**.
-//!
-//! Instruments are the interesting bit. A General MIDI device needs a bank,
-//! and unlike the AWE32 (whose GM set lives in Creative's ROM) or the MT-32
-//! (Roland's), ours is already on the disk: the Gravis `.PAT` set at
-//! `C:\ULTRASND\MIDI` that the emulated GUS uses. So "Roland" costs no asset
-//! we are not allowed to ship. The synth cannot read it — a card in
-//! `//lib:sound` has no business knowing what a file is — so it *asks*: it
-//! names a patch id, this file resolves it to `<ULTRADIR>\MIDI\<stem>.PAT`,
-//! reads it, and hands the bytes back.
-//!
-//! Loading is spread across ticks on purpose. A program change can touch an
-//! instrument that is not resident, and a `.PAT` read is a real filesystem
-//! round trip; doing a whole bank inside one audio quantum would stall the
-//! pump. A note whose instrument has not arrived yet is simply silent for a
-//! tick or two — which is exactly what a real GUS does while ULTRAMID is
-//! still uploading.
+//! [`sound::midi::Synth`] is the sound generator. The instruments are NOT
+//! this device's problem: a GM device is a ROM-bank instrument, and the ROM
+//! is burned once at boot by the kernel (`kernel::midi_bank`) — the synth
+//! here just references it, fully resident from its first byte. A boot with
+//! no bank leaves the port present and the device silent, like a module
+//! with its ROM socket empty.
 
 use super::*;
-use crate::kernel::dos::dfs::{DFS_PATH_MAX, DfsState};
-
-/// Bytes of instrument file read per audio quantum. A bank load is megabytes;
-/// whole-file reads stalled the event loop for a real disk's latency per
-/// instrument (music started seconds late; the stall also bunched PIT ticks
-/// under DOS/4GW). One bounded chunk of one file per tick keeps every tick
-/// short while the bank streams in over a few hundred ticks.
-const LOAD_CHUNK: usize = 16 * 1024;
-
-/// The GM device models a ROM-bank instrument (an SC-55 does not stream its
-/// piano from disk), so the whole bank preloads from the first tick the
-/// synth exists — by the first note of any song the instruments are already
-/// resident. Ids above the GM melodic+percussion range have no stem and are
-/// skipped instantly.
-const PRELOAD_IDS: u16 = 256;
-
-/// One instrument file mid-read: the chunked loader's only in-flight state.
-struct PatchLoad {
-    id: u16,
-    handle: i32,
-    size: usize,
-    buf: alloc::vec::Vec<u8>,
-    start_ms: u64,
-    /// Explicitly demanded by the synth (vs background bank preload):
-    /// failures are worth a log line.
-    demanded: bool,
-}
-
-/// Where the bank lives when the guest declares no `ULTRADIR`. We ship the
-/// set at this path, so this is not a guess that could mask a bad read.
-const DEFAULT_ULTRADIR: &[u8] = b"C:\\ULTRASND";
 
 pub struct Mpu {
     /// `BLASTER=... P<port>` declared an MPU-401. Absent hardware stays
@@ -61,46 +17,20 @@ pub struct Mpu {
     pub present: bool,
     pub base: u16,
     card: sound::mpu401::Mpu401,
-    /// Built on first use — the synth carries a sample pool and 32 voices,
-    /// and a program that never opens the port pays nothing.
+    /// Built on first use — the synth carries 32 voices and the MIDI wire
+    /// state; a program that never opens the port pays nothing. Instruments
+    /// come from the boot ROM by reference.
     synth: Option<alloc::boxed::Box<sound::midi::Synth>>,
-    /// `ULTRADIR` from the guest's environment (the bank's parent directory).
-    dir: [u8; 64],
-    dir_len: usize,
-    /// Patch ids we tried and could not read, so a missing instrument costs
-    /// one failed open rather than one per note.
-    denied: [u64; 4],
-    /// Patch ids already installed in the synth (the loader's own record, so
-    /// the preload sweep skips what a demand load already brought in).
-    loaded: [u64; 4],
-    /// The chunked loader's in-flight file, if any.
-    loading: Option<PatchLoad>,
-    /// Next id the background bank preload will fetch; `PRELOAD_IDS` = done.
-    preload: u16,
 }
 
 impl Mpu {
     pub fn new() -> Self {
-        let mut m = Mpu {
+        Mpu {
             present: false,
             base: 0x330,
             card: sound::mpu401::Mpu401::new(0x330),
             synth: None,
-            dir: [0; 64],
-            dir_len: 0,
-            denied: [0; 4],
-            loaded: [0; 4],
-            loading: None,
-            preload: PRELOAD_IDS,
-        };
-        m.set_dir(DEFAULT_ULTRADIR);
-        m
-    }
-
-    fn set_dir(&mut self, d: &[u8]) {
-        let n = d.len().min(self.dir.len());
-        self.dir[..n].copy_from_slice(&d[..n]);
-        self.dir_len = n;
+        }
     }
 
     /// Ports this device decodes, once the machine says it exists.
@@ -109,13 +39,8 @@ impl Mpu {
     }
 
     /// Apply the guest's environment: the MPU port comes from `BLASTER`'s
-    /// `P<port>` token (our CONFIG.SYS ships `P330`), the bank location from
-    /// `ULTRADIR` — the same variable the GUS patches use, because it is the
-    /// same bank.
+    /// `P<port>` token (our CONFIG.SYS ships `P330`).
     pub fn configure_from_env(&mut self, env: &[u8]) {
-        if let Some(val) = env_var(env, b"ULTRADIR") {
-            self.set_dir(val);
-        }
         let Some(blaster) = env_var(env, b"BLASTER") else { return };
         for tok in blaster.split(|&b| b == b' ').filter(|t| !t.is_empty()) {
             if tok[0].eq_ignore_ascii_case(&b'P')
@@ -127,25 +52,15 @@ impl Mpu {
             }
         }
         if self.present {
-            crate::dbg_println!(
-                "[mpu] MPU-401 at {:03X}, patches in {}\\MIDI",
-                self.base,
-                core::str::from_utf8(&self.dir[..self.dir_len]).unwrap_or("?")
-            );
+            crate::dbg_println!("[mpu] MPU-401 at {:03X}", self.base);
         }
     }
 
-    /// Program-exit cleanup: drop the synth and its whole sample pool so the
-    /// next program starts from a power-on device.
+    /// Program-exit cleanup: drop the synth (voices, wire state) so the next
+    /// program starts from a power-on device. The ROM, being ROM, stays.
     pub fn reset(&mut self) {
         self.card.reset();
         self.synth = None;
-        self.denied = [0; 4];
-        self.loaded = [0; 4];
-        if let Some(ld) = self.loading.take() {
-            crate::kernel::vfs::close_vfs_handle(ld.handle);
-        }
-        self.preload = PRELOAD_IDS;
         self.present = false;
     }
 
@@ -157,167 +72,32 @@ impl Mpu {
         self.card.port_out(p, val);
     }
 
-    fn deny(&mut self, id: u16) {
-        let i = (id as usize) >> 6;
-        if i < self.denied.len() {
-            self.denied[i] |= 1 << (id & 63);
-        }
-    }
-
-    fn denied(&self, id: u16) -> bool {
-        let i = (id as usize) >> 6;
-        i < self.denied.len() && self.denied[i] & (1 << (id & 63)) != 0
-    }
-
-    fn mark_loaded(&mut self, id: u16) {
-        let i = (id as usize) >> 6;
-        if i < self.loaded.len() {
-            self.loaded[i] |= 1 << (id & 63);
-        }
-    }
-
-    fn is_loaded(&self, id: u16) -> bool {
-        let i = (id as usize) >> 6;
-        i < self.loaded.len() && self.loaded[i] & (1 << (id & 63)) != 0
-    }
-
-    /// Open one instrument's `.PAT` for the chunked loader. `None` when the
-    /// id has no stem or the file is missing/empty — the caller denies it.
-    fn open_patch(&mut self, id: u16) -> Option<(i32, usize)> {
-        let stem = sound::midi::patch_stem(id)?;
-        // "<ULTRADIR>\MIDI\<STEM>.PAT", uppercase — DOS canonical case.
-        let mut dos = [0u8; DFS_PATH_MAX];
-        let mut n = 0usize;
-        let put = |s: &[u8], dos: &mut [u8; DFS_PATH_MAX], n: &mut usize| {
-            for &b in s {
-                if *n < dos.len() {
-                    dos[*n] = b.to_ascii_uppercase();
-                    *n += 1;
-                }
-            }
-        };
-        put(&self.dir[..self.dir_len], &mut dos, &mut n);
-        put(b"\\MIDI\\", &mut dos, &mut n);
-        put(stem.as_bytes(), &mut dos, &mut n);
-        put(b".PAT", &mut dos, &mut n);
-
-        let mut vfs_buf = [0u8; DFS_PATH_MAX];
-        let vlen = DfsState::to_vfs_open(&dos[..n], &mut vfs_buf).ok()?;
-        let handle = crate::kernel::vfs::open_to_handle(&vfs_buf[..vlen]);
-        if handle < 0 {
-            return None;
-        }
-        let size = crate::kernel::vfs::file_size_by_handle(handle) as usize;
-        if size == 0 {
-            crate::kernel::vfs::close_vfs_handle(handle);
-            return None;
-        }
-        Some((handle, size))
-    }
-
-    /// Advance the in-flight instrument read, or start the next one — the
-    /// synth's explicit requests first, then the background bank preload.
-    /// At most one bounded chunk of one file per tick: the bank streams in
-    /// without the event loop ever stalling for a whole file read.
-    fn service_loads<A: crate::Arch>(&mut self, machine: &mut A) {
-        if let Some(mut ld) = self.loading.take() {
-            let off = ld.buf.len();
-            let want = (ld.size - off).min(LOAD_CHUNK);
-            ld.buf.resize(off + want, 0);
-            let got = crate::kernel::vfs::read_by_handle(ld.handle, &mut ld.buf[off..off + want]);
-            if got != want as i32 {
-                crate::kernel::vfs::close_vfs_handle(ld.handle);
-                self.deny(ld.id);
-                crate::dbg_println!("[mpu] patch {}: short read", ld.id);
-                return;
-            }
-            if ld.buf.len() < ld.size {
-                self.loading = Some(ld);
-                return; // next chunk next tick
-            }
-            crate::kernel::vfs::close_vfs_handle(ld.handle);
-            let Some(synth) = self.synth.as_mut() else { return };
-            if synth.load_patch(ld.id, &ld.buf) {
-                self.mark_loaded(ld.id);
-                if ld.demanded {
-                    crate::dbg_println!(
-                        "[mpu] patch {} loaded in {} ms ({} KB)",
-                        ld.id,
-                        machine.get_ticks().saturating_sub(ld.start_ms),
-                        ld.size / 1024,
-                    );
-                }
-            } else {
-                self.deny(ld.id);
-                if ld.demanded {
-                    crate::dbg_println!("[mpu] no patch for id {}", ld.id);
-                }
-            }
-            return;
-        }
-        // Nothing in flight: demanded instruments jump the preload queue.
-        loop {
-            let (id, demanded) = {
-                let Some(s) = self.synth.as_mut() else { return };
-                if let Some(id) = s.take_patch_request() {
-                    (id, true)
-                } else if self.preload < PRELOAD_IDS {
-                    let id = self.preload;
-                    self.preload += 1;
-                    (id, false)
-                } else {
-                    return;
-                }
-            };
-            if self.denied(id) || self.is_loaded(id) {
-                continue;
-            }
-            let Some((handle, size)) = self.open_patch(id) else {
-                self.deny(id);
-                if demanded {
-                    crate::dbg_println!("[mpu] no patch for id {}", id);
-                }
-                continue;
-            };
-            self.loading = Some(PatchLoad {
-                id,
-                handle,
-                size,
-                buf: alloc::vec::Vec::with_capacity(size),
-                start_ms: machine.get_ticks(),
-                demanded,
-            });
-            return;
-        }
-    }
-
-    /// Per-quantum service: drain the port's MIDI bytes into the synth, then
-    /// satisfy a bounded number of its instrument requests. `arrival_frame` is
-    /// the current mix-frame the bytes arrived at — the synth applies each at
-    /// that frame so note onset timing is independent of the mix block size.
+    /// Per-quantum service: drain the port's MIDI bytes into the synth.
+    /// `arrival_frame` is the mix-frame the bytes arrived at — the synth
+    /// applies each at that frame.
     pub fn tick<A: crate::Arch>(&mut self, machine: &mut A, arrival_frame: u64) {
+        let _ = machine;
         if !self.present {
             return;
         }
         // Only build the synth once the guest actually drives the port —
-        // detection alone (reset/ACK) must not cost a sample pool.
+        // detection alone (reset/ACK) must not cost the voice engine. A
+        // bankless boot never builds one: the wire still ACKs (the port
+        // exists), but there is nothing to sound.
         if self.synth.is_none() {
             if !self.card.in_uart() {
                 return;
             }
-            let mut s = sound::midi::Synth::new_boxed();
+            let Some(bank) = crate::kernel::midi_bank::get() else { return };
+            let mut s = sound::midi::Synth::new_boxed(bank);
             s.init();
             self.synth = Some(s);
-            // ROM-bank device: start streaming the whole bank in now, so the
-            // instruments are resident before the first song's first note.
-            self.preload = 0;
         }
         while let Some(b) = self.card.take() {
             if let Some(s) = self.synth.as_mut() {
                 s.write_at(arrival_frame, b);
             }
         }
-        self.service_loads(machine);
     }
 
     /// Whether the synth currently owes the sink audio.

--- a/kernel/src/kernel/dos/machine/vmpu.rs
+++ b/kernel/src/kernel/dos/machine/vmpu.rs
@@ -170,7 +170,7 @@ impl Mpu {
     /// satisfy a bounded number of its instrument requests. `arrival_frame` is
     /// the current mix-frame the bytes arrived at — the synth applies each at
     /// that frame so note onset timing is independent of the mix block size.
-    pub fn tick(&mut self, arrival_frame: u64) {
+    pub fn tick<A: crate::Arch>(&mut self, machine: &mut A, arrival_frame: u64) {
         if !self.present {
             return;
         }
@@ -195,9 +195,18 @@ impl Mpu {
             if self.denied(id) {
                 continue;
             }
+            // Timed to the wall clock: notes stay silent until their patch is
+            // resident, so a slow bank read IS an audible music-start delay.
+            let t0 = machine.get_ticks();
             if !self.load_patch(id) {
                 self.deny(id);
                 crate::dbg_println!("[mpu] no patch for id {}", id);
+            } else {
+                crate::dbg_println!(
+                    "[mpu] patch {} loaded in {} ms",
+                    id,
+                    machine.get_ticks().saturating_sub(t0)
+                );
             }
         }
     }

--- a/kernel/src/kernel/dos/machine/vsb.rs
+++ b/kernel/src/kernel/dos/machine/vsb.rs
@@ -68,7 +68,13 @@ pub(super) const GUS_SCALE_Q16: i32 = 17_500;
 /// over its flat pool: instruments aliased onto each other, which is both
 /// audibly wrong and 2.7x louder, and calibrating against it baked the bug
 /// into the level.
-pub(super) const GM_SCALE_Q16: i32 = 7_700;
+///
+/// Doubled from the 7,700 GUS-matched value: WAV-measured against DOOM2, GM
+/// music sat ~-6 dB under the digital SFX (RMS ~440 vs ~900) — a ratio
+/// unchanged across the ROM-bank rework, i.e. long-standing, just unmasked
+/// once the start delay and dropouts were fixed. Pending a dosemu
+/// balance-comparison pass.
+pub(super) const GM_SCALE_Q16: i32 = 15_400;
 
 /// The PC speaker, level-matched to the same reference as the other two, but
 /// *derived* rather than measured — and it can be, because a square wave's

--- a/kernel/src/kernel/dos/mod.rs
+++ b/kernel/src/kernel/dos/mod.rs
@@ -1103,6 +1103,12 @@ pub fn audio_tick<A: crate::Arch>(machine: &mut A, dos: &mut thread::DosState<A>
     machine::audio_tick(machine, &mut dos.pc, regs);
 }
 
+/// Per-slice audio device service (trigger IRQs, DMA-probe completions, GF1
+/// timers, MPU drain) without the millisecond pump — the ticks==0 fast path.
+pub fn audio_service<A: crate::Arch>(machine: &mut A, dos: &mut thread::DosState<A>) {
+    machine::audio_service(machine, &mut dos.pc);
+}
+
 /// Try to deliver one pending interrupt from the virtual PIC. IRQ delivery
 /// is uniform regardless of the client's current mode: `deliver_pm_irq`
 /// snapshots the client state on a kernel IRQ stack and switches to the

--- a/kernel/src/kernel/drivers/ac97.rs
+++ b/kernel/src/kernel/drivers/ac97.rs
@@ -44,6 +44,7 @@ const NAM_PCM_DAC_RATE: u16 = 0x2C; // sample rate when VRA enabled
 
 // NABM (Native Audio Bus Master, BAR1): the DMA engine. PCM-Out ("PO") channel.
 const PO_BDBAR: u16 = 0x10; // 32-bit: BDL base physical address
+const PO_CIV: u16 = 0x14; // 8-bit: current index value (RO)
 const PO_LVI: u16 = 0x15; // 8-bit: last valid index
 const PO_SR: u16 = 0x16; // 16-bit: status; bit2 LVBCI, bit3 BCIS, bit4 FIFOE (W1C)
 const PO_CR: u16 = 0x1B; // 8-bit: control (bit0 run, bit1 reset, bit4 IOCE)
@@ -93,25 +94,34 @@ struct Ac97 {
     rate: u32,      // last programmed sample rate (Hz)
     /// Pipe counters for [`position`] (the DAC runs at the source rate — no
     /// resampler — so these are directly in source frames). `written` counts
-    /// frames accepted by `submit`; `consumed_bufs` counts completed ring
-    /// buffers, one per completion interrupt (`on_irq`).
+    /// frames accepted by `submit`; `consumed_bufs` accumulates completed ring
+    /// buffers from hardware CIV deltas observed when an IRQ wakes the driver.
     written: u64,
     consumed_bufs: u64,
+    last_civ: u8,
 }
 
 static AC97: Mutex<Option<Ac97>> = Mutex::new(None);
 static PRESENT: AtomicBool = AtomicBool::new(false);
+/// Private kernel MSI identity used when the controller exposes MSI.
+pub const MSI_SOURCE: u8 = 1;
+static MSI_ON: AtomicBool = AtomicBool::new(false);
 /// The wired IRQ line the codec's INTx was routed to (from PCI config 0x3C), so
 /// the canonical audio-IRQ router can match it. 0xFF until bring-up. Production
 /// is always driven from this interrupt — there is no polled model.
 static IRQ_LINE: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0xFF);
 
-/// The routed completion-IRQ line, for `sound::on_hw_irq`. `None` until up.
+/// The routed completion-IRQ line, for `sound::on_irq`. `None` when MSI is used
+/// or until bring-up has selected the INTx fallback.
 pub fn irq_line() -> Option<u8> {
     match IRQ_LINE.load(Ordering::Relaxed) {
         0xFF => None,
         n => Some(n as u8),
     }
+}
+
+pub fn msi_active() -> bool {
+    MSI_ON.load(Ordering::Relaxed)
 }
 
 /// Find an AC'97 codec (class 0x04, subclass 0x01) anywhere on PCI, via the
@@ -142,21 +152,31 @@ fn bring_up<A: crate::Arch>(machine: &mut A, bus: u8, dev: u8, func: u8) -> bool
     let cmd = crate::kernel::pci::read32(machine, bus, dev, func, 0x04);
     crate::kernel::pci::write32(machine, bus, dev, func, 0x04, (cmd & 0xFFFF) | 0x05);
 
-    // Discover the wired completion IRQ (PCI INTx). Firmware programmed the
-    // Interrupt Line register (config 0x3C low byte) with the line it routed the
-    // device's pin to; route+unmask it and drive production from it. If it is
-    // unprogrammed (0/0xFF), stay on the polled CIV path.
-    let line = (crate::kernel::pci::read32(machine, bus, dev, func, 0x3C) & 0xFF) as u8;
-    if !(1..=15).contains(&line) {
-        crate::println!(
-            "ac97: {:02x}:{:02x}.{} no INTx line — required for the sink; skipping",
-            bus, dev, func
-        );
-        return false;
+    // Prefer a namespace-safe MSI. Older AC'97 controllers commonly lack the
+    // capability, so retain INTx as a fallback; that path still depends on the
+    // firmware's Interrupt Line value until ACPI PCI routing is available.
+    let msi = machine
+        .msi_alloc(MSI_SOURCE)
+        .is_some_and(|(addr, data)| {
+            crate::kernel::pci::msi_enable(machine, bus, dev, func, addr, data)
+        });
+    if msi {
+        MSI_ON.store(true, Ordering::Relaxed);
+        crate::println!("ac97: {:02x}:{:02x}.{} MSI on", bus, dev, func);
+    } else {
+        let line =
+            (crate::kernel::pci::read32(machine, bus, dev, func, 0x3C) & 0xFF) as u8;
+        if !(1..=15).contains(&line) {
+            crate::println!(
+                "ac97: {:02x}:{:02x}.{} no MSI/INTx route; skipping",
+                bus, dev, func
+            );
+            return false;
+        }
+        machine.route_device_irq(line);
+        IRQ_LINE.store(line as u32, Ordering::Relaxed);
+        crate::println!("ac97: {:02x}:{:02x}.{} INTx line {}", bus, dev, func, line);
     }
-    machine.route_device_irq(line);
-    IRQ_LINE.store(line as u32, Ordering::Relaxed);
-    crate::println!("ac97: {:02x}:{:02x}.{} INTx line {}", bus, dev, func, line);
 
     let nam = (crate::kernel::pci::read32(machine, bus, dev, func, 0x10) & 0xFFFC) as u16; // BAR0
     let nabm = (crate::kernel::pci::read32(machine, bus, dev, func, 0x14) & 0xFFFC) as u16; // BAR1
@@ -216,6 +236,7 @@ fn bring_up<A: crate::Arch>(machine: &mut A, bus: u8, dev: u8, func: u8) -> bool
         rate: 0,
         written: 0,
         consumed_bufs: 0,
+        last_civ: 0,
     };
     d.build_bdl();
     machine.outl(nabm + PO_BDBAR, dma_phys); // BDL base
@@ -315,24 +336,32 @@ pub fn position<A: crate::Arch>(machine: &mut A) -> Option<(u64, u64)> {
     if !dev.running {
         return Some((dev.written, 0));
     }
-    // `on_irq` maintains `consumed_bufs` per completed buffer, so there is no
-    // poll here — buffer-granular consumed is what the deficit producer needs.
+    // `on_irq` maintains `consumed_bufs` from CIV deltas, so position itself
+    // performs no hardware polling.
     let frames_per_buf = (BUF_BYTES / 4) as u64;
     Some((dev.written, dev.consumed_bufs * frames_per_buf))
 }
 
 /// Service a PCM-out completion interrupt (canonical `Irq::Hw(irq_line())`
-/// routed here by `sound::on_hw_irq`). Accumulates the consumed-buffer clock
-/// from the CIV delta and clears the status register so the level INTx pin
-/// deasserts (the caller then rearms the line). Robust to coalesced interrupts
-/// because it reads the true current index, not a fixed +1.
-pub fn on_irq<A: crate::Arch>(machine: &mut A) {
+/// routed here by `sound::on_irq`). The interrupt is only a wakeup:
+/// consumption comes from the hardware CIV delta, so delayed/coalesced IRQs do
+/// not permanently skew the playback clock. Returns false when a shared INTx
+/// line fired for another device.
+pub fn on_irq<A: crate::Arch>(machine: &mut A) -> bool {
     let mut g = AC97.lock();
-    let Some(dev) = g.as_mut() else { return };
-    if dev.running {
-        dev.consumed_bufs += 1; // one buffer per completion interrupt — no CIV poll
+    let Some(dev) = g.as_mut() else { return false };
+    let status = machine.inw(dev.nabm + PO_SR);
+    if status & PO_SR_INTR == 0 {
+        return false;
     }
-    machine.outw(dev.nabm + PO_SR, PO_SR_INTR); // clear LVBCI|BCIS|FIFOE (W1C)
+    if dev.running {
+        let civ = machine.inb(dev.nabm + PO_CIV) % NUM_BUF as u8;
+        dev.consumed_bufs +=
+            ((civ + NUM_BUF as u8 - dev.last_civ) % NUM_BUF as u8) as u64;
+        dev.last_civ = civ;
+    }
+    machine.outw(dev.nabm + PO_SR, status & PO_SR_INTR);
+    true
 }
 
 /// Minimum pipe fill for a position-slaved producer, in source frames: the
@@ -345,4 +374,3 @@ pub fn on_irq<A: crate::Arch>(machine: &mut A) {
 pub fn present() -> bool {
     PRESENT.load(Ordering::Relaxed)
 }
-

--- a/kernel/src/kernel/drivers/ac97.rs
+++ b/kernel/src/kernel/drivers/ac97.rs
@@ -74,7 +74,11 @@ const BDL_BYTES: usize = 0x1000; // first page of the buffer holds the BDL
 /// 0..15, and the bus master replays them when its index runs past LVI — an
 /// audible ~ring-length echo. 32 distinct buffers, no mirror.
 const NUM_BUF: usize = 32;
-const BUF_BYTES: usize = 0x800; // 2 KB each = 512 stereo frames ≈ 23 ms @ 22 kHz
+// 1 KB = 256 stereo frames ≈ 5.8 ms @ 44.1 kHz. This is the completion-IRQ
+// granularity (one interrupt per buffer), NOT the pipe depth — the pipe is the
+// universal `sound::min_fill`. Kept ≤ half the pipe so ≥ 2 buffers are queued
+// (double-buffered event-driven refill).
+const BUF_BYTES: usize = 0x400;
 /// Prefill this many buffers before starting the bus master, so the double-
 /// buffered pipe (min_fill = 2) is full at stream start.
 const PRIME_BUFS: usize = 2;
@@ -341,14 +345,9 @@ pub fn on_irq<A: crate::Arch>(machine: &mut A) {
 /// fill must always span the start prime (`PRIME_BUFS` full buffers) plus a
 /// partial buffer of slack — below that the engine halts at LVI while the
 /// producer waits for consumption, and the pipe deadlocks.
-pub fn min_fill(_rate: u32) -> Option<u32> {
-    if !PRESENT.load(Ordering::Relaxed) {
-        return None;
-    }
-    // Double-buffered: keep 2 buffers queued ahead of the play cursor — the
-    // whole pipe, so latency ≈ 2 × the buffer duration. Event-driven refill
-    // (one completion per buffer) needs only this shallow depth.
-    let frames_per_buf = (BUF_BYTES / 4) as u32;
-    Some(2 * frames_per_buf)
+/// The sink is up and reports a play position (so `sound::min_fill` returns the
+/// universal pipe depth). The pipe latency itself is not this driver's to set.
+pub fn present() -> bool {
+    PRESENT.load(Ordering::Relaxed)
 }
 

--- a/kernel/src/kernel/drivers/ac97.rs
+++ b/kernel/src/kernel/drivers/ac97.rs
@@ -44,7 +44,6 @@ const NAM_PCM_DAC_RATE: u16 = 0x2C; // sample rate when VRA enabled
 
 // NABM (Native Audio Bus Master, BAR1): the DMA engine. PCM-Out ("PO") channel.
 const PO_BDBAR: u16 = 0x10; // 32-bit: BDL base physical address
-const PO_CIV: u16 = 0x14; // 8-bit: current index value (RO)
 const PO_LVI: u16 = 0x15; // 8-bit: last valid index
 const PO_SR: u16 = 0x16; // 16-bit: status; bit2 LVBCI, bit3 BCIS, bit4 FIFOE (W1C)
 const PO_CR: u16 = 0x1B; // 8-bit: control (bit0 run, bit1 reset, bit4 IOCE)
@@ -94,11 +93,10 @@ struct Ac97 {
     rate: u32,      // last programmed sample rate (Hz)
     /// Pipe counters for [`position`] (the DAC runs at the source rate — no
     /// resampler — so these are directly in source frames). `written` counts
-    /// frames accepted by `submit`; `consumed_bufs` accumulates completed
-    /// ring buffers from CIV deltas (CIV alone is modular).
+    /// frames accepted by `submit`; `consumed_bufs` counts completed ring
+    /// buffers, one per completion interrupt (`on_irq`).
     written: u64,
     consumed_bufs: u64,
-    last_civ: u8,
 }
 
 static AC97: Mutex<Option<Ac97>> = Mutex::new(None);
@@ -218,7 +216,6 @@ fn bring_up<A: crate::Arch>(machine: &mut A, bus: u8, dev: u8, func: u8) -> bool
         rate: 0,
         written: 0,
         consumed_bufs: 0,
-        last_civ: 0,
     };
     d.build_bdl();
     machine.outl(nabm + PO_BDBAR, dma_phys); // BDL base
@@ -333,9 +330,7 @@ pub fn on_irq<A: crate::Arch>(machine: &mut A) {
     let mut g = AC97.lock();
     let Some(dev) = g.as_mut() else { return };
     if dev.running {
-        let civ = machine.inb(dev.nabm + PO_CIV);
-        dev.consumed_bufs += ((civ + NUM_BUF as u8 - dev.last_civ) % NUM_BUF as u8) as u64;
-        dev.last_civ = civ;
+        dev.consumed_bufs += 1; // one buffer per completion interrupt — no CIV poll
     }
     machine.outw(dev.nabm + PO_SR, PO_SR_INTR); // clear LVBCI|BCIS|FIFOE (W1C)
 }

--- a/kernel/src/kernel/drivers/ac97.rs
+++ b/kernel/src/kernel/drivers/ac97.rs
@@ -46,13 +46,18 @@ const NAM_PCM_DAC_RATE: u16 = 0x2C; // sample rate when VRA enabled
 const PO_BDBAR: u16 = 0x10; // 32-bit: BDL base physical address
 const PO_CIV: u16 = 0x14; // 8-bit: current index value (RO)
 const PO_LVI: u16 = 0x15; // 8-bit: last valid index
-const PO_PICB: u16 = 0x18; // 16-bit: samples left in the current buffer (RO)
-const PO_CR: u16 = 0x1B; // 8-bit: control (bit0 run, bit1 reset)
+const PO_SR: u16 = 0x16; // 16-bit: status; bit2 LVBCI, bit3 BCIS, bit4 FIFOE (W1C)
+const PO_CR: u16 = 0x1B; // 8-bit: control (bit0 run, bit1 reset, bit4 IOCE)
 const GLOB_CNT: u16 = 0x2C; // 32-bit: bit1 = AC-link out of cold reset
 const GLOB_STA: u16 = 0x30; // 32-bit: bit8 = primary codec ready
 
 const PO_CR_RUN: u8 = 0x01;
 const PO_CR_RESET: u8 = 0x02;
+const PO_CR_IOCE: u8 = 0x10; // interrupt-on-completion enable
+/// BDL entry control word bit 15: interrupt on completion of this buffer.
+const BDL_IOC: u16 = 1 << 15;
+/// All three PO status interrupt bits (LVBCI | BCIS | FIFOE), write-1-to-clear.
+const PO_SR_INTR: u16 = 0x1C;
 
 // ── DMA ring geometry ───────────────────────────────────────────────────────
 /// Kernel VA we steal from the low-mem identity window (over phys
@@ -70,14 +75,9 @@ const BDL_BYTES: usize = 0x1000; // first page of the buffer holds the BDL
 /// audible ~ring-length echo. 32 distinct buffers, no mirror.
 const NUM_BUF: usize = 32;
 const BUF_BYTES: usize = 0x800; // 2 KB each = 512 stereo frames ≈ 23 ms @ 22 kHz
-/// Prefill this many buffers before starting the bus master — a small cushion so
-/// the gate-paced producer's jitter doesn't underrun the codec (clicking).
-const PRIME_BUFS: usize = 3;
-/// Cap how far the producer may run ahead of the codec (`LVI − CIV`). This
-/// BOUNDS LATENCY — without it, any producer/codec clock drift lets the queue
-/// grow to the whole ring (~0.7 s). It also keeps LVI from lapping CIV, which
-/// would make the bus master replay buffers (echo). ≈ 6 × 23 ms ≈ 140 ms.
-const MAX_AHEAD: usize = 6;
+/// Prefill this many buffers before starting the bus master, so the double-
+/// buffered pipe (min_fill = 2) is full at stream start.
+const PRIME_BUFS: usize = 2;
 
 struct Ac97 {
     nam: u16,       // NAM I/O base
@@ -99,6 +99,18 @@ struct Ac97 {
 
 static AC97: Mutex<Option<Ac97>> = Mutex::new(None);
 static PRESENT: AtomicBool = AtomicBool::new(false);
+/// The wired IRQ line the codec's INTx was routed to (from PCI config 0x3C), so
+/// the canonical audio-IRQ router can match it. 0xFF until bring-up. Production
+/// is always driven from this interrupt — there is no polled model.
+static IRQ_LINE: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0xFF);
+
+/// The routed completion-IRQ line, for `sound::on_hw_irq`. `None` until up.
+pub fn irq_line() -> Option<u8> {
+    match IRQ_LINE.load(Ordering::Relaxed) {
+        0xFF => None,
+        n => Some(n as u8),
+    }
+}
 
 /// Find an AC'97 codec (class 0x04, subclass 0x01) anywhere on PCI, via the
 /// shared `pci::find_class` scan. Pure presence probe — `platform::probe` uses
@@ -127,6 +139,22 @@ fn bring_up<A: crate::Arch>(machine: &mut A, bus: u8, dev: u8, func: u8) -> bool
     // dword 0x04). Writing 0 to the status word (high 16) is harmless (RW1C).
     let cmd = crate::kernel::pci::read32(machine, bus, dev, func, 0x04);
     crate::kernel::pci::write32(machine, bus, dev, func, 0x04, (cmd & 0xFFFF) | 0x05);
+
+    // Discover the wired completion IRQ (PCI INTx). Firmware programmed the
+    // Interrupt Line register (config 0x3C low byte) with the line it routed the
+    // device's pin to; route+unmask it and drive production from it. If it is
+    // unprogrammed (0/0xFF), stay on the polled CIV path.
+    let line = (crate::kernel::pci::read32(machine, bus, dev, func, 0x3C) & 0xFF) as u8;
+    if !(1..=15).contains(&line) {
+        crate::println!(
+            "ac97: {:02x}:{:02x}.{} no INTx line — required for the sink; skipping",
+            bus, dev, func
+        );
+        return false;
+    }
+    machine.route_device_irq(line);
+    IRQ_LINE.store(line as u32, Ordering::Relaxed);
+    crate::println!("ac97: {:02x}:{:02x}.{} INTx line {}", bus, dev, func, line);
 
     let nam = (crate::kernel::pci::read32(machine, bus, dev, func, 0x10) & 0xFFFC) as u16; // BAR0
     let nabm = (crate::kernel::pci::read32(machine, bus, dev, func, 0x14) & 0xFFFC) as u16; // BAR1
@@ -206,17 +234,19 @@ impl Ac97 {
         self.dma_va + BDL_BYTES + i * BUF_BYTES
     }
 
-    /// Fill the BDL: entry i → buffer i, length in 16-bit samples, control 0
-    /// (we poll CIV; no interrupt-on-completion). NUM_BUF == 32 so every entry
-    /// maps a distinct buffer — no mirrored entries to replay.
+    /// Fill the BDL: entry i → buffer i, length in 16-bit samples. Control word
+    /// carries IOC — one interrupt per completed buffer drives the event-loop
+    /// audio track. NUM_BUF == 32 so every entry maps a distinct buffer — no
+    /// mirrored entries to replay.
     fn build_bdl(&mut self) {
+        let ctrl = BDL_IOC;
         for i in 0..NUM_BUF {
             let entry = self.dma_va + i * 8;
             let samples = (BUF_BYTES / 2) as u16; // 16-bit samples per buffer
             unsafe {
                 core::ptr::write_volatile(entry as *mut u32, self.buf_phys(i));
                 core::ptr::write_volatile((entry + 4) as *mut u16, samples);
-                core::ptr::write_volatile((entry + 6) as *mut u16, 0);
+                core::ptr::write_volatile((entry + 6) as *mut u16, ctrl);
             }
         }
     }
@@ -236,16 +266,8 @@ impl Ac97 {
             return;
         }
         for i in 0..bytes.len() / fb {
-            // At each buffer boundary, cap how far we run ahead of the codec.
-            // Beyond MAX_AHEAD buffers we drop the rest (bounds latency; rare
-            // once producer/codec are rate-matched — only drift reaches here).
-            if self.cur_off == 0 && self.running {
-                let civ = machine.inb(self.nabm + PO_CIV) as usize;
-                let ahead = (self.cur_buf + NUM_BUF - civ) % NUM_BUF;
-                if ahead >= MAX_AHEAD {
-                    break;
-                }
-            }
+            // No run-ahead cap needed: the deficit producer only ever pushes
+            // enough to reach `min_fill` (2 buffers) ahead of the drain.
             let (l, r) = fmt.frame(bytes, i);
             let p = self.buf_va(self.cur_buf) + self.cur_off;
             unsafe {
@@ -260,7 +282,7 @@ impl Ac97 {
                 machine.outb(self.nabm + PO_LVI, self.cur_buf as u8);
                 if !self.running && self.cur_buf + 1 >= PRIME_BUFS {
                     let cr = machine.inb(self.nabm + PO_CR);
-                    machine.outb(self.nabm + PO_CR, cr | PO_CR_RUN);
+                    machine.outb(self.nabm + PO_CR, cr | PO_CR_RUN | PO_CR_IOCE);
                     self.running = true;
                 }
                 self.cur_buf = (self.cur_buf + 1) % NUM_BUF;
@@ -288,17 +310,30 @@ pub fn play<A: crate::Arch>(machine: &mut A, rate: u32, fmt: Format, bytes: &[u8
 pub fn position<A: crate::Arch>(machine: &mut A) -> Option<(u64, u64)> {
     let mut g = AC97.lock();
     let dev = g.as_mut()?;
+    let _ = machine;
     if !dev.running {
         return Some((dev.written, 0));
     }
-    let civ = machine.inb(dev.nabm + PO_CIV);
-    dev.consumed_bufs += ((civ + NUM_BUF as u8 - dev.last_civ) % NUM_BUF as u8) as u64;
-    dev.last_civ = civ;
+    // `on_irq` maintains `consumed_bufs` per completed buffer, so there is no
+    // poll here — buffer-granular consumed is what the deficit producer needs.
     let frames_per_buf = (BUF_BYTES / 4) as u64;
-    // PICB: 16-bit samples remaining in the current buffer → frames played.
-    let picb = machine.inw(dev.nabm + PO_PICB) as u64;
-    let in_buf = frames_per_buf.saturating_sub(picb / 2);
-    Some((dev.written, dev.consumed_bufs * frames_per_buf + in_buf))
+    Some((dev.written, dev.consumed_bufs * frames_per_buf))
+}
+
+/// Service a PCM-out completion interrupt (canonical `Irq::Hw(irq_line())`
+/// routed here by `sound::on_hw_irq`). Accumulates the consumed-buffer clock
+/// from the CIV delta and clears the status register so the level INTx pin
+/// deasserts (the caller then rearms the line). Robust to coalesced interrupts
+/// because it reads the true current index, not a fixed +1.
+pub fn on_irq<A: crate::Arch>(machine: &mut A) {
+    let mut g = AC97.lock();
+    let Some(dev) = g.as_mut() else { return };
+    if dev.running {
+        let civ = machine.inb(dev.nabm + PO_CIV);
+        dev.consumed_bufs += ((civ + NUM_BUF as u8 - dev.last_civ) % NUM_BUF as u8) as u64;
+        dev.last_civ = civ;
+    }
+    machine.outw(dev.nabm + PO_SR, PO_SR_INTR); // clear LVBCI|BCIS|FIFOE (W1C)
 }
 
 /// Minimum pipe fill for a position-slaved producer, in source frames: the
@@ -310,7 +345,10 @@ pub fn min_fill(_rate: u32) -> Option<u32> {
     if !PRESENT.load(Ordering::Relaxed) {
         return None;
     }
+    // Double-buffered: keep 2 buffers queued ahead of the play cursor — the
+    // whole pipe, so latency ≈ 2 × the buffer duration. Event-driven refill
+    // (one completion per buffer) needs only this shallow depth.
     let frames_per_buf = (BUF_BYTES / 4) as u32;
-    Some(PRIME_BUFS as u32 * frames_per_buf + frames_per_buf / 4)
+    Some(2 * frames_per_buf)
 }
 

--- a/kernel/src/kernel/drivers/hda.rs
+++ b/kernel/src/kernel/drivers/hda.rs
@@ -105,7 +105,13 @@ const DMA_PAGES: usize = (BUF_OFF + NUM_BUF * BUF_BYTES).div_ceil(0x1000);
 
 // ── PCM ring geometry (mirror ac97) ──────────────────────────────────────────
 const NUM_BUF: usize = 32;
-const BUF_BYTES: usize = 0x800; // 2 KB = 512 stereo frames ≈ 23 ms @ 22 kHz
+// 256 B = 64 stereo frames ≈ 1.45 ms @ 44.1 kHz. Deliberately small: with MSI
+// each completed buffer is one interrupt that drives one production pass, so
+// the buffer duration sets how finely the synth engine advances. A large buffer
+// would step GUS/DMX in coarse lumps (the E1M8 "cut notes" failure mode); ~1.5
+// ms keeps it close to the old 1 ms get_ticks cadence. Polled sinks are
+// unaffected — their pacing is the get_ticks servo, not the buffer size.
+const BUF_BYTES: usize = 0x100;
 const PRIME_BUFS: usize = 3;
 /// Hard drop ceiling, just under the ring's ahead/behind ambiguity point.
 /// Every producer is position-slaved (`sound::position`/`sound::Pace`) and
@@ -1739,14 +1745,23 @@ pub fn play<A: crate::Arch>(machine: &mut A, rate: u32, fmt: Format, bytes: &[u8
 /// signal the next block. For now it only accounts the interrupt; the
 /// event-loop audio track will produce a block per call in the next step.
 pub fn on_irq() {
-    let n = HDA_IRQS.fetch_add(1, core::sync::atomic::Ordering::Relaxed) + 1;
-    if let Some(dev) = HDA.lock().as_ref() {
+    HDA_IRQS.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    if let Some(dev) = HDA.lock().as_mut() {
         w8(dev.sd + SDSTS, 0x04); // BCIS write-1-clear
         w32(INTSTS, r32(INTSTS)); // clear latched stream-interrupt-status bits
+        // One IOC per buffer: each interrupt is exactly one buffer drained. This
+        // is the consumed clock the producer paces to — no SDLPIB poll needed.
+        if dev.running {
+            dev.consumed_hw += BUF_BYTES as u64;
+        }
     }
-    if n <= 3 || n % 512 == 0 {
-        crate::println!("hda: MSI completion irq #{}", n);
-    }
+}
+
+/// True once MSI is up and the sink is driving production by completion IRQ
+/// (vs the polled SDLPIB path). The producer's pacer reads this to switch to
+/// event-driven refill.
+pub fn msi_active() -> bool {
+    MSI_ON.load(core::sync::atomic::Ordering::Relaxed)
 }
 
 /// Pipe counters for `sound::position`: `(written, consumed)` in source
@@ -1758,7 +1773,12 @@ pub fn position() -> Option<(u64, u64)> {
     if dev.parked {
         return None;
     }
-    dev.update_consumed();
+    // MSI-driven: `on_irq` maintains `consumed_hw` per completed buffer, so the
+    // per-call SDLPIB poll (a KVM/MMIO exit) is gone. Polled fallback still reads
+    // the hardware position here.
+    if !MSI_ON.load(core::sync::atomic::Ordering::Relaxed) {
+        dev.update_consumed();
+    }
     if dev.src_rate == 0 || dev.rate == 0 {
         return Some((dev.written_src, 0)); // no stream session yet
     }
@@ -1777,7 +1797,13 @@ pub fn min_fill(rate: u32) -> Option<u32> {
     }
     let src = if rate == 0 { 44100 } else { rate };
     let hw = Hda::hardware_rate(src);
-    let hw_frames = ((PRIME_BUFS + 1) * BUF_BYTES / 4) as u64;
+    // Event-driven (MSI) refills one small buffer per completion interrupt, so a
+    // shallow pipe suffices and keeps latency low. The polled fallback refills on
+    // the jittery ms tick and needs a deep cushion against underrun — with the
+    // small buffers that give MSI its fine granularity, that means many of them.
+    // Both fit the 32-buffer ring (46 ms @ 44.1 kHz).
+    let depth_bufs = if MSI_ON.load(core::sync::atomic::Ordering::Relaxed) { 6 } else { 24 };
+    let hw_frames = (depth_bufs * BUF_BYTES / 4) as u64;
     Some((hw_frames * src as u64 / hw as u64) as u32 + 1)
 }
 

--- a/kernel/src/kernel/drivers/hda.rs
+++ b/kernel/src/kernel/drivers/hda.rs
@@ -108,14 +108,16 @@ const DMA_PAGES: usize = (BUF_OFF + NUM_BUF * BUF_BYTES).div_ceil(0x1000);
 
 // ── PCM ring geometry (mirror ac97) ──────────────────────────────────────────
 const NUM_BUF: usize = 32;
-// 1 KB = 256 stereo frames ≈ 5.8 ms @ 44.1 kHz. With MSI each completed buffer
-// is one interrupt that drives one production pass, so the buffer duration sets
-// how finely the synth engine advances — a large buffer would step GUS/DMX in
-// coarse lumps (the E1M8 "cut notes" failure mode). ~6 ms stays fine there while
-// giving the pipe (6 buffers ≈ 35 ms) depth to ride out the ~14.3 ms
-// framebuffer-blit stall that would otherwise crackle a shallower pipe.
-const BUF_BYTES: usize = 0x400;
-const PRIME_BUFS: usize = 3;
+// Double-buffered pipe: the producer keeps min_fill = 2 buffers queued ahead of
+// the play cursor, so playback latency ≈ 2 × this buffer's duration. MIDI onset
+// timing is stamped at arrival and applied per-frame (see midi.rs), so buffer
+// size no longer quantises notes — it is chosen purely for pipe depth. 2 KB =
+// 512 stereo frames ≈ 11.6 ms @ 44.1 kHz → ~23 ms pipe, deep enough to ride out
+// the ~14.3 ms framebuffer-blit stall. (GUS-native register writes are still
+// block-quantised, but games default to General MIDI.) The ring is larger than
+// the pipe only to give the write cursor guard room ahead of the play cursor.
+const BUF_BYTES: usize = 0x800;
+const PRIME_BUFS: usize = 2;
 /// Hard drop ceiling, just under the ring's ahead/behind ambiguity point.
 /// Every producer is position-slaved (`sound::position`/`sound::Pace`) and
 /// pins its own fill, so this only catches runaway bursts.
@@ -1781,9 +1783,11 @@ pub fn min_fill(rate: u32) -> Option<u32> {
     }
     let src = if rate == 0 { 44100 } else { rate };
     let hw = Hda::hardware_rate(src);
-    // Event-driven: one buffer is refilled per completion interrupt. Six buffers
-    // (6 × 5.8 ms ≈ 35 ms) span the ~14.3 ms framebuffer-blit stall with margin.
-    let hw_frames = (6 * BUF_BYTES / 4) as u64;
+    // Double-buffered: keep 2 buffers queued ahead of the play cursor. That is
+    // the whole pipe, so latency ≈ 2 × the buffer duration (≈23 ms) — deep enough
+    // to span the ~14.3 ms framebuffer-blit stall. MIDI timing no longer depends
+    // on it (events are stamped at arrival), so this is a pure latency knob.
+    let hw_frames = (2 * BUF_BYTES / 4) as u64;
     Some((hw_frames * src as u64 / hw as u64) as u32 + 1)
 }
 

--- a/kernel/src/kernel/drivers/hda.rs
+++ b/kernel/src/kernel/drivers/hda.rs
@@ -77,7 +77,6 @@ const RIRBCTL: usize = 0x5C; // b8: bit1 RIRBDMAEN
 const RIRBSTS: usize = 0x5D; // b8: bit0 RINTFL (response interrupt), bit2 overrun
 const RIRBSIZE: usize = 0x5E; // b8: bits1:0 size (0b10 = 256 entries)
 const INTCTL: usize = 0x20; // d32: bit31 GIE, bit30 CIE, bits0..29 per-stream SIE
-const INTSTS: usize = 0x24; // d32: bit31 GIS, bits0..29 per-stream status (W1C-ish)
 const DPLBASE: usize = 0x70; // d32: DMA position buffer base; bit0 = enable
 const DPUBASE: usize = 0x74; // d32: DMA position buffer base high
 
@@ -175,10 +174,9 @@ static HDA: Mutex<Option<Hda>> = Mutex::new(None);
 /// True once the controller BAR is mapped at `BAR_WIN_VA` (panic-path guard).
 static BAR_MAPPED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
 
-/// Canonical audio-sink IRQ line this controller's MSI is programmed to raise
-/// (an otherwise-unused ISA line so it can't alias a wired IRQ). The kernel's
-/// audio-IRQ router ([`crate::kernel::sound::on_hw_irq`]) matches on it.
-pub const MSI_LINE: u8 = 11;
+/// Kernel MSI identity allocated to the HDA sink. This is not an ISA IRQ/GSI
+/// line; the arch backend delivers it as `Irq::Msi(MSI_SOURCE)`.
+pub const MSI_SOURCE: u8 = 0;
 /// Set once bring-up successfully programmed MSI (always, on any real HDA
 /// machine — bring-up fails otherwise). Read by [`msi_active`].
 static MSI_ON: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
@@ -277,6 +275,10 @@ struct Hda {
     /// clock by construction.
     written_src: u64,
     consumed_hw: u64,
+    /// Last modular hardware DMA byte position. Completion interrupts are
+    /// wakeups; this cursor delta, not the number of queued IRQ events, is the
+    /// authoritative amount consumed.
+    last_hw_pos: u32,
     /// Sparse runtime diagnostics for real hardware bring-up.
     logged_submit: bool,
     logged_run: bool,
@@ -520,7 +522,7 @@ fn bring_up<A: crate::Arch>(machine: &mut A, bus: u8, dev: u8, func: u8) -> bool
     // machine that never existed — skip the controller loudly rather than fall
     // back to polling. There is no real hardware to serve a polled HDA path.
     let msi = machine
-        .msi_alloc(MSI_LINE)
+        .msi_alloc(MSI_SOURCE)
         .is_some_and(|(addr, data)| crate::kernel::pci::msi_enable(machine, bus, dev, func, addr, data));
     if !msi {
         crate::println!(
@@ -592,6 +594,7 @@ fn bring_up<A: crate::Arch>(machine: &mut A, bus: u8, dev: u8, func: u8) -> bool
         resample_acc: 0,
         written_src: 0,
         consumed_hw: 0,
+        last_hw_pos: 0,
         logged_submit: false,
         logged_run: false,
         diag_buffers: 0,
@@ -881,6 +884,7 @@ impl Hda {
         self.resample_acc = 0;
         self.written_src = 0;
         self.consumed_hw = 0;
+        self.last_hw_pos = 0;
         // Clear the PCM ring: the producer restarts at buffer 0, so if the
         // hardware ever runs past the freshly primed buffers (session start,
         // underrun) it must find silence, not a replay of the previous
@@ -1519,6 +1523,7 @@ impl Hda {
             // position read.
             self.written_src = 0;
             self.consumed_hw = 0;
+            self.last_hw_pos = 0;
             }
         let fb = fmt.frame_bytes();
         if fb == 0 {
@@ -1729,22 +1734,36 @@ pub fn play<A: crate::Arch>(machine: &mut A, rate: u32, fmt: Format, bytes: &[u8
     }
 }
 
-/// Service a buffer-completion interrupt (canonical `Irq::Hw(MSI_LINE)` routed
-/// here by `sound::on_hw_irq`). Acknowledges the stream's completion status
-/// (SDSTS.BCIS, write-1-clear) and the controller INTSTS so the device can
-/// signal the next block. For now it only accounts the interrupt; the
-/// event-loop audio track will produce a block per call in the next step.
-pub fn on_irq() {
-    HDA_IRQS.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-    if let Some(dev) = HDA.lock().as_mut() {
-        w8(dev.sd + SDSTS, 0x04); // BCIS write-1-clear
-        w32(INTSTS, r32(INTSTS)); // clear latched stream-interrupt-status bits
-        // One IOC per buffer: each interrupt is exactly one buffer drained. This
-        // is the consumed clock the producer paces to — no SDLPIB poll needed.
-        if dev.running {
+/// Service a buffer-completion interrupt (`Irq::Msi(MSI_SOURCE)`, routed
+/// here by `sound::on_irq`). Acknowledges the stream's completion status
+/// (SDSTS.BCIS, write-1-clear), then advances consumption from the DMA
+/// position-buffer delta. Returns false for a vector delivery with no PCM
+/// completion source.
+pub fn on_irq() -> bool {
+    let mut guard = HDA.lock();
+    let Some(dev) = guard.as_mut() else { return false };
+    let status = r8(dev.sd + SDSTS);
+    if status & 0x04 == 0 {
+        return false;
+    }
+    if dev.running {
+        let ring = (NUM_BUF * BUF_BYTES) as u32;
+        let pos = dev.dma_pos() % ring;
+        let delta = (pos + ring - dev.last_hw_pos) % ring;
+        // A BCIS with an unchanged position can occur when the position buffer
+        // write has not become visible yet. One IOC describes at least one BDL
+        // entry, so use one buffer as the conservative fallback.
+        if delta == 0 {
             dev.consumed_hw += BUF_BYTES as u64;
+            dev.last_hw_pos = (dev.last_hw_pos + BUF_BYTES as u32) % ring;
+        } else {
+            dev.consumed_hw += delta as u64;
+            dev.last_hw_pos = pos;
         }
     }
+    w8(dev.sd + SDSTS, status & 0x1C); // W1C BCIS/FIFOE/DESE sources
+    HDA_IRQS.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    true
 }
 
 /// True once the HDA sink is up and driving production by completion IRQ. The
@@ -1762,7 +1781,7 @@ pub fn position() -> Option<(u64, u64)> {
     if dev.parked {
         return None;
     }
-    // `on_irq` maintains `consumed_hw` per completed buffer — no SDLPIB poll.
+    // `on_irq` maintains `consumed_hw` from DMA-position deltas.
     if dev.src_rate == 0 || dev.rate == 0 {
         return Some((dev.written_src, 0)); // no stream session yet
     }

--- a/kernel/src/kernel/drivers/hda.rs
+++ b/kernel/src/kernel/drivers/hda.rs
@@ -108,15 +108,13 @@ const DMA_PAGES: usize = (BUF_OFF + NUM_BUF * BUF_BYTES).div_ceil(0x1000);
 
 // ── PCM ring geometry (mirror ac97) ──────────────────────────────────────────
 const NUM_BUF: usize = 32;
-// Double-buffered pipe: the producer keeps min_fill = 2 buffers queued ahead of
-// the play cursor, so playback latency ≈ 2 × this buffer's duration. MIDI onset
-// timing is stamped at arrival and applied per-frame (see midi.rs), so buffer
-// size no longer quantises notes — it is chosen purely for pipe depth. 2 KB =
-// 512 stereo frames ≈ 11.6 ms @ 44.1 kHz → ~23 ms pipe, deep enough to ride out
-// the ~14.3 ms framebuffer-blit stall. (GUS-native register writes are still
-// block-quantised, but games default to General MIDI.) The ring is larger than
-// the pipe only to give the write cursor guard room ahead of the play cursor.
-const BUF_BYTES: usize = 0x800;
+// 1 KB = 256 stereo frames ≈ 5.8 ms @ 44.1 kHz. This is the completion-IRQ
+// granularity (one interrupt per buffer), NOT the pipe depth — the pipe is the
+// universal `sound::min_fill`, shared by every sink. Kept ≤ half the pipe so
+// ≥ 2 buffers are queued (double-buffered event-driven refill). MIDI onset is
+// stamped at arrival (see midi.rs), so buffer size never quantises notes. The
+// ring is larger than the pipe only to guard the write cursor ahead of play.
+const BUF_BYTES: usize = 0x400;
 const PRIME_BUFS: usize = 2;
 /// Hard drop ceiling, just under the ring's ahead/behind ambiguity point.
 /// Every producer is position-slaved (`sound::position`/`sound::Pace`) and
@@ -1775,20 +1773,11 @@ pub fn position() -> Option<(u64, u64)> {
 /// Minimum pipe fill for a position-slaved producer, in source frames:
 /// the stream-start prime plus one hardware buffer of claim-burst slack,
 /// converted to the source rate.
-pub fn min_fill(rate: u32) -> Option<u32> {
+/// The sink is up and reports a play position (so `sound::min_fill` returns the
+/// universal pipe depth). The pipe latency itself is not this driver's to set.
+pub fn present() -> bool {
     let g = HDA.lock();
-    let dev = g.as_ref()?;
-    if dev.parked && dev.verb_failed {
-        return None;
-    }
-    let src = if rate == 0 { 44100 } else { rate };
-    let hw = Hda::hardware_rate(src);
-    // Double-buffered: keep 2 buffers queued ahead of the play cursor. That is
-    // the whole pipe, so latency ≈ 2 × the buffer duration (≈23 ms) — deep enough
-    // to span the ~14.3 ms framebuffer-blit stall. MIDI timing no longer depends
-    // on it (events are stamped at arrival), so this is a pure latency knob.
-    let hw_frames = (2 * BUF_BYTES / 4) as u64;
-    Some((hw_frames * src as u64 / hw as u64) as u32 + 1)
+    g.as_ref().is_some_and(|d| !(d.parked && d.verb_failed))
 }
 
 /// Panic-path quiesce: stop all controller DMA and hold the link in reset so a

--- a/kernel/src/kernel/drivers/hda.rs
+++ b/kernel/src/kernel/drivers/hda.rs
@@ -284,6 +284,18 @@ struct Hda {
     logged_run: bool,
     diag_buffers: u8,
     diag_stalls: u8,
+    /// Position-poll counter + print budget for the periodic stream diagnostic.
+    diag_pos_calls: u32,
+    diag_pos_prints: u8,
+    /// Hardware-stream bytes actually written into the ring. Upper bound for
+    /// `consumed_hw`: the codec cannot have played bytes never emitted, and
+    /// `on_irq` clamps its position-delta against the in-flight difference —
+    /// one stale/backward DMA-position read otherwise aliases to a near-full-
+    /// ring forward delta and the drain clock leaps a lap.
+    emitted: u64,
+    /// Frames refused at the MAX_AHEAD ceiling and lap-resync events.
+    diag_dropped: u64,
+    diag_resyncs: u32,
 }
 
 #[derive(Clone, Copy)]
@@ -599,6 +611,11 @@ fn bring_up<A: crate::Arch>(machine: &mut A, bus: u8, dev: u8, func: u8) -> bool
         logged_run: false,
         diag_buffers: 0,
         diag_stalls: 0,
+        diag_pos_calls: 0,
+        diag_pos_prints: 0,
+        emitted: 0,
+        diag_dropped: 0,
+        diag_resyncs: 0,
     };
 
     // Link reset + codec detection, with escalating recovery. A hard reboot
@@ -884,6 +901,7 @@ impl Hda {
         self.resample_acc = 0;
         self.written_src = 0;
         self.consumed_hw = 0;
+        self.emitted = 0;
         self.last_hw_pos = 0;
         // Clear the PCM ring: the producer restarts at buffer 0, so if the
         // hardware ever runs past the freshly primed buffers (session start,
@@ -1413,15 +1431,30 @@ impl Hda {
             let civ = self.play_buf();
             let ahead = (self.cur_buf + NUM_BUF - civ) % NUM_BUF;
             if ahead >= NUM_BUF / 2 {
-                // Lapped: the codec is replaying stale ring behind us (the
-                // audible "echoes"). Resync just past the play position and
-                // zero a guard buffer so the gap plays silence, not history.
+                // Lapped: the codec ran past the write cursor (underrun — the
+                // event loop stalled longer than the pipe is deep) and is
+                // replaying stale ring (the audible "echoes"). Resync just
+                // past the play position and zero a guard buffer so the gap
+                // plays silence, not history — AND snap the drain accounting
+                // to the truth that the codec has consumed everything ever
+                // written. Moving only the cursor left `Pace` believing the
+                // pipe was still full: production then trickled at drain rate
+                // forever *behind* the play head, re-tripping this branch at
+                // every buffer boundary (a resync storm) while the stale lap
+                // replayed — and the drain clock the guest's DSP block IRQs
+                // are slaved to wedged, hanging the guest's sound driver.
+                // With the snap, Pace's deficit becomes a full pipe fill and
+                // the very next pushes re-prime cleanly ahead of the codec.
                 let guard = (civ + 1) % NUM_BUF;
                 unsafe {
                     core::ptr::write_bytes(self.buf_va(guard) as *mut u8, 0, BUF_BYTES);
                 }
                 self.cur_buf = (civ + 2) % NUM_BUF;
+                self.consumed_hw = self.emitted;
+                self.last_hw_pos = self.dma_pos() % (NUM_BUF * BUF_BYTES) as u32;
+                self.diag_resyncs = self.diag_resyncs.wrapping_add(1);
             } else if ahead >= MAX_AHEAD {
+                self.diag_dropped += 1;
                 if self.diag_stalls < 3 {
                     crate::println!(
                         "hda: stall cur_buf={} play_buf={} ahead={} lpib={} pos={}",
@@ -1441,6 +1474,7 @@ impl Hda {
             write_volatile(p as *mut u16, l as u16);
             write_volatile((p + 2) as *mut u16, r as u16);
         }
+        self.emitted += 4;
         self.cur_off += 4;
         if self.cur_off >= BUF_BYTES {
             self.cur_buf = (self.cur_buf + 1) % NUM_BUF;
@@ -1523,6 +1557,7 @@ impl Hda {
             // position read.
             self.written_src = 0;
             self.consumed_hw = 0;
+            self.emitted = 0;
             self.last_hw_pos = 0;
             }
         let fb = fmt.frame_bytes();
@@ -1749,17 +1784,23 @@ pub fn on_irq() -> bool {
     if dev.running {
         let ring = (NUM_BUF * BUF_BYTES) as u32;
         let pos = dev.dma_pos() % ring;
-        let delta = (pos + ring - dev.last_hw_pos) % ring;
+        let raw = ((pos + ring - dev.last_hw_pos) % ring) as u64;
+        // The in-flight byte count is a hard ceiling on any position delta:
+        // the codec cannot have played bytes the producer never emitted. The
+        // modular subtraction above aliases a stale/backward position read
+        // (the position buffer is a plain DMA write racing this MMIO path —
+        // and unreliable outright on some real controllers) into a
+        // near-full-ring FORWARD delta; unclamped, one such read leaps the
+        // drain clock by ~a lap, the pacer overfills the ring to the
+        // lap-ambiguity point, and the resync/drop machinery grinds audibly
+        // (stutter, echo).
+        let in_flight = dev.emitted.saturating_sub(dev.consumed_hw);
         // A BCIS with an unchanged position can occur when the position buffer
         // write has not become visible yet. One IOC describes at least one BDL
         // entry, so use one buffer as the conservative fallback.
-        if delta == 0 {
-            dev.consumed_hw += BUF_BYTES as u64;
-            dev.last_hw_pos = (dev.last_hw_pos + BUF_BYTES as u32) % ring;
-        } else {
-            dev.consumed_hw += delta as u64;
-            dev.last_hw_pos = pos;
-        }
+        let delta = if raw == 0 { BUF_BYTES as u64 } else { raw }.min(in_flight);
+        dev.consumed_hw += delta;
+        dev.last_hw_pos = (dev.last_hw_pos + delta as u32) % ring;
     }
     w8(dev.sd + SDSTS, status & 0x1C); // W1C BCIS/FIFOE/DESE sources
     HDA_IRQS.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
@@ -1780,6 +1821,28 @@ pub fn position() -> Option<(u64, u64)> {
     let dev = g.as_mut()?;
     if dev.parked {
         return None;
+    }
+    // Metal bring-up diagnostic: `position` is polled every pump tick (~1 kHz)
+    // while a session is active, so every ~2 s report whether completion
+    // interrupts arrive and whether the two hardware cursors (SDLPIB, the DMA
+    // position buffer) actually advance — the three things QEMU gets right
+    // that real silicon may not.
+    dev.diag_pos_calls = dev.diag_pos_calls.wrapping_add(1);
+    if dev.diag_pos_calls % 2048 == 0 && dev.diag_pos_prints < 60 {
+        dev.diag_pos_prints += 1;
+        crate::println!(
+            "hda: diag irqs={} written_src={} consumed_hw={} lpib={} pos={} cur_buf={} emitted={} dropped={} resyncs={} running={}",
+            HDA_IRQS.load(core::sync::atomic::Ordering::Relaxed),
+            dev.written_src,
+            dev.consumed_hw,
+            r32(dev.sd + SDLPIB),
+            dev.dma_pos(),
+            dev.cur_buf,
+            dev.emitted,
+            dev.diag_dropped,
+            dev.diag_resyncs,
+            dev.running,
+        );
     }
     // `on_irq` maintains `consumed_hw` from DMA-position deltas.
     if dev.src_rate == 0 || dev.rate == 0 {

--- a/kernel/src/kernel/drivers/hda.rs
+++ b/kernel/src/kernel/drivers/hda.rs
@@ -108,13 +108,13 @@ const DMA_PAGES: usize = (BUF_OFF + NUM_BUF * BUF_BYTES).div_ceil(0x1000);
 
 // ── PCM ring geometry (mirror ac97) ──────────────────────────────────────────
 const NUM_BUF: usize = 32;
-// 256 B = 64 stereo frames ≈ 1.45 ms @ 44.1 kHz. Deliberately small: with MSI
-// each completed buffer is one interrupt that drives one production pass, so
-// the buffer duration sets how finely the synth engine advances. A large buffer
-// would step GUS/DMX in coarse lumps (the E1M8 "cut notes" failure mode); ~1.5
-// ms keeps it close to the old 1 ms get_ticks cadence. Polled sinks are
-// unaffected — their pacing is the get_ticks servo, not the buffer size.
-const BUF_BYTES: usize = 0x100;
+// 1 KB = 256 stereo frames ≈ 5.8 ms @ 44.1 kHz. With MSI each completed buffer
+// is one interrupt that drives one production pass, so the buffer duration sets
+// how finely the synth engine advances — a large buffer would step GUS/DMX in
+// coarse lumps (the E1M8 "cut notes" failure mode). ~6 ms stays fine there while
+// giving the pipe (6 buffers ≈ 35 ms) depth to ride out the ~14.3 ms
+// framebuffer-blit stall that would otherwise crackle a shallower pipe.
+const BUF_BYTES: usize = 0x400;
 const PRIME_BUFS: usize = 3;
 /// Hard drop ceiling, just under the ring's ahead/behind ambiguity point.
 /// Every producer is position-slaved (`sound::position`/`sound::Pace`) and
@@ -1781,8 +1781,8 @@ pub fn min_fill(rate: u32) -> Option<u32> {
     }
     let src = if rate == 0 { 44100 } else { rate };
     let hw = Hda::hardware_rate(src);
-    // Event-driven: one small buffer is refilled per completion interrupt, so a
-    // shallow pipe suffices and keeps latency low (6 × 1.45 ms ≈ 9 ms).
+    // Event-driven: one buffer is refilled per completion interrupt. Six buffers
+    // (6 × 5.8 ms ≈ 35 ms) span the ~14.3 ms framebuffer-blit stall with margin.
     let hw_frames = (6 * BUF_BYTES / 4) as u64;
     Some((hw_frames * src as u64 / hw as u64) as u32 + 1)
 }

--- a/kernel/src/kernel/drivers/hda.rs
+++ b/kernel/src/kernel/drivers/hda.rs
@@ -1355,6 +1355,17 @@ impl Hda {
                 crate::println!("hda: alc298 amp init aborted (codec stopped responding)");
                 return;
             }
+            // Pace the replay like the reference does. The oracle (Ubuntu's
+            // rb_audio.sh) runs one hda-verb PROCESS per write — milliseconds
+            // between verbs — while a back-to-back CORB burst gives the
+            // vendor DSP microseconds. Its banked/indirect writes (the
+            // 0x23/0x26 sequences) can silently drop under that pressure:
+            // every CORB round-trip acks, but the DSP program comes up
+            // partial — amp audible, low band buried (metal played E1M5's
+            // string line at a whisper while the same PCM through Linux's
+            // fully-programmed codec was loud). ~50 µs per verb costs ~100 ms
+            // once per boot.
+            spin(100_000);
         }
         self.amp_init_done = true;
         crate::println!(

--- a/kernel/src/kernel/drivers/hda.rs
+++ b/kernel/src/kernel/drivers/hda.rs
@@ -73,8 +73,13 @@ const RINTCNT: usize = 0x5A; // w16: response interrupt count
 const RIRBCTL: usize = 0x5C; // b8: bit1 RIRBDMAEN
 const RIRBSTS: usize = 0x5D; // b8: bit0 RINTFL (response interrupt), bit2 overrun
 const RIRBSIZE: usize = 0x5E; // b8: bits1:0 size (0b10 = 256 entries)
+const INTCTL: usize = 0x20; // d32: bit31 GIE, bit30 CIE, bits0..29 per-stream SIE
+const INTSTS: usize = 0x24; // d32: bit31 GIS, bits0..29 per-stream status (W1C-ish)
 const DPLBASE: usize = 0x70; // d32: DMA position buffer base; bit0 = enable
 const DPUBASE: usize = 0x74; // d32: DMA position buffer base high
+
+const SDSTS: usize = 0x03; // b8 (in the SD block): bit2 BCIS (buffer-complete), W1C
+const SDCTL_IOCE: u32 = 0x04; // SDCTL bit2: interrupt-on-completion enable
 
 // Output stream descriptor register offsets (added to the descriptor base, which
 // is 0x80 + ISS*0x20 — the first output stream sits past the input streams).
@@ -160,6 +165,16 @@ const REALTEK_EAPD_COEF_MASK: u32 = 1 << 9;
 static HDA: Mutex<Option<Hda>> = Mutex::new(None);
 /// True once the controller BAR is mapped at `BAR_WIN_VA` (panic-path guard).
 static BAR_MAPPED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+
+/// Canonical audio-sink IRQ line this controller's MSI is programmed to raise
+/// (an otherwise-unused ISA line so it can't alias a wired IRQ). The kernel's
+/// audio-IRQ router ([`crate::kernel::sound::on_hw_irq`]) matches on it.
+pub const MSI_LINE: u8 = 11;
+/// Set once bring-up successfully programmed MSI; when false the driver stays on
+/// the polled `SDLPIB` path and never enables interrupt-on-completion.
+static MSI_ON: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+/// Buffer-completion interrupts serviced (bring-up diagnostic for now).
+static HDA_IRQS: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
 
 #[inline]
 fn spin(n: usize) {
@@ -491,6 +506,16 @@ fn bring_up<A: crate::Arch>(machine: &mut A, bus: u8, dev: u8, func: u8) -> bool
     let cmd = crate::kernel::pci::read32(machine, bus, dev, func, 0x04);
     crate::kernel::pci::write32(machine, bus, dev, func, 0x04, (cmd & 0xFFFF) | 0x06);
 
+    // Message-signalled interrupts: ask the arch for a target that delivers the
+    // canonical `Irq::Hw(MSI_LINE)` and program it into the device's MSI
+    // capability. When unavailable (no LAPIC → PIC-only), MSI_ON stays false and
+    // the driver keeps its polled `SDLPIB` production path.
+    let msi = machine
+        .msi_alloc(MSI_LINE)
+        .is_some_and(|(addr, data)| crate::kernel::pci::msi_enable(machine, bus, dev, func, addr, data));
+    MSI_ON.store(msi, core::sync::atomic::Ordering::Relaxed);
+    crate::println!("hda: {:02x}:{:02x}.{} MSI {}", bus, dev, func, if msi { "on" } else { "unavailable (polled)" });
+
     // BAR0 is a memory BAR. Read the high dword only if it is actually 64-bit
     // (type bits [2:1] == 0b10); a 32-bit BAR would make 0x14 a different reg.
     let bar0 = crate::kernel::pci::read32(machine, bus, dev, func, 0x10);
@@ -776,15 +801,18 @@ impl Hda {
     }
 
     /// Fill the BDL: entry i → PCM buffer i. Each HDA BDL entry is 16 bytes
-    /// { addr:u64, len:u32, flags:u32 }; IOC stays off (we poll `SDLPIB`).
+    /// { addr:u64, len:u32, flags:u32 }. flags bit0 = IOC: set per buffer when
+    /// MSI is on (one completion interrupt per buffer drives the event-loop
+    /// audio track); off otherwise (the driver polls `SDLPIB` instead).
     fn build_bdl(&mut self) {
+        let ioc = if MSI_ON.load(core::sync::atomic::Ordering::Relaxed) { 1 } else { 0 };
         for i in 0..NUM_BUF {
             let entry = self.dma_va + BDL_OFF + i * 16;
             unsafe {
                 write_volatile(entry as *mut u32, self.buf_phys(i)); // addr low
                 write_volatile((entry + 4) as *mut u32, 0); // addr high
                 write_volatile((entry + 8) as *mut u32, BUF_BYTES as u32); // length
-                write_volatile((entry + 12) as *mut u32, 0); // flags (IOC off)
+                write_volatile((entry + 12) as *mut u32, ioc); // flags (IOC per buffer)
             }
         }
     }
@@ -892,6 +920,14 @@ impl Hda {
         w16(sd + SDLVI, (NUM_BUF - 1) as u16);
         // Stream tag in the descriptor control byte (bits 20..23 of SDCTL).
         w8(sd + SDCTL + 2, (STREAM_TAG << 4) as u8);
+
+        // Enable delivery of this stream's completion interrupts to the CPU:
+        // global-interrupt-enable + this stream's status-interrupt-enable bit.
+        // The per-buffer IOCE (SDCTL bit2) is set with RUN at playback start.
+        if MSI_ON.load(core::sync::atomic::Ordering::Relaxed) {
+            let sidx = (self.sd - SD_BASE) / SD_STRIDE;
+            w32(INTCTL, 0x8000_0000 | (1u32 << sidx));
+        }
     }
 
     /// Park the link: stop all DMA and hold the controller in reset (CRST
@@ -1411,7 +1447,8 @@ impl Hda {
             // stream binding with the stream number visible (a byte-0-only
             // RUN write may not retrigger it → codec never drains the FIFO).
             if !self.running && self.cur_buf >= PRIME_BUFS {
-                w32(self.sd + SDCTL, 0x02 | (STREAM_TAG << 20));
+                let ioce = if MSI_ON.load(core::sync::atomic::Ordering::Relaxed) { SDCTL_IOCE } else { 0 };
+                w32(self.sd + SDCTL, 0x02 | ioce | (STREAM_TAG << 20));
                 self.running = true;
                 if !self.logged_run {
                     crate::println!(
@@ -1693,6 +1730,22 @@ pub fn play<A: crate::Arch>(machine: &mut A, rate: u32, fmt: Format, bytes: &[u8
     let mut g = HDA.lock();
     if let Some(dev) = g.as_mut() {
         dev.submit(rate, fmt, bytes);
+    }
+}
+
+/// Service a buffer-completion interrupt (canonical `Irq::Hw(MSI_LINE)` routed
+/// here by `sound::on_hw_irq`). Acknowledges the stream's completion status
+/// (SDSTS.BCIS, write-1-clear) and the controller INTSTS so the device can
+/// signal the next block. For now it only accounts the interrupt; the
+/// event-loop audio track will produce a block per call in the next step.
+pub fn on_irq() {
+    let n = HDA_IRQS.fetch_add(1, core::sync::atomic::Ordering::Relaxed) + 1;
+    if let Some(dev) = HDA.lock().as_ref() {
+        w8(dev.sd + SDSTS, 0x04); // BCIS write-1-clear
+        w32(INTSTS, r32(INTSTS)); // clear latched stream-interrupt-status bits
+    }
+    if n <= 3 || n % 512 == 0 {
+        crate::println!("hda: MSI completion irq #{}", n);
     }
 }
 

--- a/kernel/src/kernel/drivers/hda.rs
+++ b/kernel/src/kernel/drivers/hda.rs
@@ -279,6 +279,13 @@ struct Hda {
     /// wakeups; this cursor delta, not the number of queued IRQ events, is the
     /// authoritative amount consumed.
     last_hw_pos: u32,
+    /// True once the DMA position buffer has read nonzero this stream session:
+    /// it is the preferred cursor (some QEMU builds never update SDLPIB), but
+    /// real controllers exist where it stays 0 forever while SDLPIB tracks the
+    /// stream (the ALC298 laptop's AMD controller — the split Linux's
+    /// position_fix quirk table exists for). Until it proves live, consumption
+    /// deltas come from SDLPIB.
+    posbuf_live: bool,
     /// Sparse runtime diagnostics for real hardware bring-up.
     logged_submit: bool,
     logged_run: bool,
@@ -607,6 +614,7 @@ fn bring_up<A: crate::Arch>(machine: &mut A, bus: u8, dev: u8, func: u8) -> bool
         written_src: 0,
         consumed_hw: 0,
         last_hw_pos: 0,
+        posbuf_live: false,
         logged_submit: false,
         logged_run: false,
         diag_buffers: 0,
@@ -903,6 +911,7 @@ impl Hda {
         self.consumed_hw = 0;
         self.emitted = 0;
         self.last_hw_pos = 0;
+        self.posbuf_live = false;
         // Clear the PCM ring: the producer restarts at buffer 0, so if the
         // hardware ever runs past the freshly primed buffers (session start,
         // underrun) it must find silence, not a replay of the previous
@@ -1413,6 +1422,20 @@ impl Hda {
         unsafe { read_volatile((self.dma_va + POS_OFF + idx * 8) as *const u32) }
     }
 
+    /// The authoritative hardware byte cursor for consumption accounting:
+    /// the DMA position buffer once it has proven live this session, SDLPIB
+    /// until then (see `posbuf_live`). Consumption must come from a cursor
+    /// that actually moves — deriving deltas from a dead position buffer
+    /// turned every completion IRQ into a garbage near-full-ring delta on
+    /// the ALC298 laptop (silent output, wedged pacer).
+    fn hw_cursor(&mut self) -> u32 {
+        let pos = self.dma_pos();
+        if pos != 0 {
+            self.posbuf_live = true;
+        }
+        if self.posbuf_live { pos } else { r32(self.sd + SDLPIB) }
+    }
+
     fn stop(&mut self) {
         let ctl = r8(self.sd + SDCTL);
         w8(self.sd + SDCTL, ctl & !0x02); // clear RUN
@@ -1451,7 +1474,7 @@ impl Hda {
                 }
                 self.cur_buf = (civ + 2) % NUM_BUF;
                 self.consumed_hw = self.emitted;
-                self.last_hw_pos = self.dma_pos() % (NUM_BUF * BUF_BYTES) as u32;
+                self.last_hw_pos = self.hw_cursor() % (NUM_BUF * BUF_BYTES) as u32;
                 self.diag_resyncs = self.diag_resyncs.wrapping_add(1);
             } else if ahead >= MAX_AHEAD {
                 self.diag_dropped += 1;
@@ -1559,6 +1582,7 @@ impl Hda {
             self.consumed_hw = 0;
             self.emitted = 0;
             self.last_hw_pos = 0;
+            self.posbuf_live = false;
             }
         let fb = fmt.frame_bytes();
         if fb == 0 {
@@ -1783,7 +1807,7 @@ pub fn on_irq() -> bool {
     }
     if dev.running {
         let ring = (NUM_BUF * BUF_BYTES) as u32;
-        let pos = dev.dma_pos() % ring;
+        let pos = dev.hw_cursor() % ring;
         let raw = ((pos + ring - dev.last_hw_pos) % ring) as u64;
         // The in-flight byte count is a hard ceiling on any position delta:
         // the codec cannot have played bytes the producer never emitted. The

--- a/kernel/src/kernel/drivers/hda.rs
+++ b/kernel/src/kernel/drivers/hda.rs
@@ -13,10 +13,13 @@
 //!    programmed by sending *verbs* over the **CORB/RIRB** DMA rings, then a
 //!    stream descriptor + BDL feed PCM exactly like AC'97's bus master.
 //!
-//! Everything else mirrors `ac97`: a 32-entry ring of PCM buffers in a borrowed
-//! contiguous DMA buffer, primed then run, with the producer's run-ahead capped
-//! by polling the hardware play position (`SDLPIB` here, `CIV` there) — no
-//! interrupts.
+//! Ring geometry mirrors `ac97`: a 32-entry ring of small PCM buffers in a
+//! borrowed contiguous DMA buffer, primed then run. Unlike `ac97`, HDA drives
+//! production by **MSI**: one interrupt-on-completion per buffer signals the
+//! canonical `Irq::Hw` line, and the producer refills the drained buffer from
+//! the event loop. HDA is a PCI-E-era controller, so a machine that has one
+//! always has a local APIC — there is no polled fallback (bring-up fails loudly
+//! if MSI can't be programmed).
 //!
 //! ## Topology
 //!
@@ -176,8 +179,8 @@ static BAR_MAPPED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBo
 /// (an otherwise-unused ISA line so it can't alias a wired IRQ). The kernel's
 /// audio-IRQ router ([`crate::kernel::sound::on_hw_irq`]) matches on it.
 pub const MSI_LINE: u8 = 11;
-/// Set once bring-up successfully programmed MSI; when false the driver stays on
-/// the polled `SDLPIB` path and never enables interrupt-on-completion.
+/// Set once bring-up successfully programmed MSI (always, on any real HDA
+/// machine — bring-up fails otherwise). Read by [`msi_active`].
 static MSI_ON: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
 /// Buffer-completion interrupts serviced (bring-up diagnostic for now).
 static HDA_IRQS: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
@@ -274,7 +277,6 @@ struct Hda {
     /// clock by construction.
     written_src: u64,
     consumed_hw: u64,
-    last_lpib: u32,
     /// Sparse runtime diagnostics for real hardware bring-up.
     logged_submit: bool,
     logged_run: bool,
@@ -512,15 +514,23 @@ fn bring_up<A: crate::Arch>(machine: &mut A, bus: u8, dev: u8, func: u8) -> bool
     let cmd = crate::kernel::pci::read32(machine, bus, dev, func, 0x04);
     crate::kernel::pci::write32(machine, bus, dev, func, 0x04, (cmd & 0xFFFF) | 0x06);
 
-    // Message-signalled interrupts: ask the arch for a target that delivers the
-    // canonical `Irq::Hw(MSI_LINE)` and program it into the device's MSI
-    // capability. When unavailable (no LAPIC → PIC-only), MSI_ON stays false and
-    // the driver keeps its polled `SDLPIB` production path.
+    // MSI drives the sink. HDA is a PCI-E-era controller; any machine that has
+    // one has a local APIC, so MSI is always available on real hardware. If it
+    // can't be programmed — only the artificial i486 + intel-hda QEMU combo, a
+    // machine that never existed — skip the controller loudly rather than fall
+    // back to polling. There is no real hardware to serve a polled HDA path.
     let msi = machine
         .msi_alloc(MSI_LINE)
         .is_some_and(|(addr, data)| crate::kernel::pci::msi_enable(machine, bus, dev, func, addr, data));
-    MSI_ON.store(msi, core::sync::atomic::Ordering::Relaxed);
-    crate::println!("hda: {:02x}:{:02x}.{} MSI {}", bus, dev, func, if msi { "on" } else { "unavailable (polled)" });
+    if !msi {
+        crate::println!(
+            "hda: {:02x}:{:02x}.{} no MSI — HDA implies an APIC machine (use --arch 686/x64); skipping",
+            bus, dev, func
+        );
+        return false;
+    }
+    MSI_ON.store(true, core::sync::atomic::Ordering::Relaxed);
+    crate::println!("hda: {:02x}:{:02x}.{} MSI on", bus, dev, func);
 
     // BAR0 is a memory BAR. Read the high dword only if it is actually 64-bit
     // (type bits [2:1] == 0b10); a 32-bit BAR would make 0x14 a different reg.
@@ -582,7 +592,6 @@ fn bring_up<A: crate::Arch>(machine: &mut A, bus: u8, dev: u8, func: u8) -> bool
         resample_acc: 0,
         written_src: 0,
         consumed_hw: 0,
-        last_lpib: 0,
         logged_submit: false,
         logged_run: false,
         diag_buffers: 0,
@@ -807,11 +816,10 @@ impl Hda {
     }
 
     /// Fill the BDL: entry i → PCM buffer i. Each HDA BDL entry is 16 bytes
-    /// { addr:u64, len:u32, flags:u32 }. flags bit0 = IOC: set per buffer when
-    /// MSI is on (one completion interrupt per buffer drives the event-loop
-    /// audio track); off otherwise (the driver polls `SDLPIB` instead).
+    /// { addr:u64, len:u32, flags:u32 }. flags bit0 = IOC, set per buffer: one
+    /// completion interrupt per buffer drives the event-loop audio track.
     fn build_bdl(&mut self) {
-        let ioc = if MSI_ON.load(core::sync::atomic::Ordering::Relaxed) { 1 } else { 0 };
+        let ioc = 1u32;
         for i in 0..NUM_BUF {
             let entry = self.dma_va + BDL_OFF + i * 16;
             unsafe {
@@ -873,7 +881,6 @@ impl Hda {
         self.resample_acc = 0;
         self.written_src = 0;
         self.consumed_hw = 0;
-        self.last_lpib = 0;
         // Clear the PCM ring: the producer restarts at buffer 0, so if the
         // hardware ever runs past the freshly primed buffers (session start,
         // underrun) it must find silence, not a replay of the previous
@@ -930,10 +937,8 @@ impl Hda {
         // Enable delivery of this stream's completion interrupts to the CPU:
         // global-interrupt-enable + this stream's status-interrupt-enable bit.
         // The per-buffer IOCE (SDCTL bit2) is set with RUN at playback start.
-        if MSI_ON.load(core::sync::atomic::Ordering::Relaxed) {
-            let sidx = (self.sd - SD_BASE) / SD_STRIDE;
-            w32(INTCTL, 0x8000_0000 | (1u32 << sidx));
-        }
+        let sidx = (self.sd - SD_BASE) / SD_STRIDE;
+        w32(INTCTL, 0x8000_0000 | (1u32 << sidx));
     }
 
     /// Park the link: stop all DMA and hold the controller in reset (CRST
@@ -1453,8 +1458,7 @@ impl Hda {
             // stream binding with the stream number visible (a byte-0-only
             // RUN write may not retrigger it → codec never drains the FIFO).
             if !self.running && self.cur_buf >= PRIME_BUFS {
-                let ioce = if MSI_ON.load(core::sync::atomic::Ordering::Relaxed) { SDCTL_IOCE } else { 0 };
-                w32(self.sd + SDCTL, 0x02 | ioce | (STREAM_TAG << 20));
+                w32(self.sd + SDCTL, 0x02 | SDCTL_IOCE | (STREAM_TAG << 20));
                 self.running = true;
                 if !self.logged_run {
                     crate::println!(
@@ -1515,8 +1519,7 @@ impl Hda {
             // position read.
             self.written_src = 0;
             self.consumed_hw = 0;
-            self.last_lpib = 0;
-        }
+            }
         let fb = fmt.frame_bytes();
         if fb == 0 {
             return;
@@ -1551,19 +1554,6 @@ impl Hda {
         }
     }
 
-    /// Accumulate the codec's consumed-byte counter from LPIB deltas (LPIB
-    /// itself wraps at CBL). Call cadence must beat a full ring period
-    /// (~370 ms @ 44.1 kHz); the slaved producer polls every scheduler
-    /// slice, orders of magnitude inside that.
-    fn update_consumed(&mut self) {
-        if !self.running {
-            return;
-        }
-        let cbl = (NUM_BUF * BUF_BYTES) as u32;
-        let lpib = r32(self.sd + SDLPIB) % cbl.max(1);
-        self.consumed_hw += ((lpib + cbl - self.last_lpib) % cbl) as u64;
-        self.last_lpib = lpib;
-    }
 }
 
 fn find_widget(widgets: &[Widget; MAX_WIDGETS], count: usize, nid: u32) -> Option<usize> {
@@ -1757,9 +1747,8 @@ pub fn on_irq() {
     }
 }
 
-/// True once MSI is up and the sink is driving production by completion IRQ
-/// (vs the polled SDLPIB path). The producer's pacer reads this to switch to
-/// event-driven refill.
+/// True once the HDA sink is up and driving production by completion IRQ. The
+/// producer's pacer reads this to select event-driven refill.
 pub fn msi_active() -> bool {
     MSI_ON.load(core::sync::atomic::Ordering::Relaxed)
 }
@@ -1773,12 +1762,7 @@ pub fn position() -> Option<(u64, u64)> {
     if dev.parked {
         return None;
     }
-    // MSI-driven: `on_irq` maintains `consumed_hw` per completed buffer, so the
-    // per-call SDLPIB poll (a KVM/MMIO exit) is gone. Polled fallback still reads
-    // the hardware position here.
-    if !MSI_ON.load(core::sync::atomic::Ordering::Relaxed) {
-        dev.update_consumed();
-    }
+    // `on_irq` maintains `consumed_hw` per completed buffer — no SDLPIB poll.
     if dev.src_rate == 0 || dev.rate == 0 {
         return Some((dev.written_src, 0)); // no stream session yet
     }
@@ -1797,13 +1781,9 @@ pub fn min_fill(rate: u32) -> Option<u32> {
     }
     let src = if rate == 0 { 44100 } else { rate };
     let hw = Hda::hardware_rate(src);
-    // Event-driven (MSI) refills one small buffer per completion interrupt, so a
-    // shallow pipe suffices and keeps latency low. The polled fallback refills on
-    // the jittery ms tick and needs a deep cushion against underrun — with the
-    // small buffers that give MSI its fine granularity, that means many of them.
-    // Both fit the 32-buffer ring (46 ms @ 44.1 kHz).
-    let depth_bufs = if MSI_ON.load(core::sync::atomic::Ordering::Relaxed) { 6 } else { 24 };
-    let hw_frames = (depth_bufs * BUF_BYTES / 4) as u64;
+    // Event-driven: one small buffer is refilled per completion interrupt, so a
+    // shallow pipe suffices and keeps latency low (6 × 1.45 ms ≈ 9 ms).
+    let hw_frames = (6 * BUF_BYTES / 4) as u64;
     Some((hw_frames * src as u64 / hw as u64) as u32 + 1)
 }
 

--- a/kernel/src/kernel/drivers/mod.rs
+++ b/kernel/src/kernel/drivers/mod.rs
@@ -12,5 +12,6 @@
 pub mod ac97;
 pub mod alc298_amp;
 pub mod hda;
+pub mod sb16;
 pub mod hdd;
 pub mod nvme;

--- a/kernel/src/kernel/drivers/sb16.rs
+++ b/kernel/src/kernel/drivers/sb16.rs
@@ -1,0 +1,305 @@
+//! Sound Blaster 16 output — a kernel device driver (not machine code).
+//!
+//! On a machine whose real sound hardware is a Sound Blaster 16, the emulated
+//! cards (`vsb`/`vgus`/`vmpu`) produce canonical PCM and the kernel `sound`
+//! layer needs somewhere to play it. This driver is that sink: `sound::play`
+//! dispatches here when the platform probe found a real SB16 (`Audio::RealSb`).
+//!
+//! It drives the real DSP for **16-bit signed-stereo auto-init DMA** on the ISA
+//! 8237 (channel 5) — the SB16's own double-buffer scheme, where each completed
+//! block raises **IRQ 5**. That block-completion interrupt IS the event-driven
+//! audio track's completion signal: one interrupt = one buffer drained/free, so
+//! `on_irq` is a plain block counter and the driver never reads a DMA position.
+//!
+//! Only machine *primitives* are used — port I/O (`inb`/`outb`, for the DSP,
+//! mixer, and the 8237), `dma_channel_buf` (the permanent contiguous channel-5
+//! buffer, ISA-DMA-safe), and `map_phys_range` (to map it into kernel space) —
+//! never any machine-side driver logic. The DMA window is shared with the
+//! ac97/hda sinks (only one sink is ever active), see `ac97.rs`.
+
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use spin::Mutex;
+
+use crate::kernel::sound::Format;
+
+// ── SB16 DSP / mixer ports (base 0x220; the card is machine-wide, so the sink
+//    uses the canonical base, not a per-thread BLASTER relocation) ────────────
+const BASE: u16 = 0x220;
+const DSP_RESET: u16 = BASE + 0x06;
+const DSP_READ: u16 = BASE + 0x0A; // read data
+const DSP_WRITE: u16 = BASE + 0x0C; // write command/data; bit7 = busy
+const DSP_RSTAT: u16 = BASE + 0x0E; // read-buffer status (bit7 = data ready) / 8-bit IRQ ack
+const DSP_ACK16: u16 = BASE + 0x0F; // 16-bit IRQ acknowledge
+const MIX_IDX: u16 = BASE + 0x04;
+const MIX_DATA: u16 = BASE + 0x05;
+
+// DSP commands.
+const CMD_SPEAKER_ON: u8 = 0xD1;
+const CMD_SET_RATE_OUT: u8 = 0x41; // output rate, big-endian 16-bit
+const CMD_16BIT_AUTO_OUT: u8 = 0xB6; // 16-bit, auto-init, FIFO, D/A
+const CMD_EXIT_AUTO_16: u8 = 0xD9; // finish the current block then stop
+const MODE_SIGNED_STEREO: u8 = 0x30; // bit5 stereo, bit4 signed
+
+// ── 8237 channel-5 (16-bit) registers ───────────────────────────────────────
+const DMA_CHANNEL: usize = 5;
+const DMA5_MASK: u16 = 0xD4; // write 0x05 to mask, 0x01 to unmask
+const DMA5_MODE: u16 = 0xD6;
+const DMA5_CLRFF: u16 = 0xD8;
+const DMA5_ADDR: u16 = 0xC4; // word address (low then high)
+const DMA5_COUNT: u16 = 0xC6; // word count − 1 (low then high)
+const DMA5_PAGE: u16 = 0x8B;
+// single(0x40) | auto-init(0x10) | read/mem→dev(0x08) | channel-local 1 (5−4).
+const DMA5_MODE_AUTO_READ: u8 = 0x59;
+
+// ── ring geometry (shares the stolen low-mem DMA window with ac97/hda) ───────
+const DMA_WIN_VA: usize = crate::LOW_MEM_BASE + 0xC_0000;
+const PTE_CACHE_DISABLE: u64 = 1 << 4;
+/// Completion-IRQ granularity: one interrupt per buffer. ≤ half the universal
+/// pipe (see `sound::min_fill`) so ≥ 2 buffers stay queued (double-buffered).
+const BUF_BYTES: usize = 0x400; // 1 KB = 256 stereo frames ≈ 5.8 ms @ 44.1 kHz
+const NUM_BUF: usize = 32;
+const RING_BYTES: usize = NUM_BUF * BUF_BYTES;
+/// Prime this many buffers before starting the DSP.
+const PRIME_BUFS: usize = 2;
+
+struct Sb16 {
+    dma_va: usize,
+    dma_phys: u32,
+    cur_buf: usize, // ring buffer currently being filled
+    cur_off: usize, // byte offset within `cur_buf`
+    running: bool,  // DSP auto-init playback started
+    rate: u32,      // last programmed sample rate
+    /// Pipe counters for [`position`], in source frames (the DAC runs at the
+    /// source rate — no resampler). `written` = frames accepted by `submit`;
+    /// `consumed_bufs` = buffers the DSP has finished, one per completion IRQ.
+    written: u64,
+    consumed_bufs: u64,
+}
+
+static SB16: Mutex<Option<Sb16>> = Mutex::new(None);
+static PRESENT: AtomicBool = AtomicBool::new(false);
+/// The IRQ line the card raises on block completion (read from the mixer at
+/// bring-up), so `sound::on_hw_irq` can match it. 0xFF until up.
+static IRQ_LINE: AtomicU32 = AtomicU32::new(0xFF);
+
+/// The routed completion-IRQ line, for `sound::on_hw_irq`. `None` until up.
+pub fn irq_line() -> Option<u8> {
+    match IRQ_LINE.load(Ordering::Relaxed) {
+        0xFF => None,
+        n => Some(n as u8),
+    }
+}
+
+/// The sink is up and reports a play position (so `sound::min_fill` returns the
+/// universal pipe depth).
+pub fn present() -> bool {
+    PRESENT.load(Ordering::Relaxed)
+}
+
+/// Reset the DSP and read back the 0xAA ready byte. Pure presence probe —
+/// `platform::probe` uses it for the Audio decision; an absent card reads 0xFF.
+pub fn scan<A: crate::Arch>(machine: &mut A) -> bool {
+    dsp_reset(machine)
+}
+
+/// Bring up the SB16 the platform probe found. Driver init only.
+pub fn init<A: crate::Arch>(machine: &mut A) {
+    if crate::kernel::platform::get().audio != crate::kernel::platform::Audio::RealSb {
+        return;
+    }
+    if bring_up(machine) {
+        PRESENT.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Standard DSP reset: pulse `DSP_RESET` 1→0, wait for data-ready, read 0xAA.
+fn dsp_reset<A: crate::Arch>(machine: &mut A) -> bool {
+    machine.outb(DSP_RESET, 1);
+    for _ in 0..1000 {
+        core::hint::spin_loop();
+    }
+    machine.outb(DSP_RESET, 0);
+    for _ in 0..100_000 {
+        if machine.inb(DSP_RSTAT) & 0x80 != 0 && machine.inb(DSP_READ) == 0xAA {
+            return true;
+        }
+    }
+    false
+}
+
+/// Write one DSP command/data byte once the write buffer is ready (bit7 clear).
+fn dsp_write<A: crate::Arch>(machine: &mut A, byte: u8) {
+    for _ in 0..100_000 {
+        if machine.inb(DSP_WRITE) & 0x80 == 0 {
+            break;
+        }
+    }
+    machine.outb(DSP_WRITE, byte);
+}
+
+/// Read the SB16 mixer's IRQ-select register (0x80) into an IRQ line. Bits:
+/// 1=IRQ2, 2=IRQ5, 4=IRQ7, 8=IRQ10. Defaults to 5 if the mixer is mute (0xFF).
+fn read_irq<A: crate::Arch>(machine: &mut A) -> u8 {
+    machine.outb(MIX_IDX, 0x80);
+    match machine.inb(MIX_DATA) {
+        0xFF => 5,
+        v if v & 0x04 != 0 => 7,
+        v if v & 0x08 != 0 => 10,
+        v if v & 0x01 != 0 => 2,
+        _ => 5,
+    }
+}
+
+fn bring_up<A: crate::Arch>(machine: &mut A) -> bool {
+    if !dsp_reset(machine) {
+        return false;
+    }
+    let irq = read_irq(machine);
+
+    // Map the permanent contiguous channel-5 buffer into the stolen low-mem
+    // window so the kernel can write PCM; the DSP reads it by physical address.
+    let phys_page = machine.dma_channel_buf(DMA_CHANNEL);
+    if phys_page == 0 {
+        crate::println!("sb16: no channel-{} DMA buffer; skipping", DMA_CHANNEL);
+        return false;
+    }
+    let pages = RING_BYTES.div_ceil(0x1000);
+    machine.map_phys_range(DMA_WIN_VA >> 12, pages, phys_page, PTE_CACHE_DISABLE);
+    let dma_phys = (phys_page * 0x1000) as u32;
+
+    // Start from silence so the first auto-init lap before prime isn't garbage.
+    unsafe { core::ptr::write_bytes(DMA_WIN_VA as *mut u8, 0, RING_BYTES) };
+
+    machine.outb(MIX_IDX, 0x22); // master volume index
+    machine.outb(MIX_DATA, 0xFF); // full
+    dsp_write(machine, CMD_SPEAKER_ON);
+
+    *SB16.lock() = Some(Sb16 {
+        dma_va: DMA_WIN_VA,
+        dma_phys,
+        cur_buf: 0,
+        cur_off: 0,
+        running: false,
+        rate: 0,
+        written: 0,
+        consumed_bufs: 0,
+    });
+    IRQ_LINE.store(irq as u32, Ordering::Relaxed);
+    crate::println!("sb16: {:#05x} DSP up, IRQ {}, DMA {}", BASE, irq, DMA_CHANNEL);
+    true
+}
+
+impl Sb16 {
+    fn buf_va(&self, i: usize) -> usize {
+        self.dma_va + i * BUF_BYTES
+    }
+
+    fn set_rate<A: crate::Arch>(&mut self, machine: &mut A, rate: u32) {
+        if rate != self.rate && rate != 0 {
+            dsp_write(machine, CMD_SET_RATE_OUT);
+            dsp_write(machine, (rate >> 8) as u8);
+            dsp_write(machine, rate as u8);
+            self.rate = rate;
+        }
+    }
+
+    /// Program the 8237 for the whole ring in 16-bit auto-init, then start the
+    /// DSP's 16-bit auto-init output with a per-buffer block length. Done once,
+    /// after the first buffers are primed; the DSP then free-runs the ring and
+    /// raises the completion IRQ every buffer.
+    fn start<A: crate::Arch>(&mut self, machine: &mut A) {
+        let word_addr = (self.dma_phys >> 1) & 0xFFFF;
+        let words = (RING_BYTES / 2) as u32;
+        machine.outb(DMA5_MASK, 0x05); // mask channel 5
+        machine.outb(DMA5_CLRFF, 0);
+        machine.outb(DMA5_MODE, DMA5_MODE_AUTO_READ);
+        machine.outb(DMA5_ADDR, word_addr as u8);
+        machine.outb(DMA5_ADDR, (word_addr >> 8) as u8);
+        machine.outb(DMA5_PAGE, (self.dma_phys >> 16) as u8);
+        machine.outb(DMA5_COUNT, (words - 1) as u8);
+        machine.outb(DMA5_COUNT, ((words - 1) >> 8) as u8);
+        machine.outb(DMA5_MASK, 0x01); // unmask channel 5
+
+        // DSP block length in 16-bit samples − 1 (one buffer per IRQ). Stereo
+        // counts L and R samples, so a buffer is BUF_BYTES/2 samples.
+        let block_samples = (BUF_BYTES / 2) as u16;
+        dsp_write(machine, CMD_16BIT_AUTO_OUT);
+        dsp_write(machine, MODE_SIGNED_STEREO);
+        dsp_write(machine, (block_samples - 1) as u8);
+        dsp_write(machine, ((block_samples - 1) >> 8) as u8);
+        self.running = true;
+    }
+
+    /// Decode `bytes` (`fmt`) into canonical i16 stereo and stream into the ring.
+    fn submit<A: crate::Arch>(&mut self, machine: &mut A, rate: u32, fmt: Format, bytes: &[u8]) {
+        self.set_rate(machine, rate);
+        let fb = fmt.frame_bytes();
+        if fb == 0 {
+            return;
+        }
+        for i in 0..bytes.len() / fb {
+            let (l, r) = fmt.frame(bytes, i);
+            let p = self.buf_va(self.cur_buf) + self.cur_off;
+            unsafe {
+                core::ptr::write_volatile(p as *mut u16, l as u16);
+                core::ptr::write_volatile((p + 2) as *mut u16, r as u16);
+            }
+            self.written += 1;
+            self.cur_off += 4;
+            if self.cur_off >= BUF_BYTES {
+                self.cur_buf = (self.cur_buf + 1) % NUM_BUF;
+                self.cur_off = 0;
+                if !self.running && self.cur_buf >= PRIME_BUFS {
+                    self.start(machine);
+                }
+            }
+        }
+    }
+}
+
+/// Stream a block of source PCM to the SB16 (called by `sound::play`).
+pub fn play<A: crate::Arch>(machine: &mut A, rate: u32, fmt: Format, bytes: &[u8]) {
+    let mut g = SB16.lock();
+    if let Some(dev) = g.as_mut() {
+        dev.submit(machine, rate, fmt, bytes);
+    }
+}
+
+/// Service a block-completion interrupt (canonical `Irq::Hw(irq_line())` routed
+/// here by `sound::on_hw_irq`). One interrupt = one buffer drained, so it just
+/// advances the consumed clock and acknowledges the DSP's 16-bit IRQ latch.
+/// No DMA counter is read — the interrupt itself is the completion signal.
+pub fn on_irq<A: crate::Arch>(machine: &mut A) {
+    let mut g = SB16.lock();
+    if let Some(dev) = g.as_mut() {
+        if dev.running {
+            dev.consumed_bufs += 1;
+        }
+    }
+    let _ = machine.inb(DSP_ACK16); // acknowledge the 16-bit completion IRQ
+}
+
+/// Pipe counters for `sound::position`, in source frames: `written` accepted,
+/// and `consumed` = finished buffers × frames-per-buffer (from the IRQ count).
+pub fn position<A: crate::Arch>(machine: &mut A) -> Option<(u64, u64)> {
+    let _ = machine;
+    let g = SB16.lock();
+    let dev = g.as_ref()?;
+    let frames_per_buf = (BUF_BYTES / 4) as u64;
+    Some((dev.written, dev.consumed_bufs * frames_per_buf))
+}
+
+/// Producer went idle. `park` ends the session: stop auto-init and reset counters.
+pub fn stop<A: crate::Arch>(machine: &mut A, park: bool) {
+    let mut g = SB16.lock();
+    let Some(dev) = g.as_mut() else { return };
+    if park && dev.running {
+        dsp_write(machine, CMD_EXIT_AUTO_16);
+        machine.outb(DMA5_MASK, 0x05); // mask channel 5
+        dev.running = false;
+        dev.cur_buf = 0;
+        dev.cur_off = 0;
+        dev.written = 0;
+        dev.consumed_bufs = 0;
+    }
+}

--- a/kernel/src/kernel/drivers/sb16.rs
+++ b/kernel/src/kernel/drivers/sb16.rs
@@ -38,7 +38,11 @@ const CMD_SPEAKER_ON: u8 = 0xD1;
 const CMD_SET_RATE_OUT: u8 = 0x41; // output rate, big-endian 16-bit
 const CMD_16BIT_AUTO_OUT: u8 = 0xB6; // 16-bit, auto-init, FIFO, D/A
 const CMD_EXIT_AUTO_16: u8 = 0xD9; // finish the current block then stop
-const MODE_SIGNED_STEREO: u8 = 0x30; // bit5 stereo, bit4 signed
+// Mono, signed (bit4 = signed, bit5 = stereo). QEMU's sb16 does not honour the
+// DSP stereo bit on the 16-bit auto-init path — it plays the interleaved buffer
+// as mono, which comes out at half speed / doubled — so the sink downmixes to
+// mono and programs mono output. (Stereo out is a TODO pending the QEMU quirk.)
+const MODE_SIGNED_MONO: u8 = 0x10;
 
 // ── 8237 channel-5 (16-bit) registers ───────────────────────────────────────
 const DMA_CHANNEL: usize = 5;
@@ -56,7 +60,11 @@ const DMA_WIN_VA: usize = crate::LOW_MEM_BASE + 0xC_0000;
 const PTE_CACHE_DISABLE: u64 = 1 << 4;
 /// Completion-IRQ granularity: one interrupt per buffer. ≤ half the universal
 /// pipe (see `sound::min_fill`) so ≥ 2 buffers stay queued (double-buffered).
-const BUF_BYTES: usize = 0x400; // 1 KB = 256 stereo frames ≈ 5.8 ms @ 44.1 kHz
+/// Mono: one 16-bit sample per mixed stereo frame, so a buffer holds
+/// `BUF_BYTES/2` frames.
+const BUF_BYTES: usize = 0x200; // 512 B = 256 mono samples ≈ 5.8 ms @ 44.1 kHz
+/// Playback frames (= mono samples) per buffer.
+const BUF_FRAMES: usize = BUF_BYTES / 2;
 const NUM_BUF: usize = 32;
 const RING_BYTES: usize = NUM_BUF * BUF_BYTES;
 /// Prime this many buffers before starting the DSP.
@@ -220,11 +228,11 @@ impl Sb16 {
         machine.outb(DMA5_COUNT, ((words - 1) >> 8) as u8);
         machine.outb(DMA5_MASK, 0x01); // unmask channel 5
 
-        // DSP block length in 16-bit samples − 1 (one buffer per IRQ). Stereo
-        // counts L and R samples, so a buffer is BUF_BYTES/2 samples.
-        let block_samples = (BUF_BYTES / 2) as u16;
+        // DSP block length in 16-bit samples − 1 (one buffer per IRQ). Mono, so
+        // a buffer is BUF_FRAMES samples.
+        let block_samples = BUF_FRAMES as u16;
         dsp_write(machine, CMD_16BIT_AUTO_OUT);
-        dsp_write(machine, MODE_SIGNED_STEREO);
+        dsp_write(machine, MODE_SIGNED_MONO);
         dsp_write(machine, (block_samples - 1) as u8);
         dsp_write(machine, ((block_samples - 1) >> 8) as u8);
         self.running = true;
@@ -239,13 +247,13 @@ impl Sb16 {
         }
         for i in 0..bytes.len() / fb {
             let (l, r) = fmt.frame(bytes, i);
+            let m = ((l as i32 + r as i32) / 2) as i16; // downmix to mono
             let p = self.buf_va(self.cur_buf) + self.cur_off;
             unsafe {
-                core::ptr::write_volatile(p as *mut u16, l as u16);
-                core::ptr::write_volatile((p + 2) as *mut u16, r as u16);
+                core::ptr::write_volatile(p as *mut u16, m as u16);
             }
             self.written += 1;
-            self.cur_off += 4;
+            self.cur_off += 2;
             if self.cur_off >= BUF_BYTES {
                 self.cur_buf = (self.cur_buf + 1) % NUM_BUF;
                 self.cur_off = 0;
@@ -285,8 +293,7 @@ pub fn position<A: crate::Arch>(machine: &mut A) -> Option<(u64, u64)> {
     let _ = machine;
     let g = SB16.lock();
     let dev = g.as_ref()?;
-    let frames_per_buf = (BUF_BYTES / 4) as u64;
-    Some((dev.written, dev.consumed_bufs * frames_per_buf))
+    Some((dev.written, dev.consumed_bufs * BUF_FRAMES as u64))
 }
 
 /// Producer went idle. `park` ends the session: stop auto-init and reset counters.

--- a/kernel/src/kernel/drivers/sb16.rs
+++ b/kernel/src/kernel/drivers/sb16.rs
@@ -7,9 +7,9 @@
 //!
 //! It drives the real DSP for **16-bit signed-stereo auto-init DMA** on the ISA
 //! 8237 (channel 5) — the SB16's own double-buffer scheme, where each completed
-//! block raises **IRQ 5**. That block-completion interrupt IS the event-driven
-//! audio track's completion signal: one interrupt = one buffer drained/free, so
-//! `on_irq` is a plain block counter and the driver never reads a DMA position.
+//! block raises **IRQ 5**. The interrupt wakes the event-driven audio track;
+//! `on_irq` then reads the live 8237 cursor, so delayed/coalesced delivery does
+//! not turn an event count into a false playback position.
 //!
 //! Only machine *primitives* are used — port I/O (`inb`/`outb`, for the DSP,
 //! mixer, and the 8237), `dma_channel_buf` (the permanent contiguous channel-5
@@ -32,12 +32,14 @@ const DSP_RSTAT: u16 = BASE + 0x0E; // read-buffer status (bit7 = data ready) / 
 const DSP_ACK16: u16 = BASE + 0x0F; // 16-bit IRQ acknowledge
 const MIX_IDX: u16 = BASE + 0x04;
 const MIX_DATA: u16 = BASE + 0x05;
+const MIX_IRQ_STATUS: u8 = 0x82;
+const MIX_IRQ_16BIT: u8 = 1 << 1;
 
 // DSP commands.
 const CMD_SPEAKER_ON: u8 = 0xD1;
 const CMD_SET_RATE_OUT: u8 = 0x41; // output rate, big-endian 16-bit
 const CMD_16BIT_AUTO_OUT: u8 = 0xB6; // 16-bit, auto-init, FIFO, D/A
-const CMD_EXIT_AUTO_16: u8 = 0xD9; // finish the current block then stop
+const CMD_HALT_AUTO_16: u8 = 0xD5; // halt 16-bit DMA immediately
 // Mono, signed (bit4 = signed, bit5 = stereo). QEMU's sb16 does not honour the
 // DSP stereo bit on the 16-bit auto-init path — it plays the interleaved buffer
 // as mono, which comes out at half speed / doubled — so the sink downmixes to
@@ -67,7 +69,9 @@ const BUF_BYTES: usize = 0x200; // 512 B = 256 mono samples ≈ 5.8 ms @ 44.1 kH
 const BUF_FRAMES: usize = BUF_BYTES / 2;
 const NUM_BUF: usize = 32;
 const RING_BYTES: usize = NUM_BUF * BUF_BYTES;
-/// Prime this many buffers before starting the DSP.
+/// Prime at least two completion blocks before starting the DSP. The shared
+/// 30-ms pipe normally submits five blocks on its first pass; `submit` starts
+/// only after that whole pass is in memory, rather than halfway through it.
 const PRIME_BUFS: usize = 2;
 
 struct Sb16 {
@@ -79,18 +83,23 @@ struct Sb16 {
     rate: u32,      // last programmed sample rate
     /// Pipe counters for [`position`], in source frames (the DAC runs at the
     /// source rate — no resampler). `written` = frames accepted by `submit`;
-    /// `consumed_bufs` = buffers the DSP has finished, one per completion IRQ.
+    /// `consumed_frames` comes from the live 8237 cursor whenever an IRQ wakes
+    /// the driver; IRQ event counts themselves are not trusted.
     written: u64,
-    consumed_bufs: u64,
+    consumed_frames: u64,
+    last_dma_pos: u32,
 }
 
 static SB16: Mutex<Option<Sb16>> = Mutex::new(None);
 static PRESENT: AtomicBool = AtomicBool::new(false);
+/// Diagnostic: times the play cursor caught the write cursor (underrun → the
+/// DSP replays stale ring data since auto-init has no LVI gate → a click).
+static UNDERRUNS: AtomicU32 = AtomicU32::new(0);
 /// The IRQ line the card raises on block completion (read from the mixer at
-/// bring-up), so `sound::on_hw_irq` can match it. 0xFF until up.
+/// bring-up), so `sound::on_irq` can match it. 0xFF until up.
 static IRQ_LINE: AtomicU32 = AtomicU32::new(0xFF);
 
-/// The routed completion-IRQ line, for `sound::on_hw_irq`. `None` until up.
+/// The routed completion-IRQ line, for `sound::on_irq`. `None` until up.
 pub fn irq_line() -> Option<u8> {
     match IRQ_LINE.load(Ordering::Relaxed) {
         0xFF => None,
@@ -163,6 +172,7 @@ fn bring_up<A: crate::Arch>(machine: &mut A) -> bool {
         return false;
     }
     let irq = read_irq(machine);
+    machine.route_isa_irq(irq);
 
     // Map the permanent contiguous channel-5 buffer into the stolen low-mem
     // window so the kernel can write PCM; the DSP reads it by physical address.
@@ -190,7 +200,8 @@ fn bring_up<A: crate::Arch>(machine: &mut A) -> bool {
         running: false,
         rate: 0,
         written: 0,
-        consumed_bufs: 0,
+        consumed_frames: 0,
+        last_dma_pos: 0,
     });
     IRQ_LINE.store(irq as u32, Ordering::Relaxed);
     crate::println!("sb16: {:#05x} DSP up, IRQ {}, DMA {}", BASE, irq, DMA_CHANNEL);
@@ -227,6 +238,7 @@ impl Sb16 {
         machine.outb(DMA5_COUNT, (words - 1) as u8);
         machine.outb(DMA5_COUNT, ((words - 1) >> 8) as u8);
         machine.outb(DMA5_MASK, 0x01); // unmask channel 5
+        self.last_dma_pos = 0;
 
         // DSP block length in 16-bit samples − 1 (one buffer per IRQ). Mono, so
         // a buffer is BUF_FRAMES samples.
@@ -257,10 +269,14 @@ impl Sb16 {
             if self.cur_off >= BUF_BYTES {
                 self.cur_buf = (self.cur_buf + 1) % NUM_BUF;
                 self.cur_off = 0;
-                if !self.running && self.cur_buf >= PRIME_BUFS {
-                    self.start(machine);
-                }
             }
+        }
+        // Do not start from inside the copy loop. QEMU is allowed to schedule
+        // DMA as soon as B6 is issued; starting after buffer two while the same
+        // call is still filling buffers three through five lets playback race
+        // the initial producer burst.
+        if !self.running && self.written >= (PRIME_BUFS * BUF_FRAMES) as u64 {
+            self.start(machine);
         }
     }
 }
@@ -273,40 +289,108 @@ pub fn play<A: crate::Arch>(machine: &mut A, rate: u32, fmt: Format, bytes: &[u8
     }
 }
 
-/// Service a block-completion interrupt (canonical `Irq::Hw(irq_line())` routed
-/// here by `sound::on_hw_irq`). One interrupt = one buffer drained, so it just
-/// advances the consumed clock and acknowledges the DSP's 16-bit IRQ latch.
-/// No DMA counter is read — the interrupt itself is the completion signal.
-pub fn on_irq<A: crate::Arch>(machine: &mut A) {
+fn dma_count<A: crate::Arch>(machine: &mut A) -> u16 {
+    machine.outb(DMA5_CLRFF, 0);
+    let lo = machine.inb(DMA5_COUNT) as u16;
+    let hi = machine.inb(DMA5_COUNT) as u16;
+    (hi << 8) | lo
+}
+
+fn dma_pos_bytes<A: crate::Arch>(machine: &mut A) -> u32 {
+    let words = (RING_BYTES / 2) as u32;
+    // The 8237 exposes the count as two independently read bytes while DMA is
+    // live. Around a low-byte borrow, one pair can be torn and appear to jump
+    // almost a whole ring. Two nearby complete samples must differ by only a
+    // handful of transfers; retry a few times and use the newest stable one.
+    let mut count = dma_count(machine);
+    for _ in 0..3 {
+        let next = dma_count(machine);
+        let forward = (count as u32 + words - next as u32) % words;
+        count = next;
+        if forward <= 32 {
+            break;
+        }
+    }
+    ((words - 1).wrapping_sub(count as u32) % words) * 2
+}
+
+fn update_cursor<A: crate::Arch>(dev: &mut Sb16, machine: &mut A) -> (u32, u32) {
+    let ring = RING_BYTES as u32;
+    let pos = dma_pos_bytes(machine);
+    let delta = (pos + ring - dev.last_dma_pos) % ring;
+    if delta != 0 {
+        dev.consumed_frames += (delta / 2) as u64;
+        dev.last_dma_pos = pos;
+    }
+    (pos, delta)
+}
+
+/// Service a block-completion interrupt. The mixer status distinguishes our
+/// 16-bit DMA source on a potentially shared ISA line; the live 8237 cursor
+/// supplies authoritative progress when the IRQ wakes the driver.
+pub fn on_irq<A: crate::Arch>(machine: &mut A) -> bool {
+    machine.outb(MIX_IDX, MIX_IRQ_STATUS);
+    if machine.inb(MIX_DATA) & MIX_IRQ_16BIT == 0 {
+        return false;
+    }
     let mut g = SB16.lock();
     if let Some(dev) = g.as_mut() {
         if dev.running {
-            dev.consumed_bufs += 1;
+            // The IRQ is a wakeup, not an additional unit of elapsed time.
+            // `position()` may already have observed this exact DMA cursor;
+            // inventing a block when delta==0 moves last_dma_pos ahead of the
+            // hardware and makes the next read look like a near-full-ring wrap.
+            let (pos, delta) = update_cursor(dev, machine);
+            // Diagnostic: has the play cursor reached the write cursor? (queued
+            // buffers ≤ 0 → the next buffers the DSP plays are stale.)
+            if dev.written <= dev.consumed_frames {
+                let n = UNDERRUNS.fetch_add(1, Ordering::Relaxed) + 1;
+                if n <= 3 || n % 64 == 0 {
+                    crate::println!(
+                        "sb16: underrun #{} written={} consumed={} dma_pos={} delta={}",
+                        n, dev.written, dev.consumed_frames, pos, delta
+                    );
+                }
+            }
         }
     }
     let _ = machine.inb(DSP_ACK16); // acknowledge the 16-bit completion IRQ
+    true
 }
 
 /// Pipe counters for `sound::position`, in source frames: `written` accepted,
-/// and `consumed` = finished buffers × frames-per-buffer (from the IRQ count).
+/// and `consumed` from the monotonicized live 8237 DMA cursor.
 pub fn position<A: crate::Arch>(machine: &mut A) -> Option<(u64, u64)> {
-    let _ = machine;
-    let g = SB16.lock();
-    let dev = g.as_ref()?;
-    Some((dev.written, dev.consumed_bufs * BUF_FRAMES as u64))
+    let mut g = SB16.lock();
+    let dev = g.as_mut()?;
+    if dev.running {
+        // ISA DSP interrupt latches can coalesce while auto-init DMA continues.
+        // The IRQ remains the wakeup/ack path, but this cheap 8237 read prevents
+        // a delayed latch service from hiding several already-consumed blocks.
+        update_cursor(dev, machine);
+    }
+    Some((dev.written, dev.consumed_frames))
 }
 
-/// Producer went idle. `park` ends the session: stop auto-init and reset counters.
-pub fn stop<A: crate::Arch>(machine: &mut A, park: bool) {
+/// Producer went idle: halt DMA, reset the DSP state machine, and start the
+/// next session from a clean, silent ring. Reset is deliberate here: a bare
+/// D5 pause leaves a subsequent B6 auto-init command dependent on clone-specific
+/// pause/continue state.
+pub fn stop<A: crate::Arch>(machine: &mut A, _park: bool) {
     let mut g = SB16.lock();
     let Some(dev) = g.as_mut() else { return };
-    if park && dev.running {
-        dsp_write(machine, CMD_EXIT_AUTO_16);
+    if dev.running {
+        dsp_write(machine, CMD_HALT_AUTO_16);
         machine.outb(DMA5_MASK, 0x05); // mask channel 5
-        dev.running = false;
-        dev.cur_buf = 0;
-        dev.cur_off = 0;
-        dev.written = 0;
-        dev.consumed_bufs = 0;
     }
+    let _ = dsp_reset(machine);
+    dsp_write(machine, CMD_SPEAKER_ON);
+    dev.running = false;
+    dev.rate = 0;
+    dev.cur_buf = 0;
+    dev.cur_off = 0;
+    dev.written = 0;
+    dev.consumed_frames = 0;
+    dev.last_dma_pos = 0;
+    unsafe { core::ptr::write_bytes(dev.dma_va as *mut u8, 0, RING_BYTES) };
 }

--- a/kernel/src/kernel/drivers/sb16.rs
+++ b/kernel/src/kernel/drivers/sb16.rs
@@ -334,8 +334,10 @@ pub fn on_irq<A: crate::Arch>(machine: &mut A) -> bool {
         return false;
     }
     let mut g = SB16.lock();
-    if let Some(dev) = g.as_mut() {
-        if dev.running {
+    if let Some(dev) = g.as_mut()
+        && dev.running
+    {
+        {
             // The IRQ is a wakeup, not an additional unit of elapsed time.
             // `position()` may already have observed this exact DMA cursor;
             // inventing a block when delta==0 moves last_dma_pos ahead of the
@@ -345,7 +347,7 @@ pub fn on_irq<A: crate::Arch>(machine: &mut A) -> bool {
             // buffers ≤ 0 → the next buffers the DSP plays are stale.)
             if dev.written <= dev.consumed_frames {
                 let n = UNDERRUNS.fetch_add(1, Ordering::Relaxed) + 1;
-                if n <= 3 || n % 64 == 0 {
+                if n <= 3 || n.is_multiple_of(64) {
                     crate::println!(
                         "sb16: underrun #{} written={} consumed={} dma_pos={} delta={}",
                         n, dev.written, dev.consumed_frames, pos, delta

--- a/kernel/src/kernel/irq_dispatch.rs
+++ b/kernel/src/kernel/irq_dispatch.rs
@@ -1,0 +1,22 @@
+//! Kernel-global hardware-event dispatch.
+//!
+//! Device IRQs are machine events, not console input and not personality
+//! property. Drain them before advancing a personality's virtual world so an
+//! audio completion that woke the kernel is visible to the refill pass in the
+//! same event-loop iteration. Events not claimed by a kernel driver continue
+//! to console/personality routing unchanged.
+
+/// Drain the arch event queue, service kernel-owned device interrupts, and
+/// return the remaining input/guest-visible events.
+pub fn drain<A: crate::Arch>(machine: &mut A) -> alloc::vec::Vec<crate::Irq> {
+    let mut pending = alloc::vec::Vec::new();
+    machine.drain(&mut |event| pending.push(event));
+
+    let mut remaining = alloc::vec::Vec::with_capacity(pending.len());
+    for event in pending {
+        if !crate::kernel::sound::on_irq(machine, event) {
+            remaining.push(event);
+        }
+    }
+    remaining
+}

--- a/kernel/src/kernel/midi_bank.rs
+++ b/kernel/src/kernel/midi_bank.rs
@@ -1,0 +1,52 @@
+//! The GM instrument bank, as ROM.
+//!
+//! A General MIDI device is a ROM-bank instrument — an SC-55 does not stream
+//! its piano from disk — so the kernel burns the bank in ONCE at boot, where
+//! long work is legal (no guest exists yet to starve). The bank is parsed
+//! straight into a [`sound::midi::Bank`] and leaked: every program\'s synth
+//! references the same `&\'static Bank`, fully resident from its first byte.
+//! No disk in the audio path, no per-program duplication, and no race
+//! between a song\'s first notes and a background load (metal disks lost
+//! DOOM demo1\'s opening violins to exactly that race).
+//!
+//! This is a kernel asset like a driver\'s firmware blob: `startup` decides
+//! the location (the shipped bank under the C: root) and calls [`load`];
+//! the DOS machine\'s MPU device only ever reads [`get`].
+
+static BANK: spin::Mutex<Option<&'static sound::midi::Bank>> = spin::Mutex::new(None);
+
+/// Ids swept: the GM melodic range plus percussion (128 + note).
+const BANK_IDS: u16 = 256;
+
+/// Burn the ROM: read every instrument under `dir_vfs` (a VFS directory of
+/// `<STEM>.PAT` files). Missing files are absent ids; an absent or empty
+/// directory leaves an empty bank (GM stays silent, loudly noted here).
+pub fn load(dir_vfs: &[u8]) {
+    let mut bank = sound::midi::Bank::new();
+    for id in 0..BANK_IDS {
+        let Some(stem) = sound::midi::patch_stem(id) else { continue };
+        let mut path = alloc::vec::Vec::with_capacity(dir_vfs.len() + stem.len() + 5);
+        path.extend_from_slice(dir_vfs);
+        path.push(b'/');
+        for &b in stem.as_bytes() {
+            path.push(b.to_ascii_uppercase());
+        }
+        path.extend_from_slice(b".PAT");
+        if let Ok(bytes) = crate::kernel::exec::load_file_resolved(&path) {
+            bank.load_patch(id, &bytes);
+        }
+    }
+    let (count, pool) = bank.stats();
+    if count == 0 {
+        crate::println!("midi: no GM bank under the C: root — General MIDI silent");
+        return;
+    }
+    crate::println!("midi: GM bank ROM: {} instruments, {} KB", count, pool / 1024);
+    *BANK.lock() = Some(alloc::boxed::Box::leak(alloc::boxed::Box::new(bank)));
+}
+
+/// The ROM, once burned. `None` on a bankless boot. Read at synth build —
+/// once per program, never in the mix path.
+pub fn get() -> Option<&'static sound::midi::Bank> {
+    *BANK.lock()
+}

--- a/kernel/src/kernel/midi_bank.rs
+++ b/kernel/src/kernel/midi_bank.rs
@@ -18,22 +18,72 @@ static BANK: spin::Mutex<Option<&'static sound::midi::Bank>> = spin::Mutex::new(
 /// Ids swept: the GM melodic range plus percussion (128 + note).
 const BANK_IDS: u16 = 256;
 
-/// Burn the ROM: read every instrument under `dir_vfs` (a VFS directory of
-/// `<STEM>.PAT` files). Missing files are absent ids; an absent or empty
-/// directory leaves an empty bank (GM stays silent, loudly noted here).
+/// Burn the ROM: enumerate `dir_vfs` (a VFS directory of `<STEM>.PAT`
+/// files) and match names to patch stems CASE-INSENSITIVELY — a real disk's
+/// bank may be upper- or lowercase (DOS wrote uppercase, Linux installers
+/// write lowercase; guessing one case silently emptied the bank on the
+/// laptop's ext4). Missing instruments are absent ids; an absent or empty
+/// directory leaves an empty bank, loudly noted here.
+/// Resolve one child of `base` by name, case-insensitively, to its real
+/// on-disk spelling. `None` when no entry matches.
+fn resolve_child(base: &[u8], want: &[u8], want_dir: bool) -> Option<alloc::vec::Vec<u8>> {
+    let mut index = 0;
+    while let Some(e) = crate::kernel::vfs::readdir(base, index) {
+        index += 1;
+        if e.is_dir == want_dir
+            && crate::kernel::vfs::eq_ignore_case(&e.name[..e.name_len], want)
+        {
+            let mut path = alloc::vec::Vec::with_capacity(base.len() + e.name_len + 1);
+            path.extend_from_slice(base);
+            path.push(b'/');
+            path.extend_from_slice(&e.name[..e.name_len]);
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// Burn the ROM from `<c_root>/ULTRASND/MIDI`, every path component matched
+/// case-insensitively against the real disk (DOS wrote uppercase, Linux
+/// installers write lowercase; guessing either way empties the bank).
+pub fn load_from_c_root(c_root: &[u8]) {
+    let Some(ultrasnd) = resolve_child(c_root, b"ULTRASND", true) else {
+        crate::println!("midi: no ULTRASND under the C: root — General MIDI silent");
+        return;
+    };
+    let Some(midi) = resolve_child(&ultrasnd, b"MIDI", true) else {
+        crate::println!("midi: no MIDI dir under {} — General MIDI silent",
+            core::str::from_utf8(&ultrasnd).unwrap_or("?"));
+        return;
+    };
+    load(&midi);
+}
+
 pub fn load(dir_vfs: &[u8]) {
     let mut bank = sound::midi::Bank::new();
-    for id in 0..BANK_IDS {
-        let Some(stem) = sound::midi::patch_stem(id) else { continue };
-        let mut path = alloc::vec::Vec::with_capacity(dir_vfs.len() + stem.len() + 5);
-        path.extend_from_slice(dir_vfs);
-        path.push(b'/');
-        for &b in stem.as_bytes() {
-            path.push(b.to_ascii_uppercase());
+    let mut index = 0;
+    while let Some(e) = crate::kernel::vfs::readdir(dir_vfs, index) {
+        index += 1;
+        if e.is_dir || e.name_len < 5 {
+            continue;
         }
-        path.extend_from_slice(b".PAT");
-        if let Ok(bytes) = crate::kernel::exec::load_file_resolved(&path) {
-            bank.load_patch(id, &bytes);
+        let name = &e.name[..e.name_len];
+        let (stem_part, ext) = name.split_at(e.name_len - 4);
+        if !crate::kernel::vfs::eq_ignore_case(ext, b".PAT") {
+            continue;
+        }
+        for id in 0..BANK_IDS {
+            let Some(stem) = sound::midi::patch_stem(id) else { continue };
+            if !crate::kernel::vfs::eq_ignore_case(stem_part, stem.as_bytes()) {
+                continue;
+            }
+            let mut path = alloc::vec::Vec::with_capacity(dir_vfs.len() + name.len() + 1);
+            path.extend_from_slice(dir_vfs);
+            path.push(b'/');
+            path.extend_from_slice(name);
+            if let Ok(bytes) = crate::kernel::exec::load_file_resolved(&path) {
+                bank.load_patch(id, &bytes);
+            }
         }
     }
     let (count, pool) = bank.stats();
@@ -42,6 +92,21 @@ pub fn load(dir_vfs: &[u8]) {
         return;
     }
     crate::println!("midi: GM bank ROM: {} instruments, {} KB", count, pool / 1024);
+    // Any hole in the melodic range is an instrument some song will reach
+    // for and get silence — worth one boot line to make "missing violin"
+    // diagnosable from klog instead of by ear.
+    let mut missing = alloc::string::String::new();
+    for id in 0..128u16 {
+        if sound::midi::patch_stem(id).is_some() && !bank.has_patch(id) {
+            if !missing.is_empty() {
+                missing.push(' ');
+            }
+            missing.push_str(itoa(id).as_str());
+        }
+    }
+    if !missing.is_empty() {
+        crate::println!("midi: melodic ids absent from the bank: {}", missing);
+    }
     *BANK.lock() = Some(alloc::boxed::Box::leak(alloc::boxed::Box::new(bank)));
 }
 
@@ -49,4 +114,24 @@ pub fn load(dir_vfs: &[u8]) {
 /// once per program, never in the mix path.
 pub fn get() -> Option<&'static sound::midi::Bank> {
     *BANK.lock()
+}
+
+/// Tiny integer formatter (no_std, no fmt machinery in the loop).
+fn itoa(mut v: u16) -> alloc::string::String {
+    let mut s = alloc::string::String::new();
+    if v == 0 {
+        s.push('0');
+        return s;
+    }
+    let mut digits = [0u8; 5];
+    let mut n = 0;
+    while v > 0 {
+        digits[n] = b'0' + (v % 10) as u8;
+        v /= 10;
+        n += 1;
+    }
+    for i in (0..n).rev() {
+        s.push(digits[i] as char);
+    }
+    s
 }

--- a/kernel/src/kernel/mod.rs
+++ b/kernel/src/kernel/mod.rs
@@ -38,6 +38,7 @@ pub mod kpipe;
 pub mod net;
 pub mod pci;
 pub mod portio;
+pub mod midi_bank;
 pub mod sound;
 pub mod vfs;
 // pipe.rs moved to crate root (shared between arch and kernel)

--- a/kernel/src/kernel/mod.rs
+++ b/kernel/src/kernel/mod.rs
@@ -20,6 +20,7 @@ pub mod thread;
 // ── Machine policy: what this box is, who owns the console, what it may do ─
 pub mod focus;
 pub mod io_policy;
+pub mod irq_dispatch;
 pub mod platform;
 
 // ── Diagnostics ─────────────────────────────────────────────────────────

--- a/kernel/src/kernel/osd.rs
+++ b/kernel/src/kernel/osd.rs
@@ -39,7 +39,6 @@ const NUM_ITEMS: usize = 6;
 /// Master volume as a percentage of unity, adjusted by ◄/► on the Volume row.
 /// 100 = unity (the level the per-source scales already balance to); attenuate
 /// only — a boost above unity would just clip against the mix-out rail.
-const VOL_MIN: u32 = 0;
 const VOL_MAX: u32 = 100;
 const VOL_STEP: u32 = 10;
 
@@ -111,11 +110,11 @@ static PICKER: AtomicBool = AtomicBool::new(false);
 /// current console owner.
 pub fn refresh_processes<A: crate::Arch>(threads: &[thread::Thread<A>], focused: usize) {
     let mut count = 0;
-    for i in 1..threads.len() {
+    for (i, t) in threads.iter().enumerate().skip(1) {
         if count >= MAX_LIST {
             break;
         }
-        let k = &threads[i].kernel;
+        let k = &t.kernel;
         let state = match k.state {
             thread::ThreadState::Running => b'R',
             thread::ThreadState::Ready => b'r',
@@ -232,7 +231,7 @@ fn adjust(up: bool) {
     let next = if up {
         (cur + VOL_STEP).min(VOL_MAX)
     } else {
-        cur.saturating_sub(VOL_STEP).max(VOL_MIN)
+        cur.saturating_sub(VOL_STEP) // saturation is the 0 floor
     };
     VOL_PCT.store(next, Ordering::Relaxed);
 }

--- a/kernel/src/kernel/pci.rs
+++ b/kernel/src/kernel/pci.rs
@@ -27,6 +27,51 @@ pub fn write32<A: crate::Arch>(machine: &mut A, bus: u8, dev: u8, func: u8, off:
     machine.outl(PCI_CFG_DATA, val);
 }
 
+/// PCI capability IDs we care about.
+const CAP_MSI: u8 = 0x05;
+
+/// Program a device's MSI capability with `(addr, data)` (from
+/// [`crate::Arch::msi_alloc`]) and enable it, so the device signals interrupts
+/// by memory write instead of a wired INTx line. Returns false if the device
+/// has no capability list or no MSI capability (caller falls back to INTx /
+/// polling). One vector only (Multiple-Message-Enable forced to 0).
+///
+/// Config layout of the MSI cap at offset `c`: `c+0x00` = [msg-control:16 |
+/// next:8 | id:8]; `c+0x04` = message address low; then, if the control's
+/// 64-bit-capable bit (7) is set, `c+0x08` = address high and `c+0x0C` = data,
+/// else `c+0x08` = data. All accesses are dword-aligned (caps are 4-byte
+/// aligned), so `read32`/`write32` suffice.
+pub fn msi_enable<A: crate::Arch>(
+    machine: &mut A, bus: u8, dev: u8, func: u8, addr: u64, data: u32,
+) -> bool {
+    // Status register (high 16 of dword 0x04), bit 4 = capabilities list present.
+    if read32(machine, bus, dev, func, 0x04) >> 16 & (1 << 4) == 0 {
+        return false;
+    }
+    let mut c = (read32(machine, bus, dev, func, 0x34) & 0xFC) as u8; // cap pointer
+    while c != 0 {
+        let head = read32(machine, bus, dev, func, c);
+        if (head & 0xFF) as u8 == CAP_MSI {
+            let ctrl = (head >> 16) as u16;
+            let addr64 = ctrl & (1 << 7) != 0;
+            write32(machine, bus, dev, func, c + 0x04, (addr as u32) & !0x3);
+            if addr64 {
+                write32(machine, bus, dev, func, c + 0x08, (addr >> 32) as u32);
+                write32(machine, bus, dev, func, c + 0x0C, data & 0xFFFF);
+            } else {
+                write32(machine, bus, dev, func, c + 0x08, data & 0xFFFF);
+            }
+            // Rewrite message control: force MME=0 (bits 4-6 → one vector) and
+            // set MSI-Enable (bit 0), preserving the id/next byte below it.
+            let new_ctrl = (ctrl & !0x0070) | 0x0001;
+            write32(machine, bus, dev, func, c, (head & 0xFFFF) | ((new_ctrl as u32) << 16));
+            return true;
+        }
+        c = ((head >> 8) & 0xFC) as u8; // next-capability pointer
+    }
+    false
+}
+
 /// Find the first device matching `(class, subclass)`, returning
 /// `(bus, dev, func)`. Spec-conformant brute-force enumeration: all 256 buses,
 /// all 32 devices, and functions 1-7 on multi-function devices.

--- a/kernel/src/kernel/platform.rs
+++ b/kernel/src/kernel/platform.rs
@@ -71,11 +71,12 @@ pub enum Firmware {
 /// and sound's port-window signature cache.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Audio {
-    /// A real Sound Blaster answered the DSP-status probe (legacy metal,
-    /// QEMU `sb16`): guest DSP/mixer traffic forwards to the card and only
-    /// the 8237 stays virtual. Implies a real OPL — the 0x388 window is
-    /// part of the DOS io_policy template, not a runtime grant.
-    SbPassthrough,
+    /// A real Sound Blaster 16 answered the DSP reset/probe (legacy metal, QEMU
+    /// `sb16`): the software SB/GUS/GM are emulated as usual and their canonical
+    /// PCM renders out the real SB16 as the kernel `sound` sink (`drivers::sb16`,
+    /// 16-bit auto-init DMA on channel 5, IRQ 5). (Phase B will make ownership of
+    /// the card movable — handing it to the guest for native SB playback.)
+    RealSb,
     /// No card; the software SB16 renders through the kernel sound API into an
     /// Intel HD Audio controller found on PCI (QEMU `intel-hda`, modern metal).
     EmulatedHda,
@@ -91,9 +92,12 @@ pub enum Audio {
 }
 
 impl Audio {
-    /// Guest SB programming reaches a real card (vs the software DSP).
+    /// Guest SB programming reaches the real card directly (native playback),
+    /// vs the software DSP. Phase A always emulates — even with a real SB16
+    /// present it is a kernel sink, not guest-owned — so this is always false.
+    /// Phase B makes it dynamic (true while a DOS program drives the card).
     pub fn sb_passthrough(self) -> bool {
-        matches!(self, Audio::SbPassthrough)
+        false
     }
 }
 
@@ -263,9 +267,9 @@ pub fn probed() -> bool {
 /// canonical SB base 0x220 (a per-thread BLASTER override relocates the
 /// guest-visible base, not the card).
 fn probe_audio<A: crate::Arch>(machine: &mut A) -> Audio {
-    let sb_absent = machine.inb(0x22C) == 0xFF && machine.inb(0x22E) == 0xFF;
-    if !sb_absent {
-        return Audio::SbPassthrough;
+    // A real SB16 answers a DSP reset with 0xAA — it becomes the kernel sink.
+    if crate::kernel::drivers::sb16::scan(machine) {
+        return Audio::RealSb;
     }
     if crate::kernel::drivers::hda::scan(machine).is_some() {
         return Audio::EmulatedHda;

--- a/kernel/src/kernel/sound.rs
+++ b/kernel/src/kernel/sound.rs
@@ -104,14 +104,18 @@ pub fn on_hw_irq<A: crate::Arch>(machine: &mut A, line: u8) -> bool {
             machine.rearm_irq(line);
             true
         }
+        Audio::RealSb if Some(line) == crate::kernel::drivers::sb16::irq_line() => {
+            crate::kernel::drivers::sb16::on_irq(machine);
+            machine.rearm_irq(line); // re-unmask the ISA line the sink owns
+            true
+        }
         _ => false,
     }
 }
 
 /// Stream a block of source PCM `bytes` (`fmt`, `rate` Hz) to the canonical
 /// audio output, canonicalizing to i16 stereo on the way. The sink is the
-/// boot-time platform decision; SbPassthrough never produces canonical PCM
-/// (the real card owns sound) and Silent drops it.
+/// boot-time platform decision; Silent drops it.
 pub fn play<A: crate::Arch>(machine: &mut A, rate: u32, fmt: Format, bytes: &[u8]) {
     use crate::kernel::platform::Audio;
     match crate::kernel::platform::get().audio {
@@ -123,8 +127,12 @@ pub fn play<A: crate::Arch>(machine: &mut A, rate: u32, fmt: Format, bytes: &[u8
             crate::kernel::drivers::ac97::play(machine, rate, fmt, bytes);
             return;
         }
+        Audio::RealSb => {
+            crate::kernel::drivers::sb16::play(machine, rate, fmt, bytes);
+            return;
+        }
         Audio::EmulatedPortWindow => {}
-        Audio::SbPassthrough | Audio::EmulatedSilent => return,
+        Audio::EmulatedSilent => return,
     }
     if LAST_RATE.swap(rate, Ordering::Relaxed) != rate {
         machine.outw(AUDIO_SIG, rate as u16);
@@ -147,8 +155,8 @@ pub fn stop<A: crate::Arch>(machine: &mut A, park: bool) {
     use crate::kernel::platform::Audio;
     match crate::kernel::platform::get().audio {
         Audio::EmulatedHda => crate::kernel::drivers::hda::stop(machine, park),
-        Audio::EmulatedAc97 | Audio::EmulatedPortWindow => {}
-        Audio::SbPassthrough | Audio::EmulatedSilent => {}
+        Audio::RealSb => crate::kernel::drivers::sb16::stop(machine, park),
+        Audio::EmulatedAc97 | Audio::EmulatedPortWindow | Audio::EmulatedSilent => {}
     }
 }
 
@@ -169,7 +177,8 @@ pub fn position<A: crate::Arch>(machine: &mut A) -> Option<(u64, u64)> {
     match crate::kernel::platform::get().audio {
         Audio::EmulatedHda => crate::kernel::drivers::hda::position(),
         Audio::EmulatedAc97 => crate::kernel::drivers::ac97::position(machine),
-        Audio::EmulatedPortWindow | Audio::SbPassthrough | Audio::EmulatedSilent => None,
+        Audio::RealSb => crate::kernel::drivers::sb16::position(machine),
+        Audio::EmulatedPortWindow | Audio::EmulatedSilent => None,
     }
 }
 
@@ -189,7 +198,8 @@ pub fn min_fill(rate: u32) -> Option<u32> {
     let present = match crate::kernel::platform::get().audio {
         Audio::EmulatedHda => crate::kernel::drivers::hda::present(),
         Audio::EmulatedAc97 => crate::kernel::drivers::ac97::present(),
-        Audio::EmulatedPortWindow | Audio::SbPassthrough | Audio::EmulatedSilent => false,
+        Audio::RealSb => crate::kernel::drivers::sb16::present(),
+        Audio::EmulatedPortWindow | Audio::EmulatedSilent => false,
     };
     present.then(|| rate * PIPE_MS / 1000)
 }

--- a/kernel/src/kernel/sound.rs
+++ b/kernel/src/kernel/sound.rs
@@ -85,6 +85,23 @@ pub fn window_present<A: crate::Arch>(machine: &mut A) -> bool {
     machine.inw(AUDIO_SIG) == SIGNATURE
 }
 
+/// Canonical audio-sink interrupt router. A hardware `Irq::Hw(line)` drained by
+/// any personality is offered here first: if `line` is the selected sink's
+/// completion interrupt, the sink services it and this returns `true` (the
+/// event is consumed, never forwarded to a guest). Cross-personality by design
+/// — the sink belongs to the kernel, not to whichever thread is focused.
+pub fn on_hw_irq<A: crate::Arch>(machine: &mut A, line: u8) -> bool {
+    let _ = machine;
+    use crate::kernel::platform::Audio;
+    match crate::kernel::platform::get().audio {
+        Audio::EmulatedHda if line == crate::kernel::drivers::hda::MSI_LINE => {
+            crate::kernel::drivers::hda::on_irq();
+            true
+        }
+        _ => false,
+    }
+}
+
 /// Stream a block of source PCM `bytes` (`fmt`, `rate` Hz) to the canonical
 /// audio output, canonicalizing to i16 stereo on the way. The sink is the
 /// boot-time platform decision; SbPassthrough never produces canonical PCM

--- a/kernel/src/kernel/sound.rs
+++ b/kernel/src/kernel/sound.rs
@@ -173,18 +173,25 @@ pub fn position<A: crate::Arch>(machine: &mut A) -> Option<(u64, u64)> {
     }
 }
 
-/// Minimum pipe fill (source frames at `rate`) a position-slaved producer
-/// must keep queued in the selected output: enough to cover the sink's
-/// start-of-stream prime plus its claim burst (how far ahead of audible
-/// playback the hardware grabs data at once). `None` when [`position`]
-/// would return `None` — same routing, probed once per playback session.
+/// Output pipe depth (playback latency), in source frames the producer keeps
+/// queued ahead of the sink's play cursor. This is UNIVERSAL — the same depth
+/// for every hardware sink (HDA, AC97, SB16), one latency knob, not a per-driver
+/// value. Below ~one framebuffer-blit period a present stall can underrun it
+/// (crackle); higher only adds latency. The sink's own buffer size is a separate
+/// concern (completion-IRQ granularity), never the pipe.
+const PIPE_MS: u32 = 12;
+
+/// The universal pipe depth [`PIPE_MS`] in frames, or `None` when the active sink
+/// has no real-time consumer clock (hosted WAV / silent) — then production is
+/// virtual-time paced. Probed once per playback session.
 pub fn min_fill(rate: u32) -> Option<u32> {
     use crate::kernel::platform::Audio;
-    match crate::kernel::platform::get().audio {
-        Audio::EmulatedHda => crate::kernel::drivers::hda::min_fill(rate),
-        Audio::EmulatedAc97 => crate::kernel::drivers::ac97::min_fill(rate),
-        Audio::EmulatedPortWindow | Audio::SbPassthrough | Audio::EmulatedSilent => None,
-    }
+    let present = match crate::kernel::platform::get().audio {
+        Audio::EmulatedHda => crate::kernel::drivers::hda::present(),
+        Audio::EmulatedAc97 => crate::kernel::drivers::ac97::present(),
+        Audio::EmulatedPortWindow | Audio::SbPassthrough | Audio::EmulatedSilent => false,
+    };
+    present.then(|| rate * PIPE_MS / 1000)
 }
 
 /// Producer-side pacing for a *generated* PCM stream — the synth pumps (FM,

--- a/kernel/src/kernel/sound.rs
+++ b/kernel/src/kernel/sound.rs
@@ -220,8 +220,16 @@ pub struct Pace {
     /// push, so anything queued before us drains first — see vsb).
     anchor: u64,
     /// Session frames the sink has consumed, as of the last [`due`] call
-    /// (synthetic: everything pushed — an instant consumer).
+    /// (synthetic: everything pushed — an instant consumer). Interpolated: the
+    /// sink confirms whole buffers per completion IRQ, and this advances smoothly
+    /// between them (see `drained_from`/`drained_ms`/`drain_step`) so both
+    /// production and the guest cursor derived from it advance evenly.
     drained: u64,
+    /// Last buffer-granular consumed value, the ms it stepped, and the step size
+    /// (buffer, learned) — for interpolating `drained` between completions.
+    drained_from: u64,
+    drained_ms: u64,
+    drain_step: u64,
     /// Guest-clock accumulator, frames × 1000. Production is paced on
     /// `get_ticks` (real-time to ~1e-3); this keeps whole-frame credit so a
     /// partial block remains here until the next complete block is due. Used on
@@ -234,6 +242,7 @@ impl Pace {
         Pace {
             rate: 0, fill: 0, use_pos: false,
             pushed: 0, anchor: u64::MAX, drained: 0, frac: 0,
+            drained_from: 0, drained_ms: 0, drain_step: 0,
         }
     }
 
@@ -245,6 +254,9 @@ impl Pace {
         self.anchor = u64::MAX;
         self.drained = 0;
         self.frac = 0;
+        self.drained_from = 0;
+        self.drained_ms = 0;
+        self.drain_step = 0;
     }
 
     /// Force a fresh session on the next [`due`] even at an unchanged rate —
@@ -287,22 +299,42 @@ impl Pace {
             self.pushed = 0;
             self.anchor = u64::MAX;
             self.frac = 0;
+            self.drained_from = 0;
+            self.drain_step = 0;
         }
         if self.use_pos {
             let (written, consumed) = position(machine).unwrap_or((0, 0));
             if self.anchor == u64::MAX && self.pushed > 0 {
                 self.anchor = written.saturating_sub(self.pushed);
             }
-            self.drained = if self.anchor == u64::MAX {
+            let coarse = if self.anchor == u64::MAX {
                 0
             } else {
                 consumed.saturating_sub(self.anchor)
             };
+            // The sink confirms `consumed` one whole buffer per completion IRQ — a
+            // coarse staircase. Interpolate it with real time so `drained` advances
+            // evenly, like a real DMA cursor: re-anchor on each step, cap the
+            // fraction at the last step (the buffer, learned from the step itself)
+            // so it stays monotonic and never crosses the next, unconfirmed
+            // boundary. This one smooth drain feeds BOTH the deficit below and the
+            // guest-visible SB cursor — so production and that cursor advance
+            // evenly instead of in buffer-sized bursts (the SFX-crackle source).
+            let now = machine.get_ticks();
+            if coarse != self.drained_from {
+                self.drain_step = coarse - self.drained_from;
+                self.drained_from = coarse;
+                self.drained_ms = now;
+            }
+            let frac =
+                (now.saturating_sub(self.drained_ms) * rate as u64 / 1000).min(self.drain_step);
+            self.drained = coarse + frac;
             // Refill the deficit to keep `fill` frames queued ahead of the drain.
-            // The sink advances `consumed` from its own completion interrupt, so
-            // production tracks consumption exactly — no clock drift to servo, no
-            // guest-time pacing. At startup the deficit is the whole `fill`, which
-            // primes the pipe in one go.
+            // Production paces on this smoothed drain — real-time between the
+            // completion anchors — so it tracks consumption without the coarse
+            // buffer-step bursts (and without a get_ticks drift servo: the anchors
+            // pin it to the true drain). At startup the deficit is the whole
+            // `fill`, which primes the pipe in one go.
             let deficit = (self.drained + self.fill as u64).saturating_sub(self.pushed);
             let due = deficit / block * block;
             self.pushed += due;

--- a/kernel/src/kernel/sound.rs
+++ b/kernel/src/kernel/sound.rs
@@ -91,11 +91,17 @@ pub fn window_present<A: crate::Arch>(machine: &mut A) -> bool {
 /// event is consumed, never forwarded to a guest). Cross-personality by design
 /// — the sink belongs to the kernel, not to whichever thread is focused.
 pub fn on_hw_irq<A: crate::Arch>(machine: &mut A, line: u8) -> bool {
-    let _ = machine;
     use crate::kernel::platform::Audio;
     match crate::kernel::platform::get().audio {
         Audio::EmulatedHda if line == crate::kernel::drivers::hda::MSI_LINE => {
             crate::kernel::drivers::hda::on_irq();
+            true
+        }
+        Audio::EmulatedAc97 if Some(line) == crate::kernel::drivers::ac97::irq_line() => {
+            crate::kernel::drivers::ac97::on_irq(machine);
+            // Level INTx: the driver cleared the source above; re-unmask the line
+            // (the PIC path masked it on receipt — a no-op in APIC edge mode).
+            machine.rearm_irq(line);
             true
         }
         _ => false,
@@ -167,17 +173,6 @@ pub fn position<A: crate::Arch>(machine: &mut A) -> Option<(u64, u64)> {
     }
 }
 
-/// Is the selected sink driving production by its own completion interrupt
-/// (vs a polled cursor)? When true the pacer refills purely on the drain (each
-/// completion frees one buffer to produce), because a hardware-buffer-clocked
-/// interrupt is a stable pace — unlike a jitter-prone polled cursor, which
-/// still needs the `get_ticks` smoothing servo. Probed once per session.
-pub fn irq_paced() -> bool {
-    use crate::kernel::platform::Audio;
-    matches!(crate::kernel::platform::get().audio, Audio::EmulatedHda)
-        && crate::kernel::drivers::hda::msi_active()
-}
-
 /// Minimum pipe fill (source frames at `rate`) a position-slaved producer
 /// must keep queued in the selected output: enough to cover the sink's
 /// start-of-stream prime plus its claim burst (how far ahead of audible
@@ -211,9 +206,6 @@ pub struct Pace {
     /// Pipe depth target in source frames; 0 = synthetic (no sink position).
     fill: u32,
     use_pos: bool,
-    /// The sink drives production by completion IRQ (see [`irq_paced`]): refill
-    /// purely on the drain, skipping the get_ticks drift servo.
-    irq_paced: bool,
     /// Source frames pushed this session.
     pushed: u64,
     /// Sink `written` counter at our session start (`u64::MAX` = not yet
@@ -233,7 +225,7 @@ pub struct Pace {
 impl Pace {
     pub const fn new() -> Self {
         Pace {
-            rate: 0, fill: 0, use_pos: false, irq_paced: false,
+            rate: 0, fill: 0, use_pos: false,
             pushed: 0, anchor: u64::MAX, drained: 0, frac: 0,
         }
     }
@@ -284,7 +276,6 @@ impl Pace {
             let fill = min_fill(rate);
             self.rate = rate;
             self.use_pos = fill.is_some();
-            self.irq_paced = irq_paced();
             self.fill = fill.unwrap_or(0);
             self.pushed = 0;
             self.anchor = u64::MAX;
@@ -300,38 +291,13 @@ impl Pace {
             } else {
                 consumed.saturating_sub(self.anchor)
             };
-            // Pace on GUEST TIME, not on the drain position. `get_ticks` is
-            // real-time to ~1e-3 (measured against wall-clock), so producing
-            // `rate·dt` frames matches the codec's rate directly — and, unlike
-            // chasing the jittery `consumed`, the rate is near-constant, so the
-            // synth engine (and the GUS volume ramps DMX polls to time its notes)
-            // advances evenly. Chasing the drain made the engine step in the
-            // codec's coarse jitter, which desynced DMX and dropped brief
-            // silences into GUS music.
-            //
-            // To soak the crystal-level drift between the guest clock and the
-            // codec, we ALTER THE MIX RATE — a gentle proportional servo that
-            // trims `rate` by how far the pipe fill sits off `fill` (>>4 gain →
-            // sub-0.5% trim). Not the drain position (no averaging), not a
-            // resample: production stays guest-clocked, just at a rate nudged to
-            // the codec's true crystal so the pipe neither fills nor empties.
+            // Refill the deficit to keep `fill` frames queued ahead of the drain.
+            // The sink advances `consumed` from its own completion interrupt, so
+            // production tracks consumption exactly — no clock drift to servo, no
+            // guest-time pacing. At startup the deficit is the whole `fill`, which
+            // primes the pipe in one go.
             let deficit = (self.drained + self.fill as u64).saturating_sub(self.pushed);
-            let due = if self.irq_paced || deficit > self.fill as u64 * 3 / 4 {
-                // Event-driven sink (`irq_paced`): produce exactly what the drain
-                // freed to restore `fill` frames ahead — each completion IRQ moved
-                // `drained` by one buffer, so this is one buffer's worth. The
-                // hardware-buffer-clocked interrupt is a stable pace, so no drift
-                // servo is needed. (Same catch-up formula also handles a far-behind
-                // pipe on a polled sink: empty at startup or a severe guest stall.)
-                deficit / block * block
-            } else {
-                let err = (self.pushed as i64 - self.drained as i64) - self.fill as i64;
-                let rate_eff = (rate as i64 - (err >> 4)).clamp(1, rate as i64 * 2) as u64;
-                self.frac += rate_eff * dt_ms;
-                let d = self.frac / 1000 / block * block;
-                self.frac -= d * 1000;
-                d
-            };
+            let due = deficit / block * block;
             self.pushed += due;
             due
         } else {

--- a/kernel/src/kernel/sound.rs
+++ b/kernel/src/kernel/sound.rs
@@ -85,29 +85,40 @@ pub fn window_present<A: crate::Arch>(machine: &mut A) -> bool {
     machine.inw(AUDIO_SIG) == SIGNATURE
 }
 
-/// Canonical audio-sink interrupt router. A hardware `Irq::Hw(line)` drained by
-/// any personality is offered here first: if `line` is the selected sink's
-/// completion interrupt, the sink services it and this returns `true` (the
-/// event is consumed, never forwarded to a guest). Cross-personality by design
-/// — the sink belongs to the kernel, not to whichever thread is focused.
-pub fn on_hw_irq<A: crate::Arch>(machine: &mut A, line: u8) -> bool {
+/// Canonical audio-sink interrupt router. Called by the kernel-global IRQ
+/// dispatcher before personality/console routing. The interrupt is a wakeup;
+/// each driver validates its status and reads its authoritative DMA cursor.
+pub fn on_irq<A: crate::Arch>(machine: &mut A, event: crate::Irq) -> bool {
     use crate::kernel::platform::Audio;
-    match crate::kernel::platform::get().audio {
-        Audio::EmulatedHda if line == crate::kernel::drivers::hda::MSI_LINE => {
-            crate::kernel::drivers::hda::on_irq();
-            true
+    match (crate::kernel::platform::get().audio, event) {
+        (Audio::EmulatedHda, crate::Irq::Msi(source))
+            if source == crate::kernel::drivers::hda::MSI_SOURCE =>
+        {
+            crate::kernel::drivers::hda::on_irq()
         }
-        Audio::EmulatedAc97 if Some(line) == crate::kernel::drivers::ac97::irq_line() => {
-            crate::kernel::drivers::ac97::on_irq(machine);
-            // Level INTx: the driver cleared the source above; re-unmask the line
-            // (the PIC path masked it on receipt — a no-op in APIC edge mode).
-            machine.rearm_irq(line);
-            true
+        (Audio::EmulatedAc97, crate::Irq::Hw(line))
+            if Some(line) == crate::kernel::drivers::ac97::irq_line() =>
+        {
+            let ours = crate::kernel::drivers::ac97::on_irq(machine);
+            if ours {
+                machine.rearm_irq(line);
+            }
+            ours
         }
-        Audio::RealSb if Some(line) == crate::kernel::drivers::sb16::irq_line() => {
-            crate::kernel::drivers::sb16::on_irq(machine);
-            machine.rearm_irq(line); // re-unmask the ISA line the sink owns
-            true
+        (Audio::EmulatedAc97, crate::Irq::Msi(source))
+            if crate::kernel::drivers::ac97::msi_active()
+                && source == crate::kernel::drivers::ac97::MSI_SOURCE =>
+        {
+            crate::kernel::drivers::ac97::on_irq(machine)
+        }
+        (Audio::RealSb, crate::Irq::Hw(line))
+            if Some(line) == crate::kernel::drivers::sb16::irq_line() =>
+        {
+            let ours = crate::kernel::drivers::sb16::on_irq(machine);
+            if ours {
+                machine.rearm_irq(line);
+            }
+            ours
         }
         _ => false,
     }
@@ -182,17 +193,12 @@ pub fn position<A: crate::Arch>(machine: &mut A) -> Option<(u64, u64)> {
     }
 }
 
-/// Output pipe depth (playback latency), in source frames the producer keeps
-/// queued ahead of the sink's play cursor. This is UNIVERSAL — the same depth
-/// for every hardware sink (HDA, AC97, SB16), one latency knob, not a per-driver
-/// value. Below ~one framebuffer-blit period a present stall can underrun it
-/// (crackle); higher only adds latency. The sink's own buffer size is a separate
-/// concern (completion-IRQ granularity), never the pipe.
-const PIPE_MS: u32 = 12;
+/// Desired output pipe depth (playback latency), shared by every hardware sink.
+/// Below ~one framebuffer-blit period a present stall can underrun it.
+const PIPE_MS: u32 = 30;
 
-/// The universal pipe depth [`PIPE_MS`] in frames, or `None` when the active sink
-/// has no real-time consumer clock (hosted WAV / silent) — then production is
-/// virtual-time paced. Probed once per playback session.
+/// The universal [`PIPE_MS`] depth in frames, or `None` when the active sink
+/// has no real-time consumer clock. Probed once per playback session.
 pub fn min_fill(rate: u32) -> Option<u32> {
     use crate::kernel::platform::Audio;
     let present = match crate::kernel::platform::get().audio {

--- a/kernel/src/kernel/sound.rs
+++ b/kernel/src/kernel/sound.rs
@@ -167,6 +167,17 @@ pub fn position<A: crate::Arch>(machine: &mut A) -> Option<(u64, u64)> {
     }
 }
 
+/// Is the selected sink driving production by its own completion interrupt
+/// (vs a polled cursor)? When true the pacer refills purely on the drain (each
+/// completion frees one buffer to produce), because a hardware-buffer-clocked
+/// interrupt is a stable pace — unlike a jitter-prone polled cursor, which
+/// still needs the `get_ticks` smoothing servo. Probed once per session.
+pub fn irq_paced() -> bool {
+    use crate::kernel::platform::Audio;
+    matches!(crate::kernel::platform::get().audio, Audio::EmulatedHda)
+        && crate::kernel::drivers::hda::msi_active()
+}
+
 /// Minimum pipe fill (source frames at `rate`) a position-slaved producer
 /// must keep queued in the selected output: enough to cover the sink's
 /// start-of-stream prime plus its claim burst (how far ahead of audible
@@ -200,6 +211,9 @@ pub struct Pace {
     /// Pipe depth target in source frames; 0 = synthetic (no sink position).
     fill: u32,
     use_pos: bool,
+    /// The sink drives production by completion IRQ (see [`irq_paced`]): refill
+    /// purely on the drain, skipping the get_ticks drift servo.
+    irq_paced: bool,
     /// Source frames pushed this session.
     pushed: u64,
     /// Sink `written` counter at our session start (`u64::MAX` = not yet
@@ -219,7 +233,7 @@ pub struct Pace {
 impl Pace {
     pub const fn new() -> Self {
         Pace {
-            rate: 0, fill: 0, use_pos: false,
+            rate: 0, fill: 0, use_pos: false, irq_paced: false,
             pushed: 0, anchor: u64::MAX, drained: 0, frac: 0,
         }
     }
@@ -270,6 +284,7 @@ impl Pace {
             let fill = min_fill(rate);
             self.rate = rate;
             self.use_pos = fill.is_some();
+            self.irq_paced = irq_paced();
             self.fill = fill.unwrap_or(0);
             self.pushed = 0;
             self.anchor = u64::MAX;
@@ -301,10 +316,13 @@ impl Pace {
             // resample: production stays guest-clocked, just at a rate nudged to
             // the codec's true crystal so the pipe neither fills nor empties.
             let deficit = (self.drained + self.fill as u64).saturating_sub(self.pushed);
-            let due = if deficit > self.fill as u64 * 3 / 4 {
-                // Far behind — an empty pipe at startup, or a severe guest stall.
-                // A gentle rate trim primes too slowly (underruns the codec), so
-                // catch straight up to `fill`. The servo only handles drift.
+            let due = if self.irq_paced || deficit > self.fill as u64 * 3 / 4 {
+                // Event-driven sink (`irq_paced`): produce exactly what the drain
+                // freed to restore `fill` frames ahead — each completion IRQ moved
+                // `drained` by one buffer, so this is one buffer's worth. The
+                // hardware-buffer-clocked interrupt is a stable pace, so no drift
+                // servo is needed. (Same catch-up formula also handles a far-behind
+                // pipe on a polled sink: empty at startup or a severe guest stall.)
                 deficit / block * block
             } else {
                 let err = (self.pushed as i64 - self.drained as i64) - self.fill as i64;

--- a/kernel/src/kernel/sound.rs
+++ b/kernel/src/kernel/sound.rs
@@ -320,6 +320,18 @@ impl Pace {
         }
         if self.use_pos {
             let (written, consumed) = position(machine).unwrap_or((0, 0));
+            // Sink counters restarted under our session (another owner parked
+            // or reset the stream — e.g. a child program's exit cleanup). Our
+            // frame numbering is void; re-key so the anchor below is rebuilt
+            // from the fresh counters instead of wedging `drained` at zero.
+            if written < self.pushed {
+                self.pushed = 0;
+                self.anchor = u64::MAX;
+                self.frac = 0;
+                self.drained_from = 0;
+                self.drained_ms = 0;
+                self.drain_step = 0;
+            }
             if self.anchor == u64::MAX && self.pushed > 0 {
                 self.anchor = written.saturating_sub(self.pushed);
             }

--- a/kernel/src/kernel/startup.rs
+++ b/kernel/src/kernel/startup.rs
@@ -445,12 +445,22 @@ pub fn event_loop<A: crate::Arch>(machine: &mut A, threads: &mut [thread::Thread
         if crate::kernel::osd::is_open() {
             crate::kernel::osd::refresh_processes(threads, crate::kernel::focus::focused());
         }
+        // Kernel-owned device IRQs are serviced before virtual-time/audio
+        // advancement. The remaining input/guest events retain their order for
+        // console routing below.
+        let events = crate::kernel::irq_dispatch::drain(machine);
         let thread = ctx.thread(threads);
 
         // Advance this thread's world: virtual time, console input, delivery.
         thread.personality.advance_world(machine, &mut ctx.regs);
         stats.part(machine, 0);
-        crate::kernel::console::drain(machine, &mut ctx.regs, &mut thread.kernel, &mut thread.personality);
+        crate::kernel::console::dispatch(
+            machine,
+            &mut ctx.regs,
+            &mut thread.kernel,
+            &mut thread.personality,
+            events,
+        );
         stats.part(machine, 1);
         thread.personality.after_input(machine, &mut thread.kernel, &mut ctx.regs);
         stats.part(machine, 2);

--- a/kernel/src/kernel/startup.rs
+++ b/kernel/src/kernel/startup.rs
@@ -240,6 +240,7 @@ fn init_device_policy<A: crate::Arch>(
     // interpreter) leaves the sound path on its port-window fallback.
     crate::kernel::drivers::ac97::init(machine);
     crate::kernel::drivers::hda::init(machine);
+    crate::kernel::drivers::sb16::init(machine);
 }
 
 /// /CONFIG.SYS provides the master env handed to DN and any user-driven

--- a/kernel/src/kernel/startup.rs
+++ b/kernel/src/kernel/startup.rs
@@ -436,6 +436,7 @@ pub fn event_loop<A: crate::Arch>(machine: &mut A, threads: &mut [thread::Thread
     crate::dbg_println!("event_loop entered, tid={}", first_tid);
     let mut ctx = crate::kernel::exec_ctx::ExecutionContext::seed(threads, first_tid);
     let mut stats = EventStats::new(machine);
+    let mut last_event_drain_tick = u64::MAX;
 
     loop {
         stats.slice_begin(machine);
@@ -445,15 +446,25 @@ pub fn event_loop<A: crate::Arch>(machine: &mut A, threads: &mut [thread::Thread
         if crate::kernel::osd::is_open() {
             crate::kernel::osd::refresh_processes(threads, crate::kernel::focus::focused());
         }
+        stats.part(machine, 0);
         // Kernel-owned device IRQs are serviced before virtual-time/audio
-        // advancement. The remaining input/guest events retain their order for
-        // console routing below.
-        let events = crate::kernel::irq_dispatch::drain(machine);
+        // advancement. Polling guests can cross this loop hundreds of times
+        // within one millisecond; the hardware queue only needs inspecting
+        // once on that same device cadence. This bounds keyboard/audio wakeup
+        // latency to 1 ms while avoiding a CLI/queue/STI round-trip per port.
+        let now_tick = machine.get_ticks();
+        let events = if now_tick != last_event_drain_tick {
+            last_event_drain_tick = now_tick;
+            crate::kernel::irq_dispatch::drain(machine)
+        } else {
+            alloc::vec::Vec::new()
+        };
+        stats.part(machine, 1);
         let thread = ctx.thread(threads);
 
         // Advance this thread's world: virtual time, console input, delivery.
         thread.personality.advance_world(machine, &mut ctx.regs);
-        stats.part(machine, 0);
+        stats.part(machine, 2);
         crate::kernel::console::dispatch(
             machine,
             &mut ctx.regs,
@@ -461,9 +472,10 @@ pub fn event_loop<A: crate::Arch>(machine: &mut A, threads: &mut [thread::Thread
             &mut thread.personality,
             events,
         );
-        stats.part(machine, 1);
+        stats.part(machine, 3);
         thread.personality.after_input(machine, &mut thread.kernel, &mut ctx.regs);
-        stats.part(machine, 2);
+        stats.part(machine, 4);
+
 
         // A blocked thread holds the console but not the CPU: wait for input
         // to unblock it (above) or F11 to move on.
@@ -861,8 +873,8 @@ static mut SLICE_PARTS: [u64; 5] = [0; 5];
 /// tick+display total can be divided by the right denominator.
 static mut PRESENTS: u64 = 0;
 
-/// display_tick's internals: scanout, the per-frame vec alloc+zero, render,
-/// present — plus the source pixel count.
+/// display_tick's internals: scanout, allocation, render, present — plus the
+/// number of destination pixels actually copied after dirty-span rejection.
 static mut DISP_PARTS: [u64; 5] = [0; 5];
 
 pub fn bill_display(scanout: u64, alloc: u64, render: u64, present: u64, px: usize) {
@@ -872,7 +884,23 @@ pub fn bill_display(scanout: u64, alloc: u64, render: u64, present: u64, px: usi
         (*p)[1] = (*p)[1].wrapping_add(alloc);
         (*p)[2] = (*p)[2].wrapping_add(render);
         (*p)[3] = (*p)[3].wrapping_add(present);
-        (*p)[4] = px as u64;
+        (*p)[4] = (*p)[4].wrapping_add(px as u64);
+    }
+}
+
+/// `audio_tick` internals: device maintenance/MIDI, pump setup and sink
+/// pacing, PCM source mixing/output, guest clocks/IRQ delivery, and the
+/// number of canonical PCM frames generated.
+static mut AUDIO_PARTS: [u64; 5] = [0; 5];
+
+pub fn bill_audio(devices: u64, setup: u64, pump: u64, clocks: u64, frames: u64) {
+    unsafe {
+        let p = &raw mut AUDIO_PARTS;
+        (*p)[0] = (*p)[0].wrapping_add(devices);
+        (*p)[1] = (*p)[1].wrapping_add(setup);
+        (*p)[2] = (*p)[2].wrapping_add(pump);
+        (*p)[3] = (*p)[3].wrapping_add(clocks);
+        (*p)[4] = (*p)[4].wrapping_add(frames);
     }
 }
 
@@ -957,8 +985,9 @@ struct EventStats {
     /// Cycles spent in `dispatch` per event kind — the same 11 slots as
     /// `counts`, so dividing one by the other gives cost-per-event.
     dispatch_cycles: [u64; 11],
-    /// The pre-phase, split three ways: advance_world, console drain, after_input.
-    pre_parts: [u64; 3],
+    /// Exact pre-run routine split: event bookkeeping/OSD, hardware IRQ drain,
+    /// advance_world, console dispatch, personality after_input.
+    pre_parts: [u64; 5],
     part_mark: u64,
     slice_start: u64,
     last_idx: usize,
@@ -995,7 +1024,7 @@ impl EventStats {
             pre_cycles: 0,
             post_cycles: 0,
             dispatch_cycles: [0; 11],
-            pre_parts: [0; 3],
+            pre_parts: [0; 5],
             part_mark: 0,
             slice_start: 0,
             last_idx: 0,
@@ -1033,6 +1062,11 @@ impl EventStats {
 
     /// Close out one part of the pre-phase and open the next.
     fn part<A: crate::Arch>(&mut self, machine: &mut A, i: usize) {
+        // The extra routine boundaries exist only for an active profile.
+        // Normal gameplay keeps the old event-loop instruction count.
+        if !profile_enabled() {
+            return;
+        }
         let now = machine.rdtsc();
         self.pre_parts[i] = self.pre_parts[i].wrapping_add(now.wrapping_sub(self.part_mark));
         self.part_mark = now;
@@ -1160,6 +1194,24 @@ impl EventStats {
                 crate::dbg_println!("[prof] dispatch cycles/event: in={} out={} irq={} softint={}",
                     cost(3), cost(4), cost(0), cost(1));
                 let ev = self.iterations.max(1);
+                let dispatch_total = self.dispatch_cycles.iter()
+                    .fold(0u64, |sum, &v| sum.wrapping_add(v));
+                let scheduler_total = self.post_cycles.saturating_sub(dispatch_total);
+                let pct = |v: u64| {
+                    v.saturating_mul(100).checked_div(total.max(1)).unwrap_or(0)
+                };
+                crate::dbg_println!(
+                    "[prof] kernel routines: bookkeeping={} ({}%) irq_drain={} ({}%) advance_world={} ({}%) console={} ({}%) after_input={} ({}%)",
+                    self.pre_parts[0], pct(self.pre_parts[0]),
+                    self.pre_parts[1], pct(self.pre_parts[1]),
+                    self.pre_parts[2], pct(self.pre_parts[2]),
+                    self.pre_parts[3], pct(self.pre_parts[3]),
+                    self.pre_parts[4], pct(self.pre_parts[4]));
+                crate::dbg_println!(
+                    "[prof] kernel post: dispatch={} ({}%) scheduler/exit={} ({}%) | dispatch/event pf={} syscall={}",
+                    dispatch_total, pct(dispatch_total),
+                    scheduler_total, pct(scheduler_total),
+                    cost(8), cost(10));
                 let sp = unsafe { SLICE_PARTS };
                 let np = unsafe { PRESENTS };
                 unsafe { PRESENTS = 0 };
@@ -1172,11 +1224,20 @@ impl EventStats {
                 let dp = unsafe { DISP_PARTS };
                 unsafe { DISP_PARTS = [0; 5] };
                 let per = |v: u64| v.checked_div(np.max(1)).unwrap_or(0);
-                crate::dbg_println!("[prof]   display/frame: scanout={} alloc={} render={} present={} (src {}px)",
-                    per(dp[0]), per(dp[1]), per(dp[2]), per(dp[3]), dp[4]);
+                crate::dbg_println!("[prof]   display/frame: scanout={} alloc={} render={} present={} copied={}px",
+                    per(dp[0]), per(dp[1]), per(dp[2]), per(dp[3]), per(dp[4]));
+                let ap = unsafe { AUDIO_PARTS };
+                unsafe { AUDIO_PARTS = [0; 5] };
+                crate::dbg_println!(
+                    "[prof]   audio: devices={} ({}%) setup/pace={} ({}%) pump={} ({}%) clocks/irqs={} ({}%) generated={} frames",
+                    ap[0], pct(ap[0]), ap[1], pct(ap[1]),
+                    ap[2], pct(ap[2]), ap[3], pct(ap[3]), ap[4]);
                 unsafe { SLICE_PARTS = [0; 5] };
-                crate::dbg_println!("[prof] pre cycles/event: advance_world={} drain={} after_input={}",
-                    self.pre_parts[0] / ev, self.pre_parts[1] / ev, self.pre_parts[2] / ev);
+                crate::dbg_println!(
+                    "[prof] pre cycles/event: bookkeeping={} irq_drain={} advance_world={} console={} after_input={}",
+                    self.pre_parts[0] / ev, self.pre_parts[1] / ev,
+                    self.pre_parts[2] / ev, self.pre_parts[3] / ev,
+                    self.pre_parts[4] / ev);
                 if c[3] + c[4] > 0 {
                     let mut p = self.ports;
                     p.sort_by_key(|e| core::cmp::Reverse(e.1));
@@ -1212,7 +1273,7 @@ impl EventStats {
             self.pre_cycles = 0;
             self.post_cycles = 0;
             self.dispatch_cycles = [0; 11];
-            self.pre_parts = [0; 3];
+            self.pre_parts = [0; 5];
             self.counts = [0; 11];
             self.softint_by_vec = [0; 256];
             self.ports = [(0, 0, 0); 12];

--- a/kernel/src/kernel/startup.rs
+++ b/kernel/src/kernel/startup.rs
@@ -72,6 +72,13 @@ pub fn startup<A: crate::Arch>(machine: &mut A, boot: &crate::BootConfig, mut sc
         .flat_map(|&d| crate::kernel::block::partition::scan(crate::kernel::block::Volume::whole(d)))
         .collect();
     mount_filesystems(&parts, platform.hostfs, &mut screen);
+    // Burn the GM bank ROM while long work is still legal (no guest yet):
+    // the shipped bank lives under the C: root beside the GUS patches.
+    {
+        let mut dir = alloc::vec::Vec::from(crate::kernel::dos::c_root());
+        dir.extend_from_slice(b"/ULTRASND/MIDI");
+        crate::kernel::midi_bank::load(&dir);
+    }
     init_device_policy(machine, platform);
     let master_env = load_master_env();
     init_console_pipe();

--- a/kernel/src/kernel/startup.rs
+++ b/kernel/src/kernel/startup.rs
@@ -74,11 +74,7 @@ pub fn startup<A: crate::Arch>(machine: &mut A, boot: &crate::BootConfig, mut sc
     mount_filesystems(&parts, platform.hostfs, &mut screen);
     // Burn the GM bank ROM while long work is still legal (no guest yet):
     // the shipped bank lives under the C: root beside the GUS patches.
-    {
-        let mut dir = alloc::vec::Vec::from(crate::kernel::dos::c_root());
-        dir.extend_from_slice(b"/ULTRASND/MIDI");
-        crate::kernel::midi_bank::load(&dir);
-    }
+    crate::kernel::midi_bank::load_from_c_root(crate::kernel::dos::c_root());
     init_device_policy(machine, platform);
     let master_env = load_master_env();
     init_console_pipe();

--- a/kernel/src/kernel/startup.rs
+++ b/kernel/src/kernel/startup.rs
@@ -873,18 +873,18 @@ static mut SLICE_PARTS: [u64; 5] = [0; 5];
 /// tick+display total can be divided by the right denominator.
 static mut PRESENTS: u64 = 0;
 
-/// display_tick's internals: scanout, allocation, render, present — plus the
-/// number of destination pixels actually copied after dirty-span rejection.
-static mut DISP_PARTS: [u64; 5] = [0; 5];
+/// display_tick's internals: scanout cycles, band-pass count (one raster
+/// band or one whole window-sink frame per bill), render/copy cycles, and
+/// destination pixels written.
+static mut DISP_PARTS: [u64; 4] = [0; 4];
 
-pub fn bill_display(scanout: u64, alloc: u64, render: u64, present: u64, px: usize) {
+pub fn bill_display(scanout: u64, bands: u64, raster: u64, px: usize) {
     unsafe {
         let p = &raw mut DISP_PARTS;
         (*p)[0] = (*p)[0].wrapping_add(scanout);
-        (*p)[1] = (*p)[1].wrapping_add(alloc);
-        (*p)[2] = (*p)[2].wrapping_add(render);
-        (*p)[3] = (*p)[3].wrapping_add(present);
-        (*p)[4] = (*p)[4].wrapping_add(px as u64);
+        (*p)[1] = (*p)[1].wrapping_add(bands);
+        (*p)[2] = (*p)[2].wrapping_add(raster);
+        (*p)[3] = (*p)[3].wrapping_add(px as u64);
     }
 }
 
@@ -1222,10 +1222,14 @@ impl EventStats {
                     sp[2], np, sp[2].checked_div(np.max(1)).unwrap_or(0),
                     sp[3]);
                 let dp = unsafe { DISP_PARTS };
-                unsafe { DISP_PARTS = [0; 5] };
+                unsafe { DISP_PARTS = [0; 4] };
                 let per = |v: u64| v.checked_div(np.max(1)).unwrap_or(0);
-                crate::dbg_println!("[prof]   display/frame: scanout={} alloc={} render={} present={} copied={}px",
-                    per(dp[0]), per(dp[1]), per(dp[2]), per(dp[3]), per(dp[4]));
+                let slice = |v: u64| v.checked_div(dp[1].max(1)).unwrap_or(0);
+                crate::dbg_println!(
+                    "[prof]   display/frame: scanout={} raster={} copied={}px | per-slice: scanout={} raster={} ({} slices, {}% of window)",
+                    per(dp[0]), per(dp[2]), per(dp[3]),
+                    slice(dp[0]), slice(dp[2]), dp[1],
+                    pct(dp[0].wrapping_add(dp[2])));
                 let ap = unsafe { AUDIO_PARTS };
                 unsafe { AUDIO_PARTS = [0; 5] };
                 crate::dbg_println!(

--- a/kernel/src/kernel/thread.rs
+++ b/kernel/src/kernel/thread.rs
@@ -212,19 +212,15 @@ impl<A: crate::Arch> Personality<A> {
                 let ticks = machine.take_pending_ticks();
                 // Port-polling games can exit to the kernel hundreds of
                 // thousands of times between adjacent millisecond ticks.
-                // Display and the audio PUMP are driven by this tick clock,
+                // Display and the audio pump are driven by this tick clock,
                 // so revisiting the whole virtual machine when it did not
-                // advance is pure per-exit overhead — but audio_tick's
-                // above-the-gate section (latched 0xF2 trigger IRQs, tiny
-                // single-cycle DMA probe completions, the GF1's fine
-                // timers) is SUB-quantum by design: MI2's driver arms a
-                // one-byte probe and expects the completion back-to-back
-                // (see the 35e3b27 fix — a 1 ms floor loses it, and a full
-                // early-out here reinstated exactly that floor). audio_tick
-                // itself returns right after that section when no
-                // millisecond has elapsed.
+                // advance is pure per-exit overhead. Device service is not:
+                // its latency contract is the slice (MI2 arms a one-byte DMA
+                // probe and expects the completion back-to-back; a 1 ms
+                // floor loses it — 35e3b27, regressed once by a full
+                // early-out here).
                 if ticks == 0 {
-                    crate::kernel::dos::audio_tick(machine, dos, regs);
+                    crate::kernel::dos::audio_service(machine, dos);
                     return;
                 }
                 // Instrument only actual world advances. Per-exit rdtsc

--- a/kernel/src/kernel/thread.rs
+++ b/kernel/src/kernel/thread.rs
@@ -212,10 +212,19 @@ impl<A: crate::Arch> Personality<A> {
                 let ticks = machine.take_pending_ticks();
                 // Port-polling games can exit to the kernel hundreds of
                 // thousands of times between adjacent millisecond ticks.
-                // Display and audio are both driven by this tick clock, so
-                // revisiting the whole virtual machine when it did not advance
-                // is pure per-exit overhead.
+                // Display and the audio PUMP are driven by this tick clock,
+                // so revisiting the whole virtual machine when it did not
+                // advance is pure per-exit overhead — but audio_tick's
+                // above-the-gate section (latched 0xF2 trigger IRQs, tiny
+                // single-cycle DMA probe completions, the GF1's fine
+                // timers) is SUB-quantum by design: MI2's driver arms a
+                // one-byte probe and expects the completion back-to-back
+                // (see the 35e3b27 fix — a 1 ms floor loses it, and a full
+                // early-out here reinstated exactly that floor). audio_tick
+                // itself returns right after that section when no
+                // millisecond has elapsed.
                 if ticks == 0 {
+                    crate::kernel::dos::audio_tick(machine, dos, regs);
                     return;
                 }
                 // Instrument only actual world advances. Per-exit rdtsc

--- a/kernel/src/kernel/thread.rs
+++ b/kernel/src/kernel/thread.rs
@@ -209,11 +209,18 @@ impl<A: crate::Arch> Personality<A> {
     pub fn advance_world(&mut self, machine: &mut A, regs: &mut Regs) {
         match self {
             Self::Dos(dos) => {
-                // Four rdtsc per event is ~3% of a core at this event rate, so
-                // the instrument only runs when someone is looking.
-                let prof = crate::kernel::startup::profile_enabled();
-                let t0 = if prof { machine.rdtsc() } else { 0 };
                 let ticks = machine.take_pending_ticks();
+                // Port-polling games can exit to the kernel hundreds of
+                // thousands of times between adjacent millisecond ticks.
+                // Display and audio are both driven by this tick clock, so
+                // revisiting the whole virtual machine when it did not advance
+                // is pure per-exit overhead.
+                if ticks == 0 {
+                    return;
+                }
+                // Instrument only actual world advances. Per-exit rdtsc
+                // sampling materially distorted profiles of PIT-polling games.
+                let prof = crate::kernel::startup::profile_enabled();
                 let t1 = if prof { machine.rdtsc() } else { 0 };
                 for _ in 0..ticks {
                     crate::kernel::dos::queue_tick(machine, dos);
@@ -232,7 +239,7 @@ impl<A: crate::Arch> Personality<A> {
                 if prof {
                     let t3 = machine.rdtsc();
                     crate::kernel::startup::bill_slice2(
-                        t1.wrapping_sub(t0), t1b.wrapping_sub(t1),
+                        0, t1b.wrapping_sub(t1),
                         t2.wrapping_sub(t1b), t3.wrapping_sub(t2), ticks as u64);
                 }
             }

--- a/lib/sound/src/midi.rs
+++ b/lib/sound/src/midi.rs
@@ -186,17 +186,69 @@ struct Resident {
     patch: Patch,
 }
 
-/// The General MIDI synthesizer.
+/// The instrument bank — parsed patches plus their shared sample pool, the
+/// GM device's ROM. Built once by the host (which owns file I/O) and shared
+/// by every synth instance by reference; the pool is exactly the GF1-DRAM
+/// shape, so the engine mixes from one `&[u8]`.
+pub struct Bank {
+    pool: Vec<u8>,
+    /// Resident instruments by patch id, `None` where the bank has no file.
+    resident: Vec<Option<Resident>>,
+}
+
+impl Default for Bank {
+    fn default() -> Bank {
+        Bank::new()
+    }
+}
+
+impl Bank {
+    pub fn new() -> Bank {
+        let mut resident = Vec::new();
+        resident.resize_with(PATCH_SLOTS, || None);
+        Bank { pool: Vec::new(), resident }
+    }
+
+    /// Install a `.PAT` file's bytes as patch `id`. Ignored if the bytes do
+    /// not parse — a corrupt or absent instrument leaves the slot empty and
+    /// its notes silent, never a panic. Returns whether it became resident.
+    pub fn load_patch(&mut self, id: u16, bytes: &[u8]) -> bool {
+        let Some(mut patch) = Patch::parse(bytes) else {
+            return false;
+        };
+        if id as usize >= PATCH_SLOTS {
+            return false;
+        }
+        let base = self.pool.len() as u32;
+        patch.relocate(base);
+        self.pool.extend_from_slice(&patch.pcm);
+        // The PCM now lives in the pool; drop the patch's private copy so a
+        // full bank does not hold every instrument twice.
+        patch.pcm = Vec::new();
+        self.resident[id as usize] = Some(Resident { patch });
+        true
+    }
+
+    pub fn has_patch(&self, id: u16) -> bool {
+        self.resident.get(id as usize).is_some_and(|r| r.is_some())
+    }
+
+    fn get(&self, id: u16) -> Option<&Resident> {
+        self.resident.get(id as usize)?.as_ref()
+    }
+
+    /// (instrument count, pool bytes) — for the host's boot summary line.
+    pub fn stats(&self) -> (usize, usize) {
+        (self.resident.iter().filter(|r| r.is_some()).count(), self.pool.len())
+    }
+}
+
+/// The General MIDI synthesizer: voices, channels and the MIDI wire. The
+/// instruments live in a shared [`Bank`]; a synth without one to reference
+/// cannot exist, which is the ROM-bank model made structural.
 pub struct Synth {
     engine: Box<Engine>,
-    /// One shared sample pool, exactly like the GF1's DRAM: every voice
-    /// addresses into this, so the engine mixes from one `&[u8]`.
-    pool: Vec<u8>,
-    /// Resident instruments by patch id, `None` until the host loads one.
-    resident: Vec<Option<Resident>>,
-    /// Patch ids wanted but not resident. A small ring: the host drains it
-    /// each tick, and a repeat request is harmless.
-    wanted: Vec<u16>,
+    bank: &'static Bank,
     channels: [Channel; 16],
     notes: [Note; MAX_VOICES],
     /// MIDI running status and the parameter bytes collected for it.
@@ -217,15 +269,11 @@ pub struct Synth {
 }
 
 impl Synth {
-    /// An empty synth: no instruments, all channels at GM power-on defaults.
-    pub fn new_boxed() -> Box<Synth> {
-        let mut resident = Vec::new();
-        resident.resize_with(PATCH_SLOTS, || None);
+    /// A synth over `bank`, all channels at GM power-on defaults.
+    pub fn new_boxed(bank: &'static Bank) -> Box<Synth> {
         Box::new(Synth {
             engine: Engine::new_boxed(),
-            pool: Vec::new(),
-            resident,
-            wanted: Vec::new(),
+            bank,
             channels: [Channel::new(); 16],
             notes: [Note::default(); MAX_VOICES],
             status: 0,
@@ -258,57 +306,6 @@ impl Synth {
         self.out_rate = rate;
         for ch in 0..16u8 {
             self.retune_channel(ch);
-        }
-    }
-
-    // ── patch residency (the host's half) ────────────────────────────────
-
-    /// A patch id the synth needs and does not have, or `None`. The host
-    /// resolves it with [`patch_stem`], reads the file, and calls
-    /// [`load_patch`](Self::load_patch). Drain until it returns `None`.
-    pub fn take_patch_request(&mut self) -> Option<u16> {
-        self.wanted.pop()
-    }
-
-    /// Install a `.PAT` file's bytes as patch `id`. Ignored if the bytes do
-    /// not parse — a corrupt or absent instrument leaves the slot empty and
-    /// its notes silent, never a panic.
-    ///
-    /// Returns whether the patch became resident, so a host can mark a failed
-    /// id and stop re-reading a file that will not parse.
-    pub fn load_patch(&mut self, id: u16, bytes: &[u8]) -> bool {
-        let Some(mut patch) = Patch::parse(bytes) else {
-            return false;
-        };
-        if id as usize >= PATCH_SLOTS {
-            return false;
-        }
-        let base = self.pool.len() as u32;
-        patch.relocate(base);
-        self.pool.extend_from_slice(&patch.pcm);
-        // The PCM now lives in the pool; drop the patch's private copy so a
-        // full bank does not hold every instrument twice.
-        patch.pcm = Vec::new();
-        self.resident[id as usize] = Some(Resident { patch });
-        true
-    }
-
-    /// Whether patch `id` is resident.
-    pub fn has_patch(&self, id: u16) -> bool {
-        self.resident
-            .get(id as usize)
-            .is_some_and(|r| r.is_some())
-    }
-
-    /// Note the host could not supply this patch, so we stop asking.
-    pub fn deny_patch(&mut self, id: u16) {
-        self.wanted.retain(|&w| w != id);
-        let _ = id;
-    }
-
-    fn want(&mut self, id: u16) {
-        if !self.has_patch(id) && !self.wanted.contains(&id) && self.wanted.len() < 16 {
-            self.wanted.push(id);
         }
     }
 
@@ -397,13 +394,7 @@ impl Synth {
             }
             0xA0 => {} // polyphonic aftertouch: not modelled
             0xB0 => self.control(ch, a, b2),
-            0xC0 => {
-                self.channels[ch].program = a & 0x7F;
-                if ch as u8 != DRUM_CH {
-                    let id = (a & 0x7F) as u16;
-                    self.want(id);
-                }
-            }
+            0xC0 => self.channels[ch].program = a & 0x7F,
             0xD0 => {} // channel pressure: not modelled
             0xE0 => {
                 let raw = ((b2 as i32) << 7 | a as i32) - 8192;
@@ -481,16 +472,15 @@ impl Synth {
 
     fn note_on(&mut self, ch: u8, key: u8, vel: u8) {
         let id = self.patch_for(ch, key);
-        if !self.has_patch(id) {
-            self.want(id);
-            return; // silent until the host supplies it — as a GUS would be
+        if !self.bank.has_patch(id) {
+            return; // absent from the ROM: this bank has no such instrument
         }
         // A sequencer retriggers a key constantly without always sending the
         // note-off first. Letting both sound leaves the older voice with no
         // note-off that will ever match it — an instrument that never dies.
         self.release_key(ch, key);
         let hz = self.note_hz_for(ch, key);
-        let Some(res) = self.resident[id as usize].as_ref() else { return };
+        let Some(res) = self.bank.get(id) else { return };
         let si = res.patch.select_index(hz);
         let s = res.patch.samples[si];
         let v = self.alloc_voice();
@@ -595,8 +585,9 @@ impl Synth {
         // wash down to the initial strike. Only an envelope-less sample has
         // nothing to end it, so there the loop must run out to the sample end.
         let n = self.notes[v];
-        let has_env = self.resident[n.patch as usize]
-            .as_ref()
+        let has_env = self
+            .bank
+            .get(n.patch)
             .is_some_and(|res| res.patch.samples[n.sample as usize].envelope);
         if !has_env {
             self.engine.voices[v].loop_mode = LoopMode::None;
@@ -617,7 +608,7 @@ impl Synth {
     /// one-segment ramp generator.
     fn start_stage(&mut self, v: usize, stage: u8) {
         let n = self.notes[v];
-        let Some(res) = self.resident[n.patch as usize].as_ref() else { return };
+        let Some(res) = self.bank.get(n.patch) else { return };
         let s = res.patch.samples[n.sample as usize];
         if !s.envelope || stage as usize >= 6 {
             // No envelope: play flat at the note's peak.
@@ -659,7 +650,7 @@ impl Synth {
                 continue;
             }
             let hz = self.note_hz_for(ch, n.key);
-            let Some(res) = self.resident[n.patch as usize].as_ref() else { continue };
+            let Some(res) = self.bank.get(n.patch) else { continue };
             let s = res.patch.samples[n.sample as usize];
             self.engine.voices[v].inc = pitch_inc(&s, hz, self.out_rate);
         }
@@ -704,7 +695,7 @@ impl Synth {
                 continue; // no voice sounding at this frame yet
             }
             let mut ev = Events::default();
-            let (l, r) = self.engine.mix_frame(&self.pool, self.out_rate, self.out_rate, &mut ev);
+            let (l, r) = self.engine.mix_frame(&self.bank.pool, self.out_rate, self.out_rate, &mut ev);
             slot.0 += (l * gain.0) >> 16;
             slot.1 += (r * gain.1) >> 16;
             if ev.ramp_irq != 0 {
@@ -828,9 +819,10 @@ mod tests {
     }
 
     fn synth() -> alloc::boxed::Box<Synth> {
-        let mut s = Synth::new_boxed();
+        let mut bank = Bank::new();
+        assert!(bank.load_patch(0, &tiny_patch()), "fixture must parse");
+        let mut s = Synth::new_boxed(alloc::boxed::Box::leak(alloc::boxed::Box::new(bank)));
         s.init();
-        assert!(s.load_patch(0, &tiny_patch()), "fixture must parse");
         s
     }
 

--- a/lib/sound/src/midi.rs
+++ b/lib/sound/src/midi.rs
@@ -24,6 +24,7 @@
 use crate::pat::Patch;
 use crate::{Engine, Events, LoopMode, MAX_VOICES, volume};
 use alloc::boxed::Box;
+use alloc::collections::VecDeque;
 use alloc::vec::Vec;
 
 /// General MIDI melodic programs 0-127 → `dgguspat` patch file stems.
@@ -208,6 +209,11 @@ pub struct Synth {
     clock: u64,
     /// The host's mix rate, needed to turn a pitch into an address increment.
     out_rate: u32,
+    /// MIDI bytes stamped with the absolute mix-frame they arrived at, applied
+    /// inside [`mix_into`](Self::mix_into) at that exact frame. This makes note
+    /// onset timing independent of the mix block size — a large output buffer no
+    /// longer quantises notes to its boundary. FIFO, frames non-decreasing.
+    timed: VecDeque<(u64, u8)>,
 }
 
 impl Synth {
@@ -228,6 +234,7 @@ impl Synth {
             in_sysex: false,
             clock: 0,
             out_rate: 44_100,
+            timed: VecDeque::new(),
         })
     }
 
@@ -306,6 +313,25 @@ impl Synth {
     }
 
     // ── the MIDI wire ────────────────────────────────────────────────────
+
+    /// Enqueue a MIDI byte stamped at absolute mix-frame `frame`; it is applied
+    /// inside [`mix_into`](Self::mix_into) when rendering reaches that frame, so
+    /// its note onset lands at the right sub-block position regardless of block
+    /// size. Frames must be non-decreasing (wire arrival order). The ring is
+    /// bounded; a pathological overrun falls back to applying immediately.
+    pub fn write_at(&mut self, frame: u64, b: u8) {
+        if self.timed.len() >= 8192 {
+            self.write(b);
+            return;
+        }
+        self.timed.push_back((frame, b));
+    }
+
+    /// Bytes are queued to start a note but not yet applied — the producer must
+    /// keep mixing until they are (`mixing()` alone would stop too early).
+    pub fn has_pending(&self) -> bool {
+        !self.timed.is_empty()
+    }
 
     /// Feed one byte of the MIDI stream. Handles running status, ignores
     /// real-time bytes, and swallows SysEx.
@@ -646,20 +672,37 @@ impl Synth {
         self.engine.any_running()
     }
 
-    /// Sum the synth into `block` at the host's mix rate, scaled by `gain`
-    /// (Q16). Envelope stages advance on the engine's ramp events, so the
-    /// whole six-stage envelope runs inside the mix with no clock.
-    pub fn mix_into(&mut self, rate: u32, gain: (i32, i32), block: &mut [(i32, i32)]) {
+    /// Sum the synth into `block` (absolute mix-frame `base`) at the host's mix
+    /// rate, scaled by `gain` (Q16). Timed MIDI bytes ([`write_at`](Self::write_at))
+    /// are applied at their stamped frame *inside* the loop, so a note starts at
+    /// its sub-block sample position — onset timing is independent of block size.
+    /// Envelope stages advance on the engine's ramp events, so the whole
+    /// six-stage envelope runs inside the mix with no clock.
+    pub fn mix_into(&mut self, rate: u32, base: u64, gain: (i32, i32), block: &mut [(i32, i32)]) {
         // The host's rate is authoritative and can change between sessions;
         // adopting it here means a caller never has to remember to announce it.
         self.set_rate(rate);
-        if !self.mixing() {
+        if self.timed.is_empty() && !self.mixing() {
             return;
         }
         // The bank is recorded at assorted rates; the engine resamples per
         // voice from its increment, so the "native" rate here is just the
         // output rate — one engine step per output frame.
-        for slot in block.iter_mut() {
+        for (i, slot) in block.iter_mut().enumerate() {
+            let abs = base + i as u64;
+            // Apply every byte due at or before this frame first, so a note-on
+            // stamped mid-block starts a voice exactly here (a byte stamped
+            // before `base` — the producer caught up past it — applies at i=0).
+            while let Some(&(f, b)) = self.timed.front() {
+                if f > abs {
+                    break;
+                }
+                self.timed.pop_front();
+                self.write(b);
+            }
+            if !self.mixing() {
+                continue; // no voice sounding at this frame yet
+            }
             let mut ev = Events::default();
             let (l, r) = self.engine.mix_frame(&self.pool, self.out_rate, self.out_rate, &mut ev);
             slot.0 += (l * gain.0) >> 16;
@@ -800,7 +843,7 @@ mod tests {
                 return (true, i * 64);
             }
             block.fill((0, 0));
-            s.mix_into(44_100, (1 << 16, 1 << 16), &mut block);
+            s.mix_into(44_100, 0, (1 << 16, 1 << 16), &mut block);
         }
         (!s.mixing(), limit)
     }
@@ -812,7 +855,7 @@ mod tests {
         s.write(60);
         s.write(100);
         let mut block = [(0i32, 0i32); 64];
-        s.mix_into(44_100, (1 << 16, 1 << 16), &mut block);
+        s.mix_into(44_100, 0, (1 << 16, 1 << 16), &mut block);
         assert!(s.mixing(), "the note must be sounding");
         s.write(0x80);
         s.write(60);
@@ -869,7 +912,7 @@ mod tests {
         s.write(60);
         s.write(0);
         let mut block = [(0i32, 0i32); 64];
-        s.mix_into(44_100, (1 << 16, 1 << 16), &mut block);
+        s.mix_into(44_100, 0, (1 << 16, 1 << 16), &mut block);
         assert!(s.mixing(), "the pedal must hold the note");
         s.write(0xB0);
         s.write(121);
@@ -891,7 +934,7 @@ mod tests {
         s.write(60);
         s.write(100);
         let mut block = [(0i32, 0i32); 64];
-        s.mix_into(44_100, (1 << 16, 1 << 16), &mut block);
+        s.mix_into(44_100, 0, (1 << 16, 1 << 16), &mut block);
         let v = (0..MAX_VOICES)
             .find(|&i| s.notes[i].active)
             .expect("a voice must be sounding");

--- a/lib/src/vga_render.rs
+++ b/lib/src/vga_render.rs
@@ -553,24 +553,98 @@ impl Pal {
 
 /// Render ONE source scanline into `out`, in the framebuffer's format.
 ///
-/// This is the whole renderer surface the present path needs: the caller walks
-/// source rows, stretches each one and copies it to the output rows it covers,
-/// so no full-frame intermediate is ever materialised and every mode takes the
-/// same path. `out` must hold at least `dimensions(frame.mode).0` pixels.
-pub fn render_row(frame: &Frame, sy: usize, pal: &Pal, out: &mut [u32]) {
+/// This is the whole renderer surface the present path needs: the caller
+/// walks source rows and copies each stretched row to the output rows it
+/// covers, so no full-frame intermediate is ever materialised and every mode
+/// takes the same path.
+///
+/// Horizontal-stretch cursor, templated on `N = ceil(out_w / w)` — the
+/// constant overwrite width, so each pixel's run is N straight-line stores
+/// with no per-pixel loop. The cursor advances by the true Bresenham run
+/// (`out_w/w` or one more), so the overwrite overshoots at most one pixel,
+/// harmlessly covered by the next run; `out` carries `N` slack past `out_w`
+/// for the last one. `N = 0` is the dynamic-width instance for ratios no
+/// constant was compiled for.
+struct StretchRow<'a, const N: usize> {
+    out: &'a mut [u32],
+    o: usize,
+    err: usize,
+    base: usize,
+    rem: usize,
+    w: usize,
+}
+
+impl<const N: usize> StretchRow<'_, N> {
+    #[inline]
+    fn put(&mut self, v: u32) {
+        if N == 0 {
+            self.out[self.o..self.o + self.base + 1].fill(v);
+        } else {
+            self.out[self.o..self.o + N].copy_from_slice(&[v; N]);
+        }
+        self.err += self.rem;
+        self.o += self.base + if self.err >= self.w { self.err -= self.w; 1 } else { 0 };
+    }
+}
+
+fn row_stretched<const N: usize>(
+    frame: &Frame,
+    sy: usize,
+    pal: &Pal,
+    out: &mut [u32],
+    w: usize,
+    out_w: usize,
+) {
+    let st = &mut StretchRow::<N> {
+        out,
+        o: 0,
+        err: 0,
+        base: out_w / w,
+        rem: out_w % w,
+        w,
+    };
+    match frame.mode {
+        VgaMode::Mode13h => row_mode13(frame, sy, pal, st, w),
+        VgaMode::Text80x25 => row_text(frame, sy, pal, st, w),
+        VgaMode::Cga4 => row_cga4(frame, sy, pal, st, w),
+        VgaMode::Cga2 => row_cga2(frame, sy, pal, st, w),
+        VgaMode::Planar16 { row_bytes, .. } => row_planar16(frame, sy, pal, st, w, row_bytes as usize),
+        VgaMode::ModeX { row_bytes, .. } => row_modex(frame, sy, pal, st, w, row_bytes as usize),
+        VgaMode::LinearSvga { bpp, pitch, .. } => row_svga(frame, sy, pal, st, w, bpp, pitch as usize),
+    }
+}
+
+/// Colour-translate source row `sy` — ANY mode — directly into the
+/// `out_w`-wide stretch buffer `out` (sized with `ceil(out_w/w)` slack):
+/// translation and horizontal stretch in one pass, no source-width
+/// intermediate. The decoders emit strictly left-to-right; a malformed
+/// frame may stop early, leaving the buffer's tail untouched.
+pub fn render_row_stretched(frame: &Frame, sy: usize, pal: &Pal, out: &mut [u32], out_w: usize) {
     let (w, h) = dimensions(frame.mode);
-    if sy >= h || out.len() < w {
+    if sy >= h || w == 0 || out_w < w {
         return;
     }
-    let out = &mut out[..w];
-    match frame.mode {
-        VgaMode::Mode13h => row_mode13(frame, sy, pal, out, w),
-        VgaMode::Text80x25 => row_text(frame, sy, pal, out, w),
-        VgaMode::Cga4 => row_cga4(frame, sy, pal, out, w),
-        VgaMode::Cga2 => row_cga2(frame, sy, pal, out, w),
-        VgaMode::Planar16 { row_bytes, .. } => row_planar16(frame, sy, pal, out, w, row_bytes as usize),
-        VgaMode::ModeX { row_bytes, .. } => row_modex(frame, sy, pal, out, w, row_bytes as usize),
-        VgaMode::LinearSvga { bpp, pitch, .. } => row_svga(frame, sy, pal, out, w, bpp, pitch as usize),
+    let n = out_w.div_ceil(w);
+    if out.len() < out_w + n {
+        return;
+    }
+    // Constant-width instances for the ratios real panels produce (text
+    // 720-wide → 2-3, CGA 640 → 2-4, 320-wide sources → 4-12); rarer
+    // ratios take the dynamic-width instance.
+    match n {
+        1 => row_stretched::<1>(frame, sy, pal, out, w, out_w),
+        2 => row_stretched::<2>(frame, sy, pal, out, w, out_w),
+        3 => row_stretched::<3>(frame, sy, pal, out, w, out_w),
+        4 => row_stretched::<4>(frame, sy, pal, out, w, out_w),
+        5 => row_stretched::<5>(frame, sy, pal, out, w, out_w),
+        6 => row_stretched::<6>(frame, sy, pal, out, w, out_w),
+        7 => row_stretched::<7>(frame, sy, pal, out, w, out_w),
+        8 => row_stretched::<8>(frame, sy, pal, out, w, out_w),
+        9 => row_stretched::<9>(frame, sy, pal, out, w, out_w),
+        10 => row_stretched::<10>(frame, sy, pal, out, w, out_w),
+        11 => row_stretched::<11>(frame, sy, pal, out, w, out_w),
+        12 => row_stretched::<12>(frame, sy, pal, out, w, out_w),
+        _ => row_stretched::<0>(frame, sy, pal, out, w, out_w),
     }
 }
 
@@ -585,26 +659,26 @@ fn row_origin(frame: &Frame, sy: usize) -> (usize, usize, usize) {
     }
 }
 
-fn row_mode13(frame: &Frame, sy: usize, pal: &Pal, out: &mut [u32], w: usize) {
+fn row_mode13<const N: usize>(frame: &Frame, sy: usize, pal: &Pal, st: &mut StretchRow<N>, w: usize) {
     let (start, pan, ry) = row_origin(frame, sy);
     let base = start + ry * w + pan;
-    for (x, px) in out.iter_mut().enumerate() {
-        *px = pal.lut[frame.vram.get(base + x).copied().unwrap_or(0) as usize];
+    for x in 0..w {
+        st.put(pal.lut[frame.vram.get(base + x).copied().unwrap_or(0) as usize]);
     }
 }
 
-fn row_modex(frame: &Frame, sy: usize, pal: &Pal, out: &mut [u32], w: usize, row_bytes: usize) {
+fn row_modex<const N: usize>(frame: &Frame, sy: usize, pal: &Pal, st: &mut StretchRow<N>, w: usize, row_bytes: usize) {
     let rb = if row_bytes == 0 { w / 4 } else { row_bytes };
     let (start, pan, ry) = row_origin(frame, sy);
-    for (x, px) in out.iter_mut().enumerate() {
+    for x in 0..w {
         let sx = x + pan;
         let off = start + ry * rb + sx / 4;
         let idx = frame.planes.get((sx & 3) * 0x10000 + off).copied().unwrap_or(0);
-        *px = pal.lut[idx as usize];
+        st.put(pal.lut[idx as usize]);
     }
 }
 
-fn row_planar16(frame: &Frame, sy: usize, pal: &Pal, out: &mut [u32], w: usize, row_bytes: usize) {
+fn row_planar16<const N: usize>(frame: &Frame, sy: usize, pal: &Pal, st: &mut StretchRow<N>, w: usize, row_bytes: usize) {
     let rb = if row_bytes == 0 { w / 8 } else { row_bytes };
     let (start, pan, ry) = row_origin(frame, sy);
     // Per SOURCE BYTE: fetch its 4 plane bytes once (64K apart) and spread them
@@ -620,7 +694,7 @@ fn row_planar16(frame: &Frame, sy: usize, pal: &Pal, out: &mut [u32], w: usize, 
         let p3 = frame.planes.get(0x30000 + off).copied().unwrap_or(0) as usize;
         let pix = SPREAD[p0] | (SPREAD[p1] << 1) | (SPREAD[p2] << 2) | (SPREAD[p3] << 3);
         while bit < 8 && x < w {
-            out[x] = pal.lut[planar_index(frame, ((pix >> (4 * bit)) & 0xF) as u8) as usize];
+            st.put(pal.lut[planar_index(frame, ((pix >> (4 * bit)) & 0xF) as u8) as usize]);
             bit += 1;
             x += 1;
         }
@@ -629,26 +703,26 @@ fn row_planar16(frame: &Frame, sy: usize, pal: &Pal, out: &mut [u32], w: usize, 
     }
 }
 
-fn row_cga4(frame: &Frame, sy: usize, pal: &Pal, out: &mut [u32], w: usize) {
+fn row_cga4<const N: usize>(frame: &Frame, sy: usize, pal: &Pal, st: &mut StretchRow<N>, w: usize) {
     // CGA's four colours are fixed, not DAC entries — encode them once per row.
     let c: [u32; 4] = core::array::from_fn(|i| pal.fmt.encode(frame.cga_palette[i]));
     let bank = (sy & 1) * 0x2000 + (sy >> 1) * (w / 4);
-    for (x, px) in out.iter_mut().enumerate() {
+    for x in 0..w {
         let byte = frame.vram.get(bank + x / 4).copied().unwrap_or(0);
-        *px = c[((byte >> (6 - (x & 3) * 2)) & 0x03) as usize];
+        st.put(c[((byte >> (6 - (x & 3) * 2)) & 0x03) as usize]);
     }
 }
 
-fn row_cga2(frame: &Frame, sy: usize, pal: &Pal, out: &mut [u32], w: usize) {
+fn row_cga2<const N: usize>(frame: &Frame, sy: usize, pal: &Pal, st: &mut StretchRow<N>, w: usize) {
     let (bg, fg) = (pal.fmt.encode(frame.cga_palette[0]), pal.fmt.encode(frame.cga_palette[1]));
     let bank = (sy & 1) * 0x2000 + (sy >> 1) * (w / 8);
-    for (x, px) in out.iter_mut().enumerate() {
+    for x in 0..w {
         let byte = frame.vram.get(bank + x / 8).copied().unwrap_or(0);
-        *px = if byte & (0x80 >> (x & 7)) != 0 { fg } else { bg };
+        st.put(if byte & (0x80 >> (x & 7)) != 0 { fg } else { bg });
     }
 }
 
-fn row_text(frame: &Frame, sy: usize, pal: &Pal, out: &mut [u32], w: usize) {
+fn row_text<const N: usize>(frame: &Frame, sy: usize, pal: &Pal, st: &mut StretchRow<N>, w: usize) {
     let (trow, gy) = (sy / CELL_H, sy % CELL_H);
     if frame.font.len() < 256 * 16 || trow >= TEXT_ROWS {
         return;
@@ -673,23 +747,23 @@ fn row_text(frame: &Frame, sy: usize, pal: &Pal, out: &mut [u32], w: usize) {
                 break;
             }
             let on = if gx < 8 { bits & (0x80 >> gx) != 0 } else { line_gfx && bits & 0x01 != 0 };
-            out[x] = if on { fg } else { bg };
+            st.put(if on { fg } else { bg });
         }
     }
 }
 
-fn row_svga(frame: &Frame, sy: usize, pal: &Pal, out: &mut [u32], w: usize, bpp: u8, pitch: usize) {
+fn row_svga<const N: usize>(frame: &Frame, sy: usize, pal: &Pal, st: &mut StretchRow<N>, w: usize, bpp: u8, pitch: usize) {
     let bpp8 = (bpp as usize).div_ceil(8);
     let pitch = if pitch == 0 { w * bpp8 } else { pitch };
     let vram = frame.vram;
     let rd16 = |p: usize| (vram.get(p).copied().unwrap_or(0) as u16)
         | ((vram.get(p + 1).copied().unwrap_or(0) as u16) << 8);
     let base = sy * pitch;
-    for (x, px) in out.iter_mut().enumerate() {
+    for x in 0..w {
         let p = base + x * bpp8;
         // 8bpp is a DAC index like every other mode; the direct-colour depths
         // carry their own channels and need encoding per pixel.
-        *px = match bpp {
+        st.put(match bpp {
             8 => pal.lut[vram.get(p).copied().unwrap_or(0) as usize],
             15 => {
                 let v = rd16(p);
@@ -709,7 +783,7 @@ fn row_svga(frame: &Frame, sy: usize, pal: &Pal, out: &mut [u32], w: usize, bpp:
                 let r = vram.get(p + 2).copied().unwrap_or(0) as u32;
                 pal.fmt.encode((r << 16) | (g << 8) | b)
             }
-        };
+        });
     }
 }
 

--- a/lib/src/vga_render.rs
+++ b/lib/src/vga_render.rs
@@ -1154,6 +1154,7 @@ pub const OVERLAY_CELL_H: usize = 16;
 /// Fill a `rw`×`rh` rectangle at pixel (`x`,`y`) with one `0x00RRGGBB` colour,
 /// encoded through `fmt`. `out` is pitched by `stride`; `w`/`h` clip to the
 /// visible area (a GOP `stride` may exceed `w`).
+#[allow(clippy::too_many_arguments)] // flat blit params; a rect struct would be ceremony for two callers
 pub fn overlay_fill(
     out: &mut [u32], stride: usize, w: usize, h: usize,
     x: usize, y: usize, rw: usize, rh: usize, rgb: u32, fmt: PixelFormat,
@@ -1174,6 +1175,7 @@ pub fn overlay_fill(
 /// Draw a CP437 byte string at pixel (`x`,`y`) with `FONT_8X16`, `fg`/`bg` as
 /// `0x00RRGGBB` encoded through `fmt`. One 8×16 cell per byte; stops at the
 /// right/bottom clip edge.
+#[allow(clippy::too_many_arguments)] // flat blit params; a rect struct would be ceremony for two callers
 pub fn overlay_text(
     out: &mut [u32], stride: usize, w: usize, h: usize,
     x: usize, y: usize, s: &[u8], fg: u32, bg: u32, fmt: PixelFormat,

--- a/lib/src/vga_render.rs
+++ b/lib/src/vga_render.rs
@@ -580,7 +580,14 @@ impl<const N: usize> StretchRow<'_, N> {
         if N == 0 {
             self.out[self.o..self.o + self.base + 1].fill(v);
         } else {
-            self.out[self.o..self.o + N].copy_from_slice(&[v; N]);
+            // Plain stores, deliberately: `copy_from_slice`/`fill` on a
+            // const-width slice may still lower to a memcpy/memset CALL per
+            // pixel on a size-optimized build — measured as a 2x raster
+            // regression. A counted store loop compiles to N inline stores.
+            let run = &mut self.out[self.o..self.o + N];
+            for d in run {
+                *d = v;
+            }
         }
         self.err += self.rem;
         self.o += self.base + if self.err >= self.w { self.err -= self.w; 1 } else { 0 };

--- a/run.sh
+++ b/run.sh
@@ -741,9 +741,13 @@ launch_qemu_uefi() {
         -device nvme,drive=esp,serial=esp0
     )
 
-    DISPLAY_ARGS=()
+    # Same display policy as the BIOS branch: default to SDL, NOT the GTK
+    # default — QEMU's GTK UI only repaints when its main loop goes idle, and
+    # SB16 ISA DMA (--sound sb) keeps i8257_dma_run() spinning so the window
+    # freezes on the last frame while the guest runs fine (QEMU LP#1873769).
+    DISPLAY_ARGS=(-display "${QEMU_DISPLAY:-sdl}")
     if [ "$QEMU_HEADLESS" = 1 ]; then
-        DISPLAY_ARGS+=(-display none)
+        DISPLAY_ARGS=(-display none)
     fi
 
     # -cpu max: the default qemu64 model lacks VME, forcing the kernel's software


### PR DESCRIPTION
## Summary

The interrupt-driven audio rework and everything it shook loose, verified end to end on QEMU (TCG + KVM) and on the ALC298 laptop.

**Audio production model**
- HDA/AC97 production driven by buffer-completion IRQs (canonical MSI boundary; MSI-only HDA bring-up).
- Drain-clock invariants: `consumed ≤ emitted` clamp (one stale position read can no longer leap the drain a full ring), codec-lap = snap + clean re-prime — kills the QEMU echo and the resync storms.
- Real-hardware cursor handling: the laptop's AMD controller never writes the DMA position buffer; the driver latches posbuf on first nonzero read, else uses SDLPIB.
- `audio_service` named as the per-slice half (trigger IRQs, one-byte DMA probe completions, GF1 timers, MPU drain) vs the tick-gated pump — the MI2 probe contract is now structural, with a bisect-proven regression fixed.
- SB16 sink (Phase A), universal ~12 ms pipe, drain smoothing.

**General MIDI**
- The GM bank is kernel ROM burned at boot (lib `Bank` split from `Synth`; case-insensitive path/name resolution — real ext4 disks are mixed-case). No loading in the audio path, no per-program duplication, instant complete music.
- MPU bytes stamped at the production frontier; the free-running arrival clock (the "GM start delay": Dark Forces' fanfare 3 s late) is deleted.
- Music level rebalanced ×2 (WAV-measured ~-6 dB under digital SFX).

**Display**
- Raster-beam presenter: bounded band per event-loop pass, every pixel repainted every period (no diff state to go stale), content-span sweep with one-shot clear at mode switch.
- The beam's CRTC-derived vertical blank IS the guest's 0x3DA retrace; presents on blank entry.
- Fused colour-translate+stretch (`StretchRow<const N>`, plain stores — `copy_from_slice` lowered to memcpy-per-pixel), 16-byte NT device copies on bare metal (measured: rep movsd wins under hypervisors, movntdq on real WC).
- Native-mode boot request (no more panel-stretched 1024×768), per-slice display profiling.

**DPMI/kernel**
- espfix: 64K-aligned trap stack + GDT alias so IRET to 16-bit stacks leaks no kernel ESP31:16.
- Stale register high halves kept out of 32-bit pointer returns (DOS/16M DUKE3D music SEGV).
- Event-loop per-exit overhead cuts with per-routine profiler buckets.
- run.sh: UEFI branch defaults to SDL (the --sound sb GTK-freeze footgun), honors QEMU_DISPLAY.

## Verification
- QEMU KVM/TCG: DOOM/DOOM2/MI2 boot-and-play classifiers, screendumps, hda diag counters clean (dropped=0, resyncs=0), WAV RMS balance measurements.
- Metal (ALC298 laptop): sound confirmed by ear — clean stream, instant GM start, full bank, native resolution.
- `//lib:sound` tests pass; MI2 regression bisected and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEAvFt3ydqc1SzvdZkRAsh