### PR TITLE
NativeSb: legacy machines get the real Sound Blaster natively

### DIFF
--- a/kernel/src/kernel/platform.rs
+++ b/kernel/src/kernel/platform.rs
@@ -71,11 +71,19 @@ pub enum Firmware {
 /// and sound's port-window signature cache.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Audio {
-    /// A real Sound Blaster 16 answered the DSP reset/probe (legacy metal, QEMU
-    /// `sb16`): the software SB/GUS/GM are emulated as usual and their canonical
+    /// A real Sound Blaster answered on a LEGACY machine (real VGA scanout —
+    /// the 386/486/Pentium class, and QEMU's BIOS path with `-device sb16`):
+    /// the guest owns the card NATIVELY. DSP traffic forwards straight to the
+    /// hardware, guest 8237 programming is remapped onto the real chip, the
+    /// card's IRQ reaches the guest vPIC — zero kernel mixing, no kernel
+    /// sink, and no GM bank ROM is burned. Old hardware cannot afford the
+    /// emulated stack and does not need it: the machine IS the sound card the
+    /// games were written for.
+    NativeSb,
+    /// A real Sound Blaster 16 answered on a MODERN (non-legacy-VGA) machine:
+    /// the software SB/GUS/GM are emulated as usual and their canonical
     /// PCM renders out the real SB16 as the kernel `sound` sink (`drivers::sb16`,
-    /// 16-bit auto-init DMA on channel 5, IRQ 5). (Phase B will make ownership of
-    /// the card movable — handing it to the guest for native SB playback.)
+    /// 16-bit auto-init DMA on channel 5, IRQ 5).
     RealSb,
     /// No card; the software SB16 renders through the kernel sound API into an
     /// Intel HD Audio controller found on PCI (QEMU `intel-hda`, modern metal).
@@ -97,7 +105,7 @@ impl Audio {
     /// present it is a kernel sink, not guest-owned — so this is always false.
     /// Phase B makes it dynamic (true while a DOS program drives the card).
     pub fn sb_passthrough(self) -> bool {
-        false
+        matches!(self, Audio::NativeSb)
     }
 }
 
@@ -218,6 +226,15 @@ pub fn probe<A: crate::Arch>(machine: &mut A, boot: &crate::BootConfig) -> &'sta
             Firmware::Substitute
         };
 
+        // The audio mode follows the machine class: a real SB on a machine
+        // whose display is a real VGA is the legacy class — the guest gets
+        // the card natively (see Audio::NativeSb). The same card on a
+        // modern machine stays a kernel sink.
+        let audio = if audio == Audio::RealSb && matches!(display, Display::VgaCard) {
+            Audio::NativeSb
+        } else {
+            audio
+        };
         Platform {
             host: env.host(boot.is_qemu),
             display,

--- a/kernel/src/kernel/sound.rs
+++ b/kernel/src/kernel/sound.rs
@@ -143,7 +143,7 @@ pub fn play<A: crate::Arch>(machine: &mut A, rate: u32, fmt: Format, bytes: &[u8
             return;
         }
         Audio::EmulatedPortWindow => {}
-        Audio::EmulatedSilent => return,
+        Audio::NativeSb | Audio::EmulatedSilent => return,
     }
     if LAST_RATE.swap(rate, Ordering::Relaxed) != rate {
         machine.outw(AUDIO_SIG, rate as u16);
@@ -167,7 +167,7 @@ pub fn stop<A: crate::Arch>(machine: &mut A, park: bool) {
     match crate::kernel::platform::get().audio {
         Audio::EmulatedHda => crate::kernel::drivers::hda::stop(machine, park),
         Audio::RealSb => crate::kernel::drivers::sb16::stop(machine, park),
-        Audio::EmulatedAc97 | Audio::EmulatedPortWindow | Audio::EmulatedSilent => {}
+        Audio::NativeSb | Audio::EmulatedAc97 | Audio::EmulatedPortWindow | Audio::EmulatedSilent => {}
     }
 }
 
@@ -189,7 +189,7 @@ pub fn position<A: crate::Arch>(machine: &mut A) -> Option<(u64, u64)> {
         Audio::EmulatedHda => crate::kernel::drivers::hda::position(),
         Audio::EmulatedAc97 => crate::kernel::drivers::ac97::position(machine),
         Audio::RealSb => crate::kernel::drivers::sb16::position(machine),
-        Audio::EmulatedPortWindow | Audio::EmulatedSilent => None,
+        Audio::NativeSb | Audio::EmulatedPortWindow | Audio::EmulatedSilent => None,
     }
 }
 
@@ -205,7 +205,7 @@ pub fn min_fill(rate: u32) -> Option<u32> {
         Audio::EmulatedHda => crate::kernel::drivers::hda::present(),
         Audio::EmulatedAc97 => crate::kernel::drivers::ac97::present(),
         Audio::RealSb => crate::kernel::drivers::sb16::present(),
-        Audio::EmulatedPortWindow | Audio::EmulatedSilent => false,
+        Audio::NativeSb | Audio::EmulatedPortWindow | Audio::EmulatedSilent => false,
     };
     present.then(|| rate * PIPE_MS / 1000)
 }

--- a/kernel/src/kernel/startup.rs
+++ b/kernel/src/kernel/startup.rs
@@ -73,8 +73,14 @@ pub fn startup<A: crate::Arch>(machine: &mut A, boot: &crate::BootConfig, mut sc
         .collect();
     mount_filesystems(&parts, platform.hostfs, &mut screen);
     // Burn the GM bank ROM while long work is still legal (no guest yet):
-    // the shipped bank lives under the C: root beside the GUS patches.
-    crate::kernel::midi_bank::load_from_c_root(crate::kernel::dos::c_root());
+    // the shipped bank lives under the C: root beside the GUS patches. A
+    // native-SB (legacy) machine gets no emulated GM and cannot afford the
+    // ~5 MB; a silent machine has nothing to render it to.
+    match platform.audio {
+        crate::kernel::platform::Audio::NativeSb
+        | crate::kernel::platform::Audio::EmulatedSilent => {}
+        _ => crate::kernel::midi_bank::load_from_c_root(crate::kernel::dos::c_root()),
+    }
     init_device_policy(machine, platform);
     let master_env = load_master_env();
     init_console_pipe();


### PR DESCRIPTION
Revives the passthrough path behind a platform verdict: a real SB on a legacy machine (real VGA scanout) is handed to the guest natively — no kernel mixing, no sink, no 5 MB GM bank burn. The same card on a modern machine keeps the Phase A kernel-sink behaviour. One universal kernel; the probe decides once.

Verified: `qemu --kvm --sound sb` → `audio=NativeSb`, zero bank burn, DOOM playing through QEMU's sb16/adlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEAvFt3ydqc1SzvdZkRAsh