### PR TITLE
Translate the DSP window; correct why it is trapped

### DIFF
--- a/kernel/src/kernel/dos/machine/vsb.rs
+++ b/kernel/src/kernel/dos/machine/vsb.rs
@@ -225,8 +225,9 @@ impl SoundBlaster {
         // this atomically; the hardware ~3 µs hold is irrelevant under
         // emulation. Puts the DSP back in its post-power-on state so the
         // next program's reset+probe behaves like the first one's.
-        machine.outb(self.io_base + 0x06, 1);
-        machine.outb(self.io_base + 0x06, 0);
+        let reset = self.host_port(self.io_base + 0x06);
+        machine.outb(reset, 1);
+        machine.outb(reset, 0);
         // Stop any in-flight host DMA cold; the next bind reprograms and
         // unmasks. host_dma8/host_dma16 are the SB16's 8-bit/16-bit lines.
         mask_real_8237(machine, self.host_dma8);
@@ -245,6 +246,23 @@ impl SoundBlaster {
     /// virtual in passthrough.
     pub fn is_passthrough(&self, p: u16) -> bool {
         (p >= self.io_base && p < self.io_base + 0x10) || matches!(p, 0x388..=0x38B)
+    }
+
+    /// The physical port for a guest port in the DSP window. BLASTER is the
+    /// owner's declaration and the DSP window is trapped on every access
+    /// (we must see the command stream to remap DMA), so a card strapped
+    /// somewhere else costs nothing to support: same traps, different
+    /// addend. `io_base_host` is 0 before a card is detected, in which case
+    /// there is nothing to translate to.
+    #[inline]
+    fn host_port(&self, p: u16) -> u16 {
+        if self.io_base_host == 0 || self.io_base_host == self.io_base {
+            return p;
+        }
+        match p.checked_sub(self.io_base) {
+            Some(off) if off < 0x10 => self.io_base_host + off,
+            _ => p, // OPL and anything else is at a fixed address
+        }
     }
 
     /// Read an SB DSP/mixer/OPL passthrough port, with a tiny compatibility
@@ -283,7 +301,7 @@ impl SoundBlaster {
             // Auto-init transfers (8237 mode bit 4 set) are left alone: real
             // hardware keeps accepting commands between auto-init blocks, and
             // our auto-init clients (Quake, Dune2, ROTT) must not stall here.
-            let v = machine.inb(p);
+            let v = machine.inb(self.host_port(p));
             if self.dsp_single_cycle_busy(machine, dma) {
                 self.dsp_write_busy = self.dsp_write_busy.wrapping_add(1);
                 if self.dsp_write_busy & 8 != 0 {
@@ -292,7 +310,7 @@ impl SoundBlaster {
             }
             return v;
         }
-        machine.inb(p)
+        machine.inb(self.host_port(p))
     }
 
     /// True while a single-cycle DSP DMA transfer is genuinely mid-block: a
@@ -364,7 +382,7 @@ impl SoundBlaster {
                 }
             }
         }
-        machine.outb(p, val);
+        machine.outb(self.host_port(p), val);
     }
 
     /// DMA-port read. Two distinct sources of truth, never conflated:

--- a/kernel/src/kernel/dos/machine/vsb.rs
+++ b/kernel/src/kernel/dos/machine/vsb.rs
@@ -7,9 +7,21 @@
 //! the boot-time `platform::Audio` verdict.
 //!
 //!  - **Passthrough** — a real card answers (QEMU `sb16`/`adlib` on metal): DSP
-//!    traffic forwards to it, and the guest's DMA buffer is remapped contiguous
-//!    onto the real 8237 (`maybe_remap` → `arm`). No library card exists; this
-//!    is the kernel driving real hardware and cannot be anything else.
+//!    traffic forwards to it, and the guest's DMA buffer is aliased onto the
+//!    channel buffer the real 8237 transfers from (`maybe_remap` → `arm`;
+//!    the guest's pages are re-mapped, not copied, so its own writes land
+//!    where the card reads). No library card exists; this is the kernel
+//!    driving real hardware and cannot be anything else.
+//!
+//!    Note what does NOT drive that: the DSP window. `maybe_remap` runs off
+//!    the guest's 8237 port writes, and the SB is never told an address, so
+//!    passthrough could in principle grant the DSP ports outright. It stays
+//!    trapped for three things it buys instead: the write-status busy
+//!    flicker real chips pulse and QEMU's sb16 does not (Prince of Persia
+//!    spins on it), the E4h/E8h test-register answer, and — since every
+//!    access already traps — translating a guest window onto a card
+//!    strapped at a different base (`host_port`). DSP traffic is commands,
+//!    not sample data, so the exits are rare.
 //!  - **Emulated** — no card answers (the hosted interpreter, or metal with no
 //!    SB16): the library card runs the DSP command FSM and the play cursor,
 //!    and this file supplies it with everything spatial and temporal — the
@@ -249,11 +261,10 @@ impl SoundBlaster {
     }
 
     /// The physical port for a guest port in the DSP window. BLASTER is the
-    /// owner's declaration and the DSP window is trapped on every access
-    /// (we must see the command stream to remap DMA), so a card strapped
-    /// somewhere else costs nothing to support: same traps, different
-    /// addend. `io_base_host` is 0 before a card is detected, in which case
-    /// there is nothing to translate to.
+    /// owner's declaration; the window traps on every access, so a card
+    /// strapped somewhere else costs nothing to support — same traps, one
+    /// different addend. `io_base_host` is 0 before a card is detected, in
+    /// which case there is nothing to translate to.
     #[inline]
     fn host_port(&self, p: u16) -> u16 {
         if self.io_base_host == 0 || self.io_base_host == self.io_base {

--- a/kernel/src/kernel/startup.rs
+++ b/kernel/src/kernel/startup.rs
@@ -121,8 +121,8 @@ pub fn startup<A: crate::Arch>(machine: &mut A, boot: &crate::BootConfig, mut sc
         match blaster_base(&blaster) {
             Some(b) if b == card.base => {}
             Some(b) => crate::println!(
-                "Audio: BLASTER declares A{:03X} but the card answers at {:#05X} — the guest will \
-                 find no card there. Fix BLASTER in CONFIG.SYS (or move the card).",
+                "Audio: BLASTER declares A{:03X}, the card answers at {:#05X} — translating (the \
+                 DSP window traps anyway, so the guest sees its declared card)",
                 b, card.base
             ),
             None => crate::println!(


### PR DESCRIPTION
- **Port translation**: the DSP window traps on every access anyway, so a card strapped somewhere other than `BLASTER`'s `A` is one addend, not a failure — `host_port` maps the guest's declared window onto the card's real base at the single trap boundary. `BLASTER` stays authoritative in every particular: port translated here, IRQ relayed through the vPIC, DMA remapped through the virtual 8237.
- **Comment correction**: passthrough does *not* trap the DSP because "otherwise we would never see a transfer start". `maybe_remap` runs off the guest's 8237 port writes and the SB is never handed an address — the guest's buffer pages are aliased onto the channel buffer. Trapping buys the write-status busy flicker (the Prince of Persia hang), the E4h/E8h test-register answer, and the translation above.

Verified on `qemu --kvm` with `-device sb16,iobase=0x240` against a CONFIG.SYS declaring `A220`: the sweep finds DSP 4.x at 0x240, the translation is reported, and DOOM's sound init completes (`I_StartupSound` → `S_Init`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEAvFt3ydqc1SzvdZkRAsh