### PR TITLE
BLASTER authoritative; native mode passes SB, OPL and MPU through

### DIFF
--- a/kernel/src/kernel/dos/machine/vmpu.rs
+++ b/kernel/src/kernel/dos/machine/vmpu.rs
@@ -33,9 +33,16 @@ impl Mpu {
         }
     }
 
-    /// Ports this device decodes, once the machine says it exists.
+    /// Ports this device decodes, once the machine says it exists. In
+    /// native-SB mode it decodes nothing: the guest is driving real
+    /// silicon, and whatever answers at the declared MPU port — an MPU-401,
+    /// a wavetable daughterboard, an external module — is the owner's
+    /// hardware, not ours to intercept. (Our synth could not sound anyway:
+    /// native burns no GM bank.)
     pub fn owns(&self, p: u16) -> bool {
-        self.present && self.card.owns(p)
+        self.present
+            && !crate::kernel::platform::get().audio.sb_passthrough()
+            && self.card.owns(p)
     }
 
     /// Apply the guest's environment: the MPU port comes from `BLASTER`'s

--- a/kernel/src/kernel/dos/machine/vsb.rs
+++ b/kernel/src/kernel/dos/machine/vsb.rs
@@ -629,13 +629,14 @@ impl SoundBlaster {
         // Host side: what the physical card reported (SB16 mixer) or the
         // owner declared. Only meaningful when a real card is there; the
         // emulated-only machine leaves these unknown and never remaps.
-        if let Some(card) = crate::kernel::platform::get().sb_card {
+        let plat = crate::kernel::platform::get();
+        if let Some(card) = plat.sb_card {
             self.io_base_host = card.base;
-            if let Some(w) = card.wiring {
-                self.host_irq = w.irq;
-                self.host_dma8 = w.dma8;
-                self.host_dma16 = w.dma16.unwrap_or(0xFF);
-            }
+        }
+        if let Some(w) = plat.sb_wiring {
+            self.host_irq = w.irq;
+            self.host_dma8 = w.dma8;
+            self.host_dma16 = w.dma16.unwrap_or(0xFF);
         }
         let Some(val) = env_var(env, b"BLASTER") else { return };
         for tok in val.split(|&b| b == b' ').filter(|t| !t.is_empty()) {

--- a/kernel/src/kernel/dos/mod.rs
+++ b/kernel/src/kernel/dos/mod.rs
@@ -72,31 +72,6 @@ pub fn config_var<'a>(env: &'a [u8], key: &[u8]) -> Option<&'a [u8]> {
     machine::env_var(env, key)
 }
 
-/// Replace (or add) `KEY=VALUE` in a DOS environment block. Startup uses it
-/// to fabricate `BLASTER` from the detected card in native mode.
-pub fn set_config_var(env: &mut alloc::vec::Vec<u8>, key: &[u8], val: &[u8]) {
-    let mut out = alloc::vec::Vec::with_capacity(env.len() + key.len() + val.len() + 2);
-    let mut i = 0;
-    while i < env.len() && env[i] != 0 {
-        let end = env[i..].iter().position(|&b| b == 0).map(|p| i + p).unwrap_or(env.len());
-        let entry = &env[i..end];
-        let keep = match entry.iter().position(|&b| b == b'=') {
-            Some(eq) => !entry[..eq].eq_ignore_ascii_case(key),
-            None => true,
-        };
-        if keep {
-            out.extend_from_slice(entry);
-            out.push(0);
-        }
-        i = end + 1;
-    }
-    out.extend_from_slice(key);
-    out.push(b'=');
-    out.extend_from_slice(val);
-    out.push(0);
-    out.push(0);
-    *env = out;
-}
 
 // Stub array / slot table / IRQ-stack constants live in `dos.rs` (alongside
 // the INT handlers that own them); the `dpmi` sibling module also reads them

--- a/kernel/src/kernel/io_policy.rs
+++ b/kernel/src/kernel/io_policy.rs
@@ -39,6 +39,15 @@ pub fn apply<A: crate::Arch>(machine: &mut A, personality: &Personality<A>, focu
             // answers FM detection.
             if platform::get().audio.sb_passthrough() {
                 machine.allow_io_ports(0x388, 2);
+                // The MPU-401 window the guest declared (BLASTER `P`). In
+                // native mode the emulated MPU stands down, so these reach
+                // whatever the owner actually has there — a real MPU, a
+                // wavetable daughterboard, an external module.
+                if let Personality::Dos(dos) = personality
+                    && dos.pc.mpu.present
+                {
+                    machine.allow_io_ports(dos.pc.mpu.base, 2);
+                }
             }
         }
         // Linux: no ports. The deny-all baseline stands.

--- a/kernel/src/kernel/platform.rs
+++ b/kernel/src/kernel/platform.rs
@@ -19,6 +19,12 @@ pub struct Platform {
     /// The real Sound Blaster's own report, when one answered: base,
     /// generation, and (SB16 only) its strapped IRQ/DMA.
     pub sb_card: Option<crate::kernel::drivers::sb16::SbCard>,
+    /// The physical card's wiring: read from an SB16's mixer, or declared
+    /// for an early card (`SB_AUDIO=native <irq> <dma>`). This is the HOST
+    /// side — which line the PIC delivers and which 8237 channels we
+    /// reprogram. The guest's own IRQ/DMA are labels it picks in BLASTER;
+    /// the relay and the DMA remap translate between them.
+    pub sb_wiring: Option<crate::kernel::drivers::sb16::SbWiring>,
     pub firmware: Firmware,
     pub audio: Audio,
     /// A host filesystem transport answered — the native backend punch-through
@@ -278,6 +284,9 @@ pub fn probe<A: crate::Arch>(machine: &mut A, boot: &crate::BootConfig) -> &'sta
             firmware,
             audio_hw,
             sb_card,
+            // Filled by `apply_audio_mode`, which also sees the owner's
+            // declaration for cards that cannot report their straps.
+            sb_wiring: sb_card.and_then(|c| c.wiring),
             // Policy comes later, when CONFIG.SYS is readable
             // (`apply_audio_mode`); until then, the hardware's default.
             audio: audio_hw.default_verdict(),
@@ -311,13 +320,18 @@ pub fn probe<A: crate::Arch>(machine: &mut A, boot: &crate::BootConfig) -> &'sta
 /// bank, and buys GUS/GM wavetable music on an SB-only machine; `native`
 /// hands the card over and costs the kernel nothing, which is what a 386/486
 /// (and the 86Box/Bochs emulations of one) can afford.
-pub fn apply_audio_mode(mixed: bool) {
+pub fn apply_audio_mode(
+    mixed: bool,
+    declared: Option<crate::kernel::drivers::sb16::SbWiring>,
+) {
     let p = unsafe { (&raw mut PLATFORM).as_mut().unwrap().as_mut() }
         .expect("platform::apply_audio_mode before probe");
     p.audio = match (p.audio_hw, mixed) {
         (AudioHw::Sb, true) => Audio::SbSink,
         (hw, _) => hw.default_verdict(),
     };
+    // An SB16 reports its own straps; anything older needs the owner's.
+    p.sb_wiring = p.sb_card.and_then(|c| c.wiring).or(declared);
     crate::println!("Audio: {:?} ({})", p.audio,
         if mixed { "SB_AUDIO=mixed" } else { "SB_AUDIO=native" });
 }

--- a/kernel/src/kernel/startup.rs
+++ b/kernel/src/kernel/startup.rs
@@ -77,7 +77,7 @@ pub fn startup<A: crate::Arch>(machine: &mut A, boot: &crate::BootConfig, mut sc
     // consumes the verdict (IOPB grants, the bank burn, the first guest).
     // `SB_AUDIO=native|mixed`; QEMU's `-fw_cfg opt/audio=mixed` overrides it
     // for testing without editing the disk.
-    let mut master_env = load_master_env();
+    let master_env = load_master_env();
     let sb_audio = crate::kernel::dos::config_var(&master_env, b"SB_AUDIO")
         .map(alloc::vec::Vec::from)
         .unwrap_or_default();
@@ -98,36 +98,52 @@ pub fn startup<A: crate::Arch>(machine: &mut A, boot: &crate::BootConfig, mut sc
     //            software and the owner declares them on the SB_AUDIO line
     //            (`SB_AUDIO=native <irq> <dma8>`). Nothing is guessed — a
     //            wrong IRQ silently swallows every completion.
+    // BLASTER is authoritative in both modes — it declares the card the
+    // guest sees, and the owner sets it to whatever their games expect.
+    //
+    // In MIXED mode that card is ours, so every value is honoured as-is.
+    //
+    // In NATIVE mode the guest drives real silicon, and only one of those
+    // values is physical: the PORT is granted through the IOPB, so the
+    // guest's writes land wherever BLASTER points — the card's base or
+    // nothing at all. IRQ and DMA are labels the machine translates (the
+    // card's line is relayed onto the guest's vPIC line, its 8237 channels
+    // are remapped onto the card's), so those stay free. We verify rather
+    // than rewrite: a mismatch is the owner's to fix, and silently
+    // "correcting" it would break the games whose own configs agree with
+    // CONFIG.SYS.
     if platform.audio == crate::kernel::platform::Audio::NativeSb
         && let Some(card) = platform.sb_card
     {
+        let blaster = crate::kernel::dos::config_var(&master_env, b"BLASTER")
+            .map(alloc::vec::Vec::from)
+            .unwrap_or_default();
+        match blaster_base(&blaster) {
+            Some(b) if b == card.base => {}
+            Some(b) => crate::println!(
+                "Audio: BLASTER declares A{:03X} but the card answers at {:#05X} — the guest will \
+                 find no card there. Fix BLASTER in CONFIG.SYS (or move the card).",
+                b, card.base
+            ),
+            None => crate::println!(
+                "Audio: no BLASTER port declared, card is at {:#05X}", card.base
+            ),
+        }
         if platform.sb_wiring.is_none() {
             crate::println!(
-                "Audio: SB DSP {}.x cannot report its IRQ/DMA — declare the card's real ones as `SB_AUDIO=native <irq> <dma>` in CONFIG.SYS; sound is off until then",
+                "Audio: SB DSP {}.x cannot report its IRQ/DMA — declare the card's real ones as \
+                 `SB_AUDIO=native <irq> <dma>` in CONFIG.SYS; DMA cannot be remapped until then",
                 card.dsp_major
             );
         }
-        // The guest's BLASTER stays the owner's, verbatim: IRQ and DMA are
-        // only labels (the card's line is relayed onto the guest's vPIC
-        // line, its 8237 channels are remapped onto the card's), so a game
-        // with its own saved sound settings keeps working. The PORT is the
-        // exception — it is granted through the IOPB and the guest's writes
-        // land on the real card — so A must be the card's base, and a
-        // disagreeing CONFIG.SYS gets said out loud.
-        let cfg_blaster = crate::kernel::dos::config_var(&master_env, b"BLASTER")
-            .map(alloc::vec::Vec::from)
-            .unwrap_or_default();
-        if blaster_base(&cfg_blaster) != Some(card.base) {
+        if card.wiring.and_then(|w| w.dma16).is_none()
+            && blaster.split(|&b| b == b' ').any(|t| t.first().is_some_and(|c| c.eq_ignore_ascii_case(&b'H')))
+        {
             crate::println!(
-                "Audio: CONFIG.SYS BLASTER declares A{:03X}, the card answers at {:#05X} — using the card",
-                blaster_base(&cfg_blaster).unwrap_or(0), card.base
+                "Audio: BLASTER declares a 16-bit channel but a DSP {}.x card has none",
+                card.dsp_major
             );
         }
-        let keep_h = card.wiring.and_then(|w| w.dma16).is_some();
-        let blaster = rewrite_blaster_base(&cfg_blaster, card.base, keep_h);
-        crate::println!("Audio: native SB — BLASTER={}",
-            core::str::from_utf8(&blaster).unwrap_or("?"));
-        crate::kernel::dos::set_config_var(&mut master_env, b"BLASTER", &blaster);
     }
 
     // Burn the GM bank ROM while long work is still legal (no guest yet):
@@ -356,33 +372,6 @@ fn blaster_base(v: &[u8]) -> Option<u16> {
         }
     }
     None
-}
-
-/// The owner's BLASTER with its `A` token replaced by the card's real base
-/// — the one value that cannot be relabelled. `H` is dropped when the card
-/// has no 16-bit channel to remap onto.
-fn rewrite_blaster_base(v: &[u8], base: u16, keep_h: bool) -> alloc::vec::Vec<u8> {
-    use core::fmt::Write;
-    let mut out = alloc::vec::Vec::new();
-    struct W<'a>(&'a mut alloc::vec::Vec<u8>);
-    impl core::fmt::Write for W<'_> {
-        fn write_str(&mut self, s: &str) -> core::fmt::Result {
-            self.0.extend_from_slice(s.as_bytes());
-            Ok(())
-        }
-    }
-    let _ = write!(W(&mut out), "A{:03X}", base);
-    for tok in v.split(|&b| b == b' ').filter(|t| !t.is_empty()) {
-        match tok[0].to_ascii_uppercase() {
-            b'A' => {}
-            b'H' if !keep_h => {}
-            _ => {
-                out.push(b' ');
-                out.extend_from_slice(tok);
-            }
-        }
-    }
-    out
 }
 
 /// Allocate the console stdin pipe (keyboard → Linux stdin). The kernel

--- a/kernel/src/kernel/startup.rs
+++ b/kernel/src/kernel/startup.rs
@@ -83,7 +83,7 @@ pub fn startup<A: crate::Arch>(machine: &mut A, boot: &crate::BootConfig, mut sc
         .unwrap_or_default();
     let mixed = boot.audio_mixed
         || sb_audio.split(|&b| b == b' ').next().is_some_and(|m| m.eq_ignore_ascii_case(b"mixed"));
-    crate::kernel::platform::apply_audio_mode(mixed);
+    crate::kernel::platform::apply_audio_mode(mixed, parse_sb_wiring(&sb_audio));
     let platform = crate::kernel::platform::get();
 
     // BLASTER describes THE CARD THE GUEST SEES.
@@ -101,22 +101,33 @@ pub fn startup<A: crate::Arch>(machine: &mut A, boot: &crate::BootConfig, mut sc
     if platform.audio == crate::kernel::platform::Audio::NativeSb
         && let Some(card) = platform.sb_card
     {
-        let declared = parse_sb_wiring(&sb_audio);
-        match card.wiring.or(declared) {
-            Some(w) => {
-                let mut b = alloc::vec::Vec::new();
-                fmt_blaster(&mut b, card.base, w.irq, w.dma8, w.dma16);
-                crate::println!(
-                    "Audio: native SB — BLASTER={}",
-                    core::str::from_utf8(&b).unwrap_or("?")
-                );
-                crate::kernel::dos::set_config_var(&mut master_env, b"BLASTER", &b);
-            }
-            None => crate::println!(
-                "Audio: SB DSP {}.x at {:#05x} has no readable wiring — declare it as                  `SB_AUDIO=native <irq> <dma>` in CONFIG.SYS; sound is off until then",
-                card.dsp_major, card.base
-            ),
+        if platform.sb_wiring.is_none() {
+            crate::println!(
+                "Audio: SB DSP {}.x cannot report its IRQ/DMA — declare the card's real ones as `SB_AUDIO=native <irq> <dma>` in CONFIG.SYS; sound is off until then",
+                card.dsp_major
+            );
         }
+        // The guest's BLASTER stays the owner's, verbatim: IRQ and DMA are
+        // only labels (the card's line is relayed onto the guest's vPIC
+        // line, its 8237 channels are remapped onto the card's), so a game
+        // with its own saved sound settings keeps working. The PORT is the
+        // exception — it is granted through the IOPB and the guest's writes
+        // land on the real card — so A must be the card's base, and a
+        // disagreeing CONFIG.SYS gets said out loud.
+        let cfg_blaster = crate::kernel::dos::config_var(&master_env, b"BLASTER")
+            .map(alloc::vec::Vec::from)
+            .unwrap_or_default();
+        if blaster_base(&cfg_blaster) != Some(card.base) {
+            crate::println!(
+                "Audio: CONFIG.SYS BLASTER declares A{:03X}, the card answers at {:#05X} — using the card",
+                blaster_base(&cfg_blaster).unwrap_or(0), card.base
+            );
+        }
+        let keep_h = card.wiring.and_then(|w| w.dma16).is_some();
+        let blaster = rewrite_blaster_base(&cfg_blaster, card.base, keep_h);
+        crate::println!("Audio: native SB — BLASTER={}",
+            core::str::from_utf8(&blaster).unwrap_or("?"));
+        crate::kernel::dos::set_config_var(&mut master_env, b"BLASTER", &blaster);
     }
 
     // Burn the GM bank ROM while long work is still legal (no guest yet):
@@ -333,10 +344,26 @@ fn parse_u8(s: &[u8]) -> Option<u8> {
     (!s.is_empty() && n < 256).then_some(n as u8)
 }
 
-/// `A%03x I%d D%d[ H%d]` — the canonical BLASTER form. The 16-bit channel is
-/// only present on cards that have one.
-fn fmt_blaster(out: &mut alloc::vec::Vec<u8>, base: u16, irq: u8, dma8: u8, dma16: Option<u8>) {
+/// The `A` token of a BLASTER string, as a port number.
+fn blaster_base(v: &[u8]) -> Option<u16> {
+    for tok in v.split(|&b| b == b' ').filter(|t| !t.is_empty()) {
+        if tok[0].eq_ignore_ascii_case(&b'A') {
+            let mut n: u16 = 0;
+            for &c in &tok[1..] {
+                n = n * 16 + (c as char).to_digit(16)? as u16;
+            }
+            return Some(n);
+        }
+    }
+    None
+}
+
+/// The owner's BLASTER with its `A` token replaced by the card's real base
+/// — the one value that cannot be relabelled. `H` is dropped when the card
+/// has no 16-bit channel to remap onto.
+fn rewrite_blaster_base(v: &[u8], base: u16, keep_h: bool) -> alloc::vec::Vec<u8> {
     use core::fmt::Write;
+    let mut out = alloc::vec::Vec::new();
     struct W<'a>(&'a mut alloc::vec::Vec<u8>);
     impl core::fmt::Write for W<'_> {
         fn write_str(&mut self, s: &str) -> core::fmt::Result {
@@ -344,11 +371,18 @@ fn fmt_blaster(out: &mut alloc::vec::Vec<u8>, base: u16, irq: u8, dma8: u8, dma1
             Ok(())
         }
     }
-    let mut w = W(out);
-    let _ = write!(w, "A{:03X} I{} D{}", base, irq, dma8);
-    if let Some(h) = dma16 {
-        let _ = write!(w, " H{}", h);
+    let _ = write!(W(&mut out), "A{:03X}", base);
+    for tok in v.split(|&b| b == b' ').filter(|t| !t.is_empty()) {
+        match tok[0].to_ascii_uppercase() {
+            b'A' => {}
+            b'H' if !keep_h => {}
+            _ => {
+                out.push(b' ');
+                out.extend_from_slice(tok);
+            }
+        }
     }
+    out
 }
 
 /// Allocate the console stdin pipe (keyboard → Linux stdin). The kernel


### PR DESCRIPTION
Follow-up to #37, settling who owns what in native mode.

- **BLASTER is authoritative in both modes.** It declares the card the guest sees, and the owner sets it to whatever their games expect. Mixed honours every value (the card is ours). Native honours them too — IRQ and DMA are labels the machine translates (the card's line is relayed onto the guest's vPIC line; the guest's 8237 channels are remapped onto the card's), so games with their own saved sound settings keep working.
- **Only the port is physical**, since it is IOPB-granted: native *verifies* `A` against the detected card and barks on mismatch rather than silently rewriting it (a rewrite would break the games whose configs agree with CONFIG.SYS). Also barks when an early card's wiring was never declared, or when BLASTER claims a 16-bit channel a pre-SB16 card lacks.
- **The MPU window passes through in native.** Whatever sits at 0x330 — a real MPU-401, a wavetable daughterboard, an external module — is the owner's hardware; our emulated MPU stands down instead of answering detection and then playing silence (native burns no GM bank).

Verified on `qemu --kvm`: card relocated with `-device sb16,iobase=0x240` is found by the base sweep and the A220 mismatch is reported; default layout runs clean with `BLASTER=A220 I7 D1 H5 P330 T6` preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEAvFt3ydqc1SzvdZkRAsh