### PR TITLE
Audio mode follows the card; display follows the firmware

### DIFF
--- a/arch-abi/src/lib.rs
+++ b/arch-abi/src/lib.rs
@@ -47,6 +47,14 @@ pub struct BootConfig {
     /// Host is QEMU-like: fabricate the synthetic 0x3DA vtrace etc. (vs Bochs /
     /// real hardware, whose 0x3DA is passed through).
     pub is_qemu: bool,
+    /// `audio=mixed`: on a BIOS machine with a real Sound Blaster, run the
+    /// EMULATED sound stack (SB + OPL + GUS + GM mixed in software, rendered
+    /// out the card) instead of handing the card to the guest. Buys wavetable
+    /// GUS/GM music on an SB-only machine at the cost of mixing everything —
+    /// a CPU-budget judgment that only the machine's owner can make, so it is
+    /// a knob and never a probe heuristic. Ignored on UEFI machines, which
+    /// have no ISA card to hand over and always mix.
+    pub audio_mixed: bool,
 }
 
 impl BootConfig {
@@ -55,7 +63,7 @@ impl BootConfig {
             cmdline: [0; 4096], cmdline_len: None,
             cwd: [0; 256], cwd_len: None,
             c_root: [0; 128], c_root_len: 0,
-            debug_watch: None, is_qemu: false,
+            debug_watch: None, is_qemu: false, audio_mixed: false,
         };
         // Default C: root = "home/retroos/".
         let d = *b"home/retroos/";

--- a/etc/CONFIG.SYS
+++ b/etc/CONFIG.SYS
@@ -5,6 +5,13 @@
 
 COMSPEC=C:\BOOT\COMMAND.COM
 PATH=C:\;C:\BOOT;C:\TC;C:\BORLANDC\BIN
+# Sound Blaster ownership. native = the guest drives the real card itself
+# (no kernel mixing, no GM bank) — the only thing a 386/486, 86Box or Bochs
+# can afford. mixed = emulate SB+OPL+GUS+GM and mix them out the card, which
+# buys wavetable GUS/GM music on an SB-only machine if the CPU can spare it.
+# Machines without a real SB (HDA/AC'97) always mix and ignore this.
+SB_AUDIO=native
+
 ADLIB=A388
 BLASTER=A220 I7 D1 H5 P330 T6
 ULTRASND=240,3,3,5,5

--- a/kernel/src/arch/boot.rs
+++ b/kernel/src/arch/boot.rs
@@ -298,6 +298,10 @@ fn read_boot_config() -> crate::BootConfig {
     if let Some(n) = read_named(b"opt/debug-watch", &mut dw) {
         cfg.debug_watch = crate::parse_debug_watch(&dw[..n]);
     }
+    let mut audio = [0u8; 16];
+    if let Some(n) = read_named(b"opt/audio", &mut audio) {
+        cfg.audio_mixed = audio[..n].starts_with(b"mixed");
+    }
     cfg
 }
 

--- a/kernel/src/kernel/dos/mod.rs
+++ b/kernel/src/kernel/dos/mod.rs
@@ -65,6 +65,13 @@ pub use dos::parse_config_env;
 /// BootConfig.c_root; read by the bootfs mount and the DN/CONFIG launch paths.
 pub use dfs::{set_c_root, c_root};
 
+/// Look up `KEY` in a DOS environment block (the parsed CONFIG.SYS master
+/// env). Startup reads boot policy out of it — `SB_AUDIO=` — before any
+/// guest exists.
+pub fn config_var<'a>(env: &'a [u8], key: &[u8]) -> Option<&'a [u8]> {
+    machine::env_var(env, key)
+}
+
 // Stub array / slot table / IRQ-stack constants live in `dos.rs` (alongside
 // the INT handlers that own them); the `dpmi` sibling module also reads them
 // when wiring PM↔RM control flow. Re-import here so both can write

--- a/kernel/src/kernel/drivers/sb16.rs
+++ b/kernel/src/kernel/drivers/sb16.rs
@@ -3,7 +3,7 @@
 //! On a machine whose real sound hardware is a Sound Blaster 16, the emulated
 //! cards (`vsb`/`vgus`/`vmpu`) produce canonical PCM and the kernel `sound`
 //! layer needs somewhere to play it. This driver is that sink: `sound::play`
-//! dispatches here when the platform probe found a real SB16 (`Audio::RealSb`).
+//! dispatches here when the platform probe found a real SB16 (`Audio::SbSink`).
 //!
 //! It drives the real DSP for **16-bit signed-stereo auto-init DMA** on the ISA
 //! 8237 (channel 5) — the SB16's own double-buffer scheme, where each completed
@@ -121,7 +121,7 @@ pub fn scan<A: crate::Arch>(machine: &mut A) -> bool {
 
 /// Bring up the SB16 the platform probe found. Driver init only.
 pub fn init<A: crate::Arch>(machine: &mut A) {
-    if crate::kernel::platform::get().audio != crate::kernel::platform::Audio::RealSb {
+    if crate::kernel::platform::get().audio != crate::kernel::platform::Audio::SbSink {
         return;
     }
     if bring_up(machine) {

--- a/kernel/src/kernel/platform.rs
+++ b/kernel/src/kernel/platform.rs
@@ -14,6 +14,8 @@ use crate::println;
 pub struct Platform {
     pub host: Host,
     pub display: Display,
+    /// What sound hardware answered (probe fact).
+    pub audio_hw: AudioHw,
     pub firmware: Firmware,
     pub audio: Audio,
     /// A host filesystem transport answered — the native backend punch-through
@@ -66,9 +68,42 @@ pub enum Firmware {
     Substitute,
 }
 
-/// The audio path — exactly one of these is true, decided here. Replaces
-/// three lazy probes: vsb's `ensure_mode` (SB card), ac97's PRESENT atomic,
-/// and sound's port-window signature cache.
+/// What sound hardware answered — pure probe fact, no policy. Which of
+/// these the guest may drive itself, and what the kernel does with the rest,
+/// is [`Audio`], decided later from the boot config.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum AudioHw {
+    /// A real Sound Blaster answered a DSP reset with 0xAA.
+    Sb,
+    /// An Intel HD Audio controller on PCI (class 04:03).
+    Hda,
+    /// An AC'97 codec on PCI.
+    Ac97,
+    /// A backend installed a sink behind the canonical port window (hosted).
+    PortWindow,
+    /// Nothing answered.
+    None,
+}
+
+impl AudioHw {
+    /// The default verdict for this hardware, before config policy: a real
+    /// SB is the guest's (only card a DOS program can drive; the cheapest
+    /// thing a slow machine can do), everything else is the kernel's to
+    /// emulate through.
+    fn default_verdict(self) -> Audio {
+        match self {
+            AudioHw::Sb => Audio::NativeSb,
+            AudioHw::Hda => Audio::EmulatedHda,
+            AudioHw::Ac97 => Audio::EmulatedAc97,
+            AudioHw::PortWindow => Audio::EmulatedPortWindow,
+            AudioHw::None => Audio::EmulatedSilent,
+        }
+    }
+}
+
+/// The audio path — who owns the sound hardware and what renders through
+/// it. Derived from [`AudioHw`] plus the boot config's `SB_AUDIO=` policy
+/// (`apply_audio_mode`), never probed directly.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Audio {
     /// A real Sound Blaster answered on a LEGACY machine (real VGA scanout —
@@ -187,7 +222,7 @@ static mut PLATFORM: Option<Platform> = None;
 /// `startup` — after the heap, before threading (still single-threaded, so
 /// the write-once static needs no lock).
 pub fn probe<A: crate::Arch>(machine: &mut A, boot: &crate::BootConfig) -> &'static Platform {
-    let audio = probe_audio(machine);
+    let audio_hw = probe_audio(machine);
     // A native host backend (hosted "punch-through") means /host is available
     // without COM1 — take it as hostfs-present and skip the serial probe.
     // Otherwise fall back to the COM1 transport (metal, or the Python bridge).
@@ -232,30 +267,15 @@ pub fn probe<A: crate::Arch>(machine: &mut A, boot: &crate::BootConfig) -> &'sta
             Firmware::Substitute
         };
 
-        // Display and sound are decided on independent axes.
-        //
-        // The DISPLAY axis is firmware: a BIOS machine has a real VGA that
-        // scans out its own memory (nothing for us to do), a UEFI machine
-        // has a dumb framebuffer we raster into. That is `display` above.
-        //
-        // The SOUND axis is the CARD. HDA and AC'97 are PCI codecs no DOS
-        // program can drive, so they are always emulated-and-mixed — true
-        // on a UEFI laptop and equally on a BIOS-era PCI machine (native
-        // VGA, emulated sound). Only a real Sound Blaster is a card the
-        // guest itself can drive, so only there is there a choice, and it
-        // is the owner's: native by default (guest owns the card, no
-        // kernel mixing, no bank ROM — what a 386/486 can afford) or
-        // emulated when they want GUS/GM music on a machine fast enough to
-        // mix it (`audio=mixed`).
-        let audio = match audio {
-            Audio::NativeSb | Audio::SbSink if boot.audio_mixed => Audio::SbSink,
-            other => other,
-        };
+
         Platform {
             host: env.host(boot.is_qemu),
             display,
             firmware,
-            audio,
+            audio_hw,
+            // Policy comes later, when CONFIG.SYS is readable
+            // (`apply_audio_mode`); until then, the hardware's default.
+            audio: audio_hw.default_verdict(),
             hostfs,
             debug: env.debug,
         }
@@ -274,6 +294,29 @@ pub fn probe<A: crate::Arch>(machine: &mut A, boot: &crate::BootConfig) -> &'sta
 
 /// The frozen platform description. Panics if `probe` has not run — an init
 /// ordering bug that should be loud.
+/// Apply the boot config's sound-mode policy to the frozen probe. Called
+/// exactly once by `startup`, after the mounts make CONFIG.SYS readable and
+/// before anything reads `audio` (io_policy's IOPB build, the bank burn, the
+/// first guest).
+///
+/// The probe reports which card answered; this decides who owns it. Only a
+/// real Sound Blaster is guest-drivable, so only there is there a choice —
+/// HDA/AC'97 are PCI codecs no DOS program can address and are always
+/// emulated. `mixed` costs a software mix of every source plus the ~5 MB GM
+/// bank, and buys GUS/GM wavetable music on an SB-only machine; `native`
+/// hands the card over and costs the kernel nothing, which is what a 386/486
+/// (and the 86Box/Bochs emulations of one) can afford.
+pub fn apply_audio_mode(mixed: bool) {
+    let p = unsafe { (&raw mut PLATFORM).as_mut().unwrap().as_mut() }
+        .expect("platform::apply_audio_mode before probe");
+    p.audio = match (p.audio_hw, mixed) {
+        (AudioHw::Sb, true) => Audio::SbSink,
+        (hw, _) => hw.default_verdict(),
+    };
+    crate::println!("Audio: {:?} ({})", p.audio,
+        if mixed { "SB_AUDIO=mixed" } else { "SB_AUDIO=native" });
+}
+
 pub fn get() -> &'static Platform {
     unsafe {
         (&raw const PLATFORM)
@@ -299,23 +342,20 @@ pub fn probed() -> bool {
 /// installed a sink. Card presence is machine-wide, so the probe uses the
 /// canonical SB base 0x220 (a per-thread BLASTER override relocates the
 /// guest-visible base, not the card).
-fn probe_audio<A: crate::Arch>(machine: &mut A) -> Audio {
-    // A real SB answers a DSP reset with 0xAA. Whether the guest owns it or
-    // the kernel mixes through it is decided by the caller (firmware class +
-    // the owner's `audio=` choice); this is only "a card is there".
+fn probe_audio<A: crate::Arch>(machine: &mut A) -> AudioHw {
     if crate::kernel::drivers::sb16::scan(machine) {
-        return Audio::NativeSb;
+        return AudioHw::Sb;
     }
     if crate::kernel::drivers::hda::scan(machine).is_some() {
-        return Audio::EmulatedHda;
+        return AudioHw::Hda;
     }
     if crate::kernel::drivers::ac97::scan(machine).is_some() {
-        return Audio::EmulatedAc97;
+        return AudioHw::Ac97;
     }
     if crate::kernel::sound::window_present(machine) {
-        return Audio::EmulatedPortWindow;
+        return AudioHw::PortWindow;
     }
-    Audio::EmulatedSilent
+    AudioHw::None
 }
 
 

--- a/kernel/src/kernel/platform.rs
+++ b/kernel/src/kernel/platform.rs
@@ -80,11 +80,15 @@ pub enum Audio {
     /// emulated stack and does not need it: the machine IS the sound card the
     /// games were written for.
     NativeSb,
-    /// A real Sound Blaster 16 answered on a MODERN (non-legacy-VGA) machine:
-    /// the software SB/GUS/GM are emulated as usual and their canonical
-    /// PCM renders out the real SB16 as the kernel `sound` sink (`drivers::sb16`,
-    /// 16-bit auto-init DMA on channel 5, IRQ 5).
-    RealSb,
+    /// A real Sound Blaster on a BIOS machine that the owner chose to run
+    /// EMULATED (`audio=mixed`): the software SB/GUS/GM are emulated as usual
+    /// and their canonical PCM renders out the real card as the kernel `sound`
+    /// sink (`drivers::sb16`, 16-bit auto-init DMA on channel 5, IRQ 5). Buys
+    /// GUS/GM music on a machine that only has an SB — DOOM with wavetable
+    /// MIDI on a fast Pentium — at the cost of mixing every source in
+    /// software. Not a probe verdict: one card has one owner, so this is a
+    /// judgment about CPU budget that only the machine's owner can make.
+    SbSink,
     /// No card; the software SB16 renders through the kernel sound API into an
     /// Intel HD Audio controller found on PCI (QEMU `intel-hda`, modern metal).
     EmulatedHda,
@@ -104,6 +108,8 @@ impl Audio {
     /// vs the software DSP. Phase A always emulates — even with a real SB16
     /// present it is a kernel sink, not guest-owned — so this is always false.
     /// Phase B makes it dynamic (true while a DOS program drives the card).
+    /// The guest owns the Sound Blaster: its DSP/mixer ports are granted
+    /// through the IOPB and its DMA is remapped onto the real 8237.
     pub fn sb_passthrough(self) -> bool {
         matches!(self, Audio::NativeSb)
     }
@@ -226,14 +232,24 @@ pub fn probe<A: crate::Arch>(machine: &mut A, boot: &crate::BootConfig) -> &'sta
             Firmware::Substitute
         };
 
-        // The audio mode follows the machine class: a real SB on a machine
-        // whose display is a real VGA is the legacy class — the guest gets
-        // the card natively (see Audio::NativeSb). The same card on a
-        // modern machine stays a kernel sink.
-        let audio = if audio == Audio::RealSb && matches!(display, Display::VgaCard) {
-            Audio::NativeSb
-        } else {
-            audio
+        // Display and sound are decided on independent axes.
+        //
+        // The DISPLAY axis is firmware: a BIOS machine has a real VGA that
+        // scans out its own memory (nothing for us to do), a UEFI machine
+        // has a dumb framebuffer we raster into. That is `display` above.
+        //
+        // The SOUND axis is the CARD. HDA and AC'97 are PCI codecs no DOS
+        // program can drive, so they are always emulated-and-mixed — true
+        // on a UEFI laptop and equally on a BIOS-era PCI machine (native
+        // VGA, emulated sound). Only a real Sound Blaster is a card the
+        // guest itself can drive, so only there is there a choice, and it
+        // is the owner's: native by default (guest owns the card, no
+        // kernel mixing, no bank ROM — what a 386/486 can afford) or
+        // emulated when they want GUS/GM music on a machine fast enough to
+        // mix it (`audio=mixed`).
+        let audio = match audio {
+            Audio::NativeSb | Audio::SbSink if boot.audio_mixed => Audio::SbSink,
+            other => other,
         };
         Platform {
             host: env.host(boot.is_qemu),
@@ -284,9 +300,11 @@ pub fn probed() -> bool {
 /// canonical SB base 0x220 (a per-thread BLASTER override relocates the
 /// guest-visible base, not the card).
 fn probe_audio<A: crate::Arch>(machine: &mut A) -> Audio {
-    // A real SB16 answers a DSP reset with 0xAA — it becomes the kernel sink.
+    // A real SB answers a DSP reset with 0xAA. Whether the guest owns it or
+    // the kernel mixes through it is decided by the caller (firmware class +
+    // the owner's `audio=` choice); this is only "a card is there".
     if crate::kernel::drivers::sb16::scan(machine) {
-        return Audio::RealSb;
+        return Audio::NativeSb;
     }
     if crate::kernel::drivers::hda::scan(machine).is_some() {
         return Audio::EmulatedHda;

--- a/kernel/src/kernel/sound.rs
+++ b/kernel/src/kernel/sound.rs
@@ -111,7 +111,7 @@ pub fn on_irq<A: crate::Arch>(machine: &mut A, event: crate::Irq) -> bool {
         {
             crate::kernel::drivers::ac97::on_irq(machine)
         }
-        (Audio::RealSb, crate::Irq::Hw(line))
+        (Audio::SbSink, crate::Irq::Hw(line))
             if Some(line) == crate::kernel::drivers::sb16::irq_line() =>
         {
             let ours = crate::kernel::drivers::sb16::on_irq(machine);
@@ -138,7 +138,7 @@ pub fn play<A: crate::Arch>(machine: &mut A, rate: u32, fmt: Format, bytes: &[u8
             crate::kernel::drivers::ac97::play(machine, rate, fmt, bytes);
             return;
         }
-        Audio::RealSb => {
+        Audio::SbSink => {
             crate::kernel::drivers::sb16::play(machine, rate, fmt, bytes);
             return;
         }
@@ -166,7 +166,7 @@ pub fn stop<A: crate::Arch>(machine: &mut A, park: bool) {
     use crate::kernel::platform::Audio;
     match crate::kernel::platform::get().audio {
         Audio::EmulatedHda => crate::kernel::drivers::hda::stop(machine, park),
-        Audio::RealSb => crate::kernel::drivers::sb16::stop(machine, park),
+        Audio::SbSink => crate::kernel::drivers::sb16::stop(machine, park),
         Audio::NativeSb | Audio::EmulatedAc97 | Audio::EmulatedPortWindow | Audio::EmulatedSilent => {}
     }
 }
@@ -188,7 +188,7 @@ pub fn position<A: crate::Arch>(machine: &mut A) -> Option<(u64, u64)> {
     match crate::kernel::platform::get().audio {
         Audio::EmulatedHda => crate::kernel::drivers::hda::position(),
         Audio::EmulatedAc97 => crate::kernel::drivers::ac97::position(machine),
-        Audio::RealSb => crate::kernel::drivers::sb16::position(machine),
+        Audio::SbSink => crate::kernel::drivers::sb16::position(machine),
         Audio::NativeSb | Audio::EmulatedPortWindow | Audio::EmulatedSilent => None,
     }
 }
@@ -204,7 +204,7 @@ pub fn min_fill(rate: u32) -> Option<u32> {
     let present = match crate::kernel::platform::get().audio {
         Audio::EmulatedHda => crate::kernel::drivers::hda::present(),
         Audio::EmulatedAc97 => crate::kernel::drivers::ac97::present(),
-        Audio::RealSb => crate::kernel::drivers::sb16::present(),
+        Audio::SbSink => crate::kernel::drivers::sb16::present(),
         Audio::NativeSb | Audio::EmulatedPortWindow | Audio::EmulatedSilent => false,
     };
     present.then(|| rate * PIPE_MS / 1000)

--- a/kernel/src/kernel/startup.rs
+++ b/kernel/src/kernel/startup.rs
@@ -72,9 +72,21 @@ pub fn startup<A: crate::Arch>(machine: &mut A, boot: &crate::BootConfig, mut sc
         .flat_map(|&d| crate::kernel::block::partition::scan(crate::kernel::block::Volume::whole(d)))
         .collect();
     mount_filesystems(&parts, platform.hostfs, &mut screen);
+
+    // CONFIG.SYS is readable now: apply its sound-mode policy before anything
+    // consumes the verdict (IOPB grants, the bank burn, the first guest).
+    // `SB_AUDIO=native|mixed`; QEMU's `-fw_cfg opt/audio=mixed` overrides it
+    // for testing without editing the disk.
+    let master_env = load_master_env();
+    let mixed = boot.audio_mixed
+        || crate::kernel::dos::config_var(&master_env, b"SB_AUDIO")
+            .is_some_and(|v| v.eq_ignore_ascii_case(b"mixed"));
+    crate::kernel::platform::apply_audio_mode(mixed);
+    let platform = crate::kernel::platform::get();
+
     // Burn the GM bank ROM while long work is still legal (no guest yet):
     // the shipped bank lives under the C: root beside the GUS patches. A
-    // native-SB (legacy) machine gets no emulated GM and cannot afford the
+    // native-SB machine has no emulated GM to feed and cannot afford the
     // ~5 MB; a silent machine has nothing to render it to.
     match platform.audio {
         crate::kernel::platform::Audio::NativeSb
@@ -82,7 +94,6 @@ pub fn startup<A: crate::Arch>(machine: &mut A, boot: &crate::BootConfig, mut sc
         _ => crate::kernel::midi_bank::load_from_c_root(crate::kernel::dos::c_root()),
     }
     init_device_policy(machine, platform);
-    let master_env = load_master_env();
     init_console_pipe();
 
     run(machine, boot, &master_env, &mut threads, screen)

--- a/run.sh
+++ b/run.sh
@@ -8,6 +8,8 @@
 #
 #   BACKEND        qemu | bochs | 86box | hosted   (default: qemu)
 #   --firmware     bios | uefi                     (default: bios; qemu/bochs only)
+#   --sb-audio     native | mixed                  (qemu only: fw_cfg override of
+#                  CONFIG.SYS's SB_AUDIO — who owns a real SB, the guest or our mixer)
 #   --sound        sb | ac97 | hda | none          (default: sb; ac97/hda qemu only,
 #                                                   incl. qemu --firmware uefi)
 #   --arch         386 | 686 | x64                 (default: 386; qemu/bochs only)
@@ -83,6 +85,7 @@ HOSTED_TERMINAL=""
 
 # Passthrough args for the underlying emulator.
 PASS=()
+SB_AUDIO=""   # --sb-audio native|mixed: fw_cfg override of CONFIG.SYS's SB_AUDIO=
 
 # Optional leading positional BACKEND.
 case "${1:-}" in
@@ -95,6 +98,7 @@ while [ $# -gt 0 ]; do
         --backend)    BACKEND="$2"; shift 2 ;;
         --firmware)   FIRMWARE="$2"; shift 2 ;;
         --sound)      SOUND="$2"; shift 2 ;;
+        --sb-audio)   SB_AUDIO="$2"; shift 2 ;;
         --arch)       ARCH="$2"; ARCH_SET=1; shift 2 ;;
         -i|--image)   IMG="$2"; IMG_SET=1; shift 2 ;;
 
@@ -629,6 +633,7 @@ launch_qemu() {
     else
         IMAGE="$SCRIPT_DIR/bazel-bin/$IMAGE_FILE"
         FWCFG_ARGS=()
+        [ -n "$SB_AUDIO" ] && FWCFG_ARGS+=(-fw_cfg "name=opt/audio,string=$SB_AUDIO")
         FWCFG_TMPDIR=""
         # --cmd is the simple alias for the qemu cmdline (mirrors hosted --cmd),
         # so `run.sh qemu --cmd GAMES/DOOMS/DOOM.EXE` just runs it from the disk.
@@ -758,6 +763,7 @@ launch_qemu_uefi() {
     # --cmd / -r autostart (same as the BIOS path): pass the program path via
     # fw_cfg opt/cmdline; the kernel (boot.rs read_named) execs it instead of DN.
     local FWCFG_ARGS=()
+    [ -n "$SB_AUDIO" ] && FWCFG_ARGS+=(-fw_cfg "name=opt/audio,string=$SB_AUDIO")
     [ -z "$START_BIN" ] && [ -n "${HOSTED_CMD:-}" ] && START_BIN="$HOSTED_CMD"
     if [ -n "$START_BIN" ]; then
         printf '%s' "$START_BIN" > "$WORK/cmdline"


### PR DESCRIPTION
Splits the two axes that were conflated in #35:

- **display ← firmware**: BIOS = native VGA scanout, UEFI = emulated raster.
- **sound ← the card**: HDA/AC'97 are PCI codecs no DOS game can drive → always emulated + mixed (true on a UEFI laptop *and* on a BIOS-era PCI machine). Only a real SB is guest-drivable → native by default, or emulated via the owner's `audio=mixed` knob (fw_cfg `opt/audio`) for wavetable GUS/GM music on an SB-only machine.

Drops the unreachable "modern machine with an ISA SB" state; the sink variant is now `Audio::SbSink`, reachable only by explicit choice.

Verified on `qemu --kvm`: BIOS+sb → `NativeSb`/no bank; BIOS+sb+`opt/audio=mixed` → `SbSink`/bank; UEFI+hda → framebuffer/bank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEAvFt3ydqc1SzvdZkRAsh