### PR TITLE
Per-port IOPB: trap only where the guest's card disagrees with the real one

### DIFF
--- a/kernel/src/kernel/dos/machine/vsb.rs
+++ b/kernel/src/kernel/dos/machine/vsb.rs
@@ -140,6 +140,9 @@ pub struct SoundBlaster {
     /// this is the sink's target.
     pub io_base_host: u16,
     dsp_test_reg: u8,
+    /// Last mixer index the guest selected (`base+0x04`), so `base+0x05`
+    /// can answer the wiring registers from the guest's own numbers.
+    mixer_idx: u8,
     dsp_read_data: Option<u8>,
     dsp_expect_test_write: bool,
     /// Parameter bytes still expected for the in-progress passthrough DSP
@@ -191,7 +194,7 @@ impl SoundBlaster {
             // remaps (and says so) rather than driving someone else's
             // channels.
             host_dma8: 0xFF, host_dma16: 0xFF, host_irq: 0xFF, io_base_host: 0,
-            dsp_test_reg: 0, dsp_read_data: None, dsp_expect_test_write: false,
+            dsp_test_reg: 0, mixer_idx: 0, dsp_read_data: None, dsp_expect_test_write: false,
             dsp_param_bytes: 0, dsp_dma_active: false, dsp_write_busy: 0,
             bound_chan: 0xFF, bound_host: 0xFF,
             bound_gpa: 0, bound_len: 0, bound_vpage: 0, bound_pages: 0,
@@ -256,6 +259,30 @@ impl SoundBlaster {
     /// 0x388-0x38B. In passthrough these go straight to the real card (QEMU
     /// `sb16`/`adlib`); emulated, to the library card. Only the 8237 is
     /// virtual in passthrough.
+    /// Ports inside the DSP window that MUST trap, as a mask of offsets
+    /// from `io_base`. Everything else can be granted to the guest outright
+    /// (the IOPB is per-port), so DSP traffic on a correctly-declared card
+    /// costs no exits at all.
+    ///
+    ///  * mixer index+data (0x04/0x05) — the wiring registers are
+    ///    virtualized (see `sb_read`), always.
+    ///  * the whole window when the card is strapped somewhere other than
+    ///    BLASTER's base: every access needs `host_port` translation.
+    ///  * DSP data/status (0x0A/0x0C/0x0E) under QEMU only, where the
+    ///    E4h/E8h test register and the write-status busy flicker must be
+    ///    synthesized because QEMU's sb16 lacks them. Real silicon has
+    ///    both, so metal grants them.
+    pub fn trap_mask(&self) -> u16 {
+        if self.io_base_host != 0 && self.io_base_host != self.io_base {
+            return 0xFFFF;
+        }
+        let mut m = (1u16 << 0x04) | (1u16 << 0x05);
+        if crate::kernel::platform::get().host == crate::kernel::platform::Host::Qemu {
+            m |= (1 << 0x0A) | (1 << 0x0C) | (1 << 0x0E);
+        }
+        m
+    }
+
     pub fn is_passthrough(&self, p: u16) -> bool {
         (p >= self.io_base && p < self.io_base + 0x10) || matches!(p, 0x388..=0x38B)
     }
@@ -283,6 +310,26 @@ impl SoundBlaster {
     pub fn sb_read<A: crate::Arch>(&mut self, machine: &mut A, dma: &Dma8237, p: u16) -> u8 {
         if self.emulated() {
             return self.core.port_read(p);
+        }
+        if p == self.io_base + 0x05 {
+            // Mixer data. Registers 0x80/0x81 report the IRQ and DMA the
+            // card is strapped to — physical facts the guest must NOT see
+            // in passthrough: it was told its own numbers by BLASTER, and
+            // the machine translates (the vPIC relays the card's line onto
+            // the guest's, the virtual 8237 remaps its channels). A guest
+            // believing the straps would hook a line we never raise. Every
+            // other mixer register is real state and passes through.
+            match self.mixer_idx {
+                0x80 => return match self.irq {
+                    2 => 0x01, 5 => 0x02, 7 => 0x04, 10 => 0x08, _ => 0x02,
+                },
+                0x81 => {
+                    let lo = match self.dma8 { 0 => 0x01, 1 => 0x02, 3 => 0x08, _ => 0x02 };
+                    let hi = match self.dma16 { 5 => 0x20, 6 => 0x40, 7 => 0x80, _ => 0 };
+                    return lo | hi;
+                }
+                _ => {}
+            }
         }
         if p == self.io_base + 0x0A {
             if let Some(v) = self.dsp_read_data.take() {
@@ -392,6 +439,14 @@ impl SoundBlaster {
                     _ => {}
                 }
             }
+        }
+        if p == self.io_base + 0x04 {
+            self.mixer_idx = val;
+        } else if p == self.io_base + 0x05 && matches!(self.mixer_idx, 0x80 | 0x81) {
+            // The guest may move ITS view of the wiring — the relay and the
+            // remap follow BLASTER — but the physical straps stay where the
+            // kernel found them; nothing else on the machine knows they moved.
+            return;
         }
         machine.outb(self.host_port(p), val);
     }

--- a/kernel/src/kernel/dos/machine/vsb.rs
+++ b/kernel/src/kernel/dos/machine/vsb.rs
@@ -264,19 +264,37 @@ impl SoundBlaster {
     /// (the IOPB is per-port), so DSP traffic on a correctly-declared card
     /// costs no exits at all.
     ///
-    ///  * mixer index+data (0x04/0x05) — the wiring registers are
-    ///    virtualized (see `sb_read`), always.
+    /// A port traps only where the guest's declared card DISAGREES with the
+    /// one that is there:
+    ///
     ///  * the whole window when the card is strapped somewhere other than
-    ///    BLASTER's base: every access needs `host_port` translation.
+    ///    BLASTER's base — every access needs `host_port` translation.
+    ///  * mixer index+data (0x04/0x05) when BLASTER's IRQ or DMA differ
+    ///    from the straps: registers 0x80/0x81 would otherwise report
+    ///    physical facts to a guest that was told labels, and it would hook
+    ///    a line we never raise (see `sb_read`). Where they agree, the card
+    ///    reports the guest's own numbers and needs no help.
     ///  * DSP data/status (0x0A/0x0C/0x0E) under QEMU only, where the
     ///    E4h/E8h test register and the write-status busy flicker must be
-    ///    synthesized because QEMU's sb16 lacks them. Real silicon has
-    ///    both, so metal grants them.
+    ///    synthesized because QEMU's sb16 lacks what real silicon has.
+    ///
+    /// So a BLASTER that matches the hardware on a real machine traps
+    /// nothing at all: the guest drives the card directly, exactly as it
+    /// would have on the bare metal of the era.
     pub fn trap_mask(&self) -> u16 {
         if self.io_base_host != 0 && self.io_base_host != self.io_base {
             return 0xFFFF;
         }
-        let mut m = (1u16 << 0x04) | (1u16 << 0x05);
+        let mut m = 0u16;
+        let strapped = crate::kernel::platform::get().sb_wiring;
+        let agrees = strapped.is_some_and(|w| {
+            w.irq == self.irq
+                && w.dma8 == self.dma8
+                && w.dma16.unwrap_or(0xFF) == self.dma16
+        });
+        if !agrees {
+            m |= (1 << 0x04) | (1 << 0x05);
+        }
         if crate::kernel::platform::get().host == crate::kernel::platform::Host::Qemu {
             m |= (1 << 0x0A) | (1 << 0x0C) | (1 << 0x0E);
         }

--- a/kernel/src/kernel/io_policy.rs
+++ b/kernel/src/kernel/io_policy.rs
@@ -39,6 +39,17 @@ pub fn apply<A: crate::Arch>(machine: &mut A, personality: &Personality<A>, focu
             // answers FM detection.
             if platform::get().audio.sb_passthrough() {
                 machine.allow_io_ports(0x388, 2);
+                // The DSP window, port by port: the IOPB is a bitmap, so
+                // only what genuinely needs interception traps (see
+                // `trap_mask`) and the rest reaches the card directly.
+                if let Personality::Dos(dos) = personality {
+                    let mask = dos.pc.sb.trap_mask();
+                    for off in 0..16u16 {
+                        if mask & (1 << off) == 0 {
+                            machine.allow_io_ports(dos.pc.sb.io_base + off, 1);
+                        }
+                    }
+                }
                 // The MPU-401 window the guest declared (BLASTER `P`). In
                 // native mode the emulated MPU stands down, so these reach
                 // whatever the owner actually has there — a real MPU, a


### PR DESCRIPTION
Two fixes and a principle.

**The wiring registers leaked physical truth.** Mixer registers 0x80/0x81 report which IRQ/DMA the card is strapped to; forwarding them told a guest that BLASTER had given *labels* the *physical* values, so it would hook a line we never raise (the vPIC relays the card's line onto the guest's, the virtual 8237 remaps its channels). They are now answered from the guest's own wiring, and writes move only the guest's view.

**Trap-or-grant was a false choice** — the IOPB is a bitmap. `trap_mask` names each trap and its reason:

- base mismatch → whole window (needs `host_port` translation)
- wiring mismatch → the mixer pair (0x04/0x05)
- QEMU → DSP data/status (0x0A/0x0C/0x0E), where the E4h/E8h test register and the write-status busy flicker must be synthesized because QEMU's sb16 lacks what real silicon has

So a `BLASTER` that matches the hardware on a real machine traps **nothing**: the guest drives the card directly, as on period metal. What remains is only structurally unavoidable — the IRQ relay (the kernel owns the IDT) and 8237 interception (the real chip needs host-physical addresses).

Verified on `qemu --kvm` both ways: matched base, and a card relocated to 0x240 against a CONFIG.SYS declaring A220 — DOOM's sound init completes in both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEAvFt3ydqc1SzvdZkRAsh